### PR TITLE
Fix Linux/GCC build

### DIFF
--- a/libs/filesystem/cellFs.c
+++ b/libs/filesystem/cellFs.c
@@ -12,6 +12,20 @@
 #include <sys/stat.h>
 #include <errno.h>
 
+/* glibc's <sys/stat.h> exposes st_atime/st_mtime/st_ctime as macros that expand
+ * to st_atim.tv_sec etc.  They collide with the identically named members of the
+ * PS3 CellFsStat struct, so undefine them here; host times are read via the
+ * explicit timespec fields in the POSIX branch of the conversion below. */
+#ifdef st_atime
+#  undef st_atime
+#endif
+#ifdef st_mtime
+#  undef st_mtime
+#endif
+#ifdef st_ctime
+#  undef st_ctime
+#endif
+
 #ifdef _WIN32
 #  include <windows.h>
 #  include <io.h>
@@ -180,9 +194,15 @@ static void fill_cellfs_stat(CellFsStat* sb, const HOST_STAT_T* hst)
 
     sb->st_uid   = 0;
     sb->st_gid   = 0;
+#ifdef _WIN32
     sb->st_atime = (s64)hst->st_atime;
     sb->st_mtime = (s64)hst->st_mtime;
     sb->st_ctime = (s64)hst->st_ctime;
+#else
+    sb->st_atime = (s64)hst->st_atim.tv_sec;
+    sb->st_mtime = (s64)hst->st_mtim.tv_sec;
+    sb->st_ctime = (s64)hst->st_ctim.tv_sec;
+#endif
     sb->st_size  = (u64)hst->st_size;
     sb->st_blksize = 4096;
 }

--- a/libs/system/cellRtc.c
+++ b/libs/system/cellRtc.c
@@ -9,6 +9,7 @@
 #include "cellRtc.h"
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>   /* abs */
 #include <time.h>
 
 #ifdef _WIN32

--- a/libs/system/cellSaveData.c
+++ b/libs/system/cellSaveData.c
@@ -16,6 +16,20 @@
 #include <errno.h>
 #include <time.h>
 
+/* glibc's <sys/stat.h> exposes st_atime/st_mtime/st_ctime as macros (st_atim.tv_sec
+ * etc.) that collide with the identically named members of CellSaveData*Stat; undef
+ * them so the struct fields resolve, and read host times via the explicit timespec
+ * fields in the POSIX branches below. */
+#ifdef st_atime
+#  undef st_atime
+#endif
+#ifdef st_mtime
+#  undef st_mtime
+#endif
+#ifdef st_ctime
+#  undef st_ctime
+#endif
+
 #ifdef _WIN32
 #  include <windows.h>
 #  include <io.h>
@@ -329,9 +343,15 @@ static u32 enumerate_save_files(const char* save_path,
                 strncpy(fileList[count].fileName, de->d_name,
                         CELL_SAVEDATA_FILENAME_SIZE - 1);
                 fileList[count].st_size = (u64)st.st_size;
+#ifdef _WIN32
                 fileList[count].st_atime = (s64)st.st_atime;
                 fileList[count].st_mtime = (s64)st.st_mtime;
                 fileList[count].st_ctime = (s64)st.st_ctime;
+#else
+                fileList[count].st_atime = (s64)st.st_atim.tv_sec;
+                fileList[count].st_mtime = (s64)st.st_mtim.tv_sec;
+                fileList[count].st_ctime = (s64)st.st_ctim.tv_sec;
+#endif
             }
             count++;
         }
@@ -523,9 +543,15 @@ static s32 savedata_execute(const char* dirName, int is_save,
     if (!is_new) {
         HOST_STAT_T hst;
         if (HOST_STAT(save_path, &hst) == 0) {
+#ifdef _WIN32
             statGet.dir.st_atime = (s64)hst.st_atime;
             statGet.dir.st_mtime = (s64)hst.st_mtime;
             statGet.dir.st_ctime = (s64)hst.st_ctime;
+#else
+            statGet.dir.st_atime = (s64)hst.st_atim.tv_sec;
+            statGet.dir.st_mtime = (s64)hst.st_mtim.tv_sec;
+            statGet.dir.st_ctime = (s64)hst.st_ctim.tv_sec;
+#endif
         }
         read_param_sfo(save_path, &statGet.getParam);
     }

--- a/libs/video/rsx_d3d12_backend.c
+++ b/libs/video/rsx_d3d12_backend.c
@@ -1233,6 +1233,9 @@ void rsx_d3d12_backend_present(void)
 
 #else /* !_WIN32 */
 
+#include <ps3emu/ps3types.h>   /* u32 (header includes above are inside the _WIN32 guard) */
+#include <stdio.h>
+
 /* Stub for non-Windows — D3D12 is Windows-only */
 int rsx_d3d12_backend_init(u32 w, u32 h, const char* t)
 {

--- a/runtime/syscalls/lv2_register.c
+++ b/runtime/syscalls/lv2_register.c
@@ -10,6 +10,7 @@
  * remain available as direct C calls for the runtime to use.
  */
 
+#include <stdlib.h>   /* calloc, free */
 #include "lv2_syscall_table.h"
 #include "sys_ppu_thread.h"
 #include "sys_mutex.h"


### PR DESCRIPTION
## Why

`CONTRIBUTING.md` lists **GCC 12+** and **Clang 15+** as supported compilers, but the runtime does not currently compile on Linux/GCC — five translation units fail. This fixes those errors so `cmake --build build` produces `libps3recomp_runtime.a` on Linux, giving downstream game projects a Linux runtime to link against.

One logical change: **make the runtime compile on Linux/GCC.** No Windows (`_WIN32`) code path is modified.

## What

- **`cellFs.c` / `cellSaveData.c` — glibc `st_atime` macro collision.** glibc's `<sys/stat.h>` defines `st_atime`/`st_mtime`/`st_ctime` as *macros* (→ `st_atim.tv_sec`) that shadow the identically named members of `CellFsStat` / `CellSaveData{File,Dir}Stat`, so `dst->st_atime = …` expanded to `dst->st_atim.tv_sec` and failed. Fix: `#undef` the three macros after the system includes and read host timestamps from the explicit `st_atim.tv_sec` timespec fields on POSIX (Win32 `_stat64` fields unchanged).
- **`cellRtc.c` / `lv2_register.c` — missing `<stdlib.h>`** for `abs()` / `calloc()`/`free()` (previously reachable only transitively via `<windows.h>`).
- **`rsx_d3d12_backend.c` — non-Windows stub** lives *outside* the `#ifdef _WIN32` block that includes the backend header, so it had no `u32` type and no `printf`. Fix: include `<ps3emu/ps3types.h>` and `<stdio.h>` in the `#else` branch.

## Scope — this only unlocks the *build*, there is still work left

This makes the runtime **compile** on Linux. It does **not** make a game *run* on Linux — the host backends are still Windows-only and remain to be ported:

- **Graphics (RSX):** both `rsx_d3d12_backend.c` and `rsx_null_backend.c` are entirely `#ifdef _WIN32` (the "null" backend is a Win32 GDI window). The non-Windows D3D12 path added here is a stub returning `-1`. A real Linux build needs a Vulkan or headless backend.
- **Audio:** `cellAudio` uses WASAPI; the `PS3RECOMP_AUDIO_USE_SDL2` path isn't wired/validated on Linux.
- **Input:** `cellPad` → XInput is Win32-only.
- The runtime is **compile-validated** on Linux only, not yet run.

Please treat this as a foundation PR that unblocks Linux work, not a complete Linux port.

## Test evidence

**Before** (Linux, GCC 16) — 5 TUs fail, e.g.:
```
cellFs.c:184:        error: 'CellFsStat' has no member named 'st_atim'
cellSaveData.c:      error: 'CellSaveDataFileStat' has no member named 'st_atim'
cellRtc.c:           error: implicit declaration of function 'abs'
lv2_register.c:      error: implicit declaration of function 'calloc' / 'free'
rsx_d3d12_backend.c:1237: error: unknown type name 'u32'
```

**After:**
```
$ cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release && cmake --build build
[102/102] Linking C static library libps3recomp_runtime.a
$ echo $?
0          # 0 compile errors, 102 objects, libps3recomp_runtime.a (1.08 MB)
```
Windows build unaffected — every edit is a POSIX `#else` branch or an added header.

## CONTRIBUTING.md compliance
- One logical change (Linux/GCC compile) ✓ · "why" described ✓ · before/after evidence ✓
- No generated/lifter code committed ✓ · no game binaries / keys / proprietary data ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
