### PR TITLE
ppu_lifter: emit __builtin_clzll MSVC polyfill

### DIFF
--- a/tools/ppu_lifter.py
+++ b/tools/ppu_lifter.py
@@ -104,6 +104,11 @@ static inline int __builtin_clz(unsigned int x) {
     _BitScanReverse(&idx, x);
     return 31 - (int)idx;
 }
+static inline int __builtin_clzll(unsigned long long x) {
+    unsigned long idx;
+    _BitScanReverse64(&idx, x);
+    return 63 - (int)idx;
+}
 static inline int64_t ppc_mulhd(int64_t a, int64_t b) {
     int64_t hi;
     _mul128(a, b, &hi);


### PR DESCRIPTION
The lifter preamble polyfills `__builtin_clz` for MSVC but not `__builtin_clzll`. Any `cntlzd` lift (added in #2) fails to build under `cl` with C3861. Adds the 64-bit `_BitScanReverse64` polyfill next to the existing 32-bit one.

Surfaced building The Simpsons Arcade Game (NPUB30563): the 119 MB `ppu_recomp.cpp` now compiles and links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)