### PR TITLE
Add vmx lifter handlers

### DIFF
--- a/tools/ppu_disasm.py
+++ b/tools/ppu_disasm.py
@@ -771,6 +771,22 @@ def decode(insn: int, addr: int = 0) -> Instruction:
             result.mnemonic = "lvsr"
             result.operands = f"v{rd}, r{ra}, r{rb}"
             return result
+        if xo_full == 519:  # lvlx (Cell ext: Load Vector Left Indexed)
+            result.mnemonic = "lvlx"
+            result.operands = f"v{rd}, r{ra}, r{rb}"
+            return result
+        if xo_full == 551:  # lvrx (Cell ext: Load Vector Right Indexed)
+            result.mnemonic = "lvrx"
+            result.operands = f"v{rd}, r{ra}, r{rb}"
+            return result
+        if xo_full == 775:  # lvlxl (Cell ext: Load Vector Left Indexed Last)
+            result.mnemonic = "lvlxl"
+            result.operands = f"v{rd}, r{ra}, r{rb}"
+            return result
+        if xo_full == 532:  # ldbrx (Load Doubleword Byte-Reverse Indexed)
+            result.mnemonic = "ldbrx"
+            result.operands = f"r{rd}, r{ra}, r{rb}"
+            return result
 
         # Fall through – unknown ext opcode 31
         result.mnemonic = f"op31_x{xo_full}"
@@ -900,8 +916,8 @@ def decode(insn: int, addr: int = 0) -> Instruction:
             6: "vcmpequb", 70: "vcmpequh", 134: "vcmpequw",
             198: "vcmpeqfp", 966: "vcmpbfp", 454: "vcmpgefp",
             710: "vcmpgtfp",
-            518: "vcmpgtsb", 582: "vcmpgtsh", 646: "vcmpgtsw",
-            774: "vcmpgtub", 838: "vcmpgtuh", 902: "vcmpgtuw",
+            774: "vcmpgtsb", 838: "vcmpgtsh", 902: "vcmpgtsw",
+            518: "vcmpgtub", 582: "vcmpgtuh", 646: "vcmpgtuw",
         }
         # Strip Rc (bit 10 of the 11-bit xo_full) to get the base 10-bit XO
         base_cmp_xo = xo_full & ~(1 << 10)  # strip Rc bit (now bit 10 of 11-bit field)
@@ -917,8 +933,8 @@ def decode(insn: int, addr: int = 0) -> Instruction:
         vmx_vx = {
             # Float arithmetic
             10: "vaddfp", 74: "vsubfp",
-            842: "vrefp", 778: "vrsqrtefp",
-            266: "vmaxfp", 1034: "vminfp",
+            266: "vrefp", 330: "vrsqrtefp",
+            1034: "vmaxfp", 1098: "vminfp",
 
             # Integer add/sub
             0: "vaddubm", 64: "vadduhm", 128: "vadduwm",
@@ -929,7 +945,7 @@ def decode(insn: int, addr: int = 0) -> Instruction:
             1792: "vsubsbs", 1856: "vsubshs", 1920: "vsubsws",
 
             # Integer min/max
-            256: "vmaxub", 320: "vmaxuh", 384: "vmaxuw",
+            2: "vmaxub", 66: "vmaxuh", 130: "vmaxuw",
             258: "vmaxsb", 322: "vmaxsh", 386: "vmaxsw",
             514: "vminub", 578: "vminuh", 642: "vminuw",
             770: "vminsb", 834: "vminsh", 898: "vminsw",
@@ -959,10 +975,10 @@ def decode(insn: int, addr: int = 0) -> Instruction:
             # "vD, vB, UIMM" operand form, not here.
 
             # Pack/unpack
-            782: "vpkuhum", 846: "vpkuwum",
-            14: "vpkuhus", 78: "vpkuwus",
-            398: "vpkshus", 462: "vpkswus",
-            270: "vpkshss", 334: "vpkswss",
+            14: "vpkuhum", 78: "vpkuwum",
+            142: "vpkuhus", 206: "vpkuwus",
+            270: "vpkshus", 334: "vpkswus",
+            398: "vpkshss", 462: "vpkswss",
             526: "vupkhsb", 590: "vupkhsh",
             654: "vupklsb", 718: "vupklsh",
 
@@ -980,8 +996,8 @@ def decode(insn: int, addr: int = 0) -> Instruction:
             776: "vmulesb", 840: "vmulesh",
 
             # Sum across
-            1032: "vsumsws", 1672: "vsum2sws",
-            1544: "vsum4ubs", 1608: "vsum4sbs", 1800: "vsum4shs",
+            1928: "vsumsws", 1672: "vsum2sws",
+            1544: "vsum4ubs", 1800: "vsum4sbs", 1608: "vsum4shs",
         }
         if xo_full in vmx_vx:
             result.mnemonic = vmx_vx[xo_full]
@@ -993,7 +1009,7 @@ def decode(insn: int, addr: int = 0) -> Instruction:
         # All emit "vD, vB, UIMM" so the lifter reads a bare integer at ops[2].
         vmx_uimm = {
             524: "vspltb", 588: "vsplth", 652: "vspltw",
-            330: "vcfux", 394: "vcfsx", 906: "vctuxs", 970: "vctsxs",
+            778: "vcfux", 842: "vcfsx", 906: "vctuxs", 970: "vctsxs",
         }
         if xo_full in vmx_uimm:
             result.mnemonic = vmx_uimm[xo_full]
@@ -1214,3 +1230,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+                        

--- a/tools/ppu_disasm.py
+++ b/tools/ppu_disasm.py
@@ -935,6 +935,7 @@ def decode(insn: int, addr: int = 0) -> Instruction:
             10: "vaddfp", 74: "vsubfp",
             266: "vrefp", 330: "vrsqrtefp",
             1034: "vmaxfp", 1098: "vminfp",
+            714: "vrfim",  # round to FP integer toward -inf (floor)
 
             # Integer add/sub
             0: "vaddubm", 64: "vadduhm", 128: "vadduwm",
@@ -1230,4 +1231,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-                        

--- a/tools/ppu_lifter.py
+++ b/tools/ppu_lifter.py
@@ -935,6 +935,26 @@ class PPULifter:
                     f"((result <= ctx->gpr[{rb}] && ca) ? (1u << 29) : 0); "
                     f"ctx->gpr[{rd}] = result; }}")
 
+        # ------- addc/subfc (carry arithmetic, carry-out only, no carry-in) -------
+        # startswith() captures the . (record) and o (overflow) variants, matching
+        # the addme/subfme/subfze family. CA is XER bit 29.
+        # addc:  rD = rA + rB; CA = carry out of the add (unsigned wrap => result < rA).
+        if mn.startswith("addc"):
+            rd, ra, rb = _reg_idx(ops[0]), _reg_idx(ops[1]), _reg_idx(ops[2])
+            return (f"{{ uint64_t result = ctx->gpr[{ra}] + ctx->gpr[{rb}]; "
+                    f"ctx->xer = (ctx->xer & ~(1u << 29)) | "
+                    f"((result < ctx->gpr[{ra}]) ? (1u << 29) : 0); "
+                    f"ctx->gpr[{rd}] = result; }}")
+
+        # subfc: rD = ~rA + rB + 1 (= rB - rA); CA = carry out of ~rA + rB + 1,
+        # which equals 1 iff rB >= rA (unsigned).
+        if mn.startswith("subfc"):
+            rd, ra, rb = _reg_idx(ops[0]), _reg_idx(ops[1]), _reg_idx(ops[2])
+            return (f"{{ uint64_t result = ~ctx->gpr[{ra}] + ctx->gpr[{rb}] + 1; "
+                    f"ctx->xer = (ctx->xer & ~(1u << 29)) | "
+                    f"((ctx->gpr[{rb}] >= ctx->gpr[{ra}]) ? (1u << 29) : 0); "
+                    f"ctx->gpr[{rd}] = result; }}")
+
         # ------- Condition register logical ops -------
         if mn == "cror":
             bt, ba, bb = int(ops[0]), int(ops[1]), int(ops[2])
@@ -1089,6 +1109,15 @@ class PPULifter:
                     f"uint16_t raw; memcpy(&raw, vm_base + (uint32_t)ea, 2); "
                     f"ctx->gpr[{rd}] = raw; }}")
 
+        if mn == "ldbrx":
+            # Load doubleword byte-reverse: a raw 8-byte copy yields the
+            # byte-reversed (little-endian) value on the LE host, same convention
+            # as lhbrx above.
+            rd, ra, rb = _reg_idx(ops[0]), _reg_idx(ops[1]), _reg_idx(ops[2])
+            return (f"{{ uint64_t ea = ctx->gpr[{ra}] + ctx->gpr[{rb}]; "
+                    f"uint64_t raw; memcpy(&raw, vm_base + (uint32_t)ea, 8); "
+                    f"ctx->gpr[{rd}] = raw; }}")
+
         if mn == "sthbrx":
             rs, ra, rb = _reg_idx(ops[0]), _reg_idx(ops[1]), _reg_idx(ops[2])
             return (f"{{ uint64_t ea = ctx->gpr[{ra}] + ctx->gpr[{rb}]; "
@@ -1181,6 +1210,31 @@ class PPULifter:
             rb = _reg_idx(ops[2])
             return (f"{{ uint64_t ea = (ctx->gpr[{ra}] + ctx->gpr[{rb}]) & ~0xFULL; "
                     f"memcpy(vm_base + (uint32_t)ea, &ctx->vr[{vs}], 16); }}")
+
+        # Cell unaligned vector loads (CBEA / AltiVec): lvlx loads bytes
+        # [EA&15 .. 15] of the aligned quadword left-justified into vD and
+        # zero-fills the right; lvrx is the mirror (fills the right end). lvlxl
+        # is lvlx with a cache hint (same data). Byte-loop matches the raw-byte
+        # convention used by vperm/lvsl.
+        if mn == "lvlx" or mn == "lvlxl":
+            vd = int(ops[0][1:]) if ops[0].startswith("v") else _reg_idx(ops[0])
+            ra = _reg_idx(ops[1])
+            rb = _reg_idx(ops[2])
+            return (f"{{ uint64_t ea = ctx->gpr[{ra}] + ctx->gpr[{rb}]; "
+                    f"uint32_t sh = (uint32_t)(ea & 0xF); "
+                    f"uint8_t* m = vm_base + (uint32_t)(ea & ~0xFULL); "
+                    f"uint8_t* d = (uint8_t*)&ctx->vr[{vd}]; "
+                    f"for (int i = 0; i < 16; i++) d[i] = (sh + (uint32_t)i < 16) ? m[sh + i] : 0; }}")
+
+        if mn == "lvrx" or mn == "lvrxl":
+            vd = int(ops[0][1:]) if ops[0].startswith("v") else _reg_idx(ops[0])
+            ra = _reg_idx(ops[1])
+            rb = _reg_idx(ops[2])
+            return (f"{{ uint64_t ea = ctx->gpr[{ra}] + ctx->gpr[{rb}]; "
+                    f"uint32_t sh = (uint32_t)(ea & 0xF); "
+                    f"uint8_t* m = vm_base + (uint32_t)(ea & ~0xFULL); "
+                    f"uint8_t* d = (uint8_t*)&ctx->vr[{vd}]; "
+                    f"for (int i = 0; i < 16; i++) d[i] = ((uint32_t)i >= 16u - sh) ? m[i - (int)(16u - sh)] : 0; }}")
 
         if mn == "lvebx" or mn == "lvehx" or mn == "lvewx":
             vd = int(ops[0][1:]) if ops[0].startswith("v") else _reg_idx(ops[0])
@@ -1391,7 +1445,7 @@ class PPULifter:
             "vminsb":  None, "vminsh": None, "vminsw": None,
         }
 
-        if mn in ("vaddubm", "vadduhm", "vadduwm", "vsububm", "vsubuhm", "vsubuwm"):
+        if mn in ("vaddubm", "vadduhm", "vadduwm", "vsububm", "vsubuhm", "vsubuwm", "vand"):
             ty, cnt, op = vmx_int_binop[mn]
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
             return (f"{{ {ty}* d=({ty}*)&ctx->vr[{vd}]; {ty}* a=({ty}*)&ctx->vr[{va}]; "
@@ -1466,14 +1520,19 @@ class PPULifter:
 
         # Float reciprocal estimate / reciprocal sqrt estimate
         if mn == "vrefp":
-            vd, vb = int(ops[0][1:]), int(ops[1][1:]) if len(ops) > 1 else int(ops[0][1:])
+            vd, vb = int(ops[0][1:]), int(ops[-1][1:])  # vB = last operand (vmx_vx emits vD, vA, vB)
             return (f"{{ float* d=(float*)&ctx->vr[{vd}]; float* b=(float*)&ctx->vr[{vb}]; "
                     f"for(int i=0;i<4;i++) d[i]=1.0f/b[i]; }}")
 
         if mn == "vrsqrtefp":
-            vd, vb = int(ops[0][1:]), int(ops[1][1:]) if len(ops) > 1 else int(ops[0][1:])
+            vd, vb = int(ops[0][1:]), int(ops[-1][1:])  # vB = last operand (vmx_vx emits vD, vA, vB)
             return (f"{{ float* d=(float*)&ctx->vr[{vd}]; float* b=(float*)&ctx->vr[{vb}]; "
                     f"for(int i=0;i<4;i++) d[i]=1.0f/sqrtf(b[i]); }}")
+
+        if mn == "vrfim":  # round to FP integer toward -inf (floor); vrfim is vD,vB
+            vd, vb = int(ops[0][1:]), int(ops[-1][1:])
+            return (f"{{ float* d=(float*)&ctx->vr[{vd}]; float* b=(float*)&ctx->vr[{vb}]; "
+                    f"for(int i=0;i<4;i++) d[i]=floorf(b[i]); }}")
 
         # Float/int convert (operand form "vD, vB, UIMM" — UIMM is a bare int)
         if mn == "vcfsx" or mn == "vcfux":
@@ -1537,6 +1596,33 @@ class PPULifter:
                     f"int32_t* b=(int32_t*)&ctx->vr[{vb}]; "
                     f"for(int i=0;i<4;i++){{int64_t r=(int64_t)a[i]-(int64_t)b[i]; d[i]=(int32_t)(r>0x7FFFFFFFLL?0x7FFFFFFFLL:r<-0x80000000LL?-0x80000000LL:r);}} }}")
 
+        if mn == "vsububs":  # subtract unsigned byte, saturate to [0,255]
+            vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
+            return (f"{{ uint8_t* d=(uint8_t*)&ctx->vr[{vd}]; uint8_t* a=(uint8_t*)&ctx->vr[{va}]; "
+                    f"uint8_t* b=(uint8_t*)&ctx->vr[{vb}]; "
+                    f"for(int i=0;i<16;i++){{int32_t r=(int32_t)a[i]-(int32_t)b[i]; d[i]=(uint8_t)(r<0?0:r);}} }}")
+
+        if mn == "vsum2sws":
+            # AltiVec PEM: d.word1 = SAT_s32(a.w0 + a.w1 + b.w1);
+            #              d.word3 = SAT_s32(a.w2 + a.w3 + b.w3); d.word0 = d.word2 = 0.
+            # (word index = BE element, matching the VMX handlers above.) temp
+            # buffer so vD may alias vA/vB.
+            vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
+            return (f"{{ int32_t* a=(int32_t*)&ctx->vr[{va}]; int32_t* b=(int32_t*)&ctx->vr[{vb}]; "
+                    f"int64_t s0=(int64_t)a[0]+a[1]+b[1]; int64_t s1=(int64_t)a[2]+a[3]+b[3]; "
+                    f"int32_t r[4]={{0,0,0,0}}; "
+                    f"r[1]=(int32_t)(s0>0x7FFFFFFFLL?0x7FFFFFFFLL:s0<-0x80000000LL?-0x80000000LL:s0); "
+                    f"r[3]=(int32_t)(s1>0x7FFFFFFFLL?0x7FFFFFFFLL:s1<-0x80000000LL?-0x80000000LL:s1); "
+                    f"memcpy(&ctx->vr[{vd}], r, 16); }}")
+
+        if mn == "vupkhsh":
+            # Unpack high signed halfword: sign-extend the high 4 halfwords
+            # (BE elements 0-3) to 4 words. temp so vD may alias vB.
+            vd = int(ops[0][1:]); vb = int(ops[-1][1:])
+            return (f"{{ int16_t* b=(int16_t*)&ctx->vr[{vb}]; int32_t r[4]; "
+                    f"for(int i=0;i<4;i++) r[i]=(int32_t)b[i]; "
+                    f"memcpy(&ctx->vr[{vd}], r, 16); }}")
+
         # Shifts and rotates
         if mn == "vslb":
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
@@ -1548,6 +1634,11 @@ class PPULifter:
             return (f"{{ uint32_t* d=(uint32_t*)&ctx->vr[{vd}]; uint32_t* a=(uint32_t*)&ctx->vr[{va}]; "
                     f"uint32_t* b=(uint32_t*)&ctx->vr[{vb}]; "
                     f"for(int i=0;i<4;i++) d[i]=a[i]<<(b[i]&31u); }}")
+        if mn == "vsrw":  # vector shift right word (logical), per-element count = b[i] & 31
+            vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
+            return (f"{{ uint32_t* d=(uint32_t*)&ctx->vr[{vd}]; uint32_t* a=(uint32_t*)&ctx->vr[{va}]; "
+                    f"uint32_t* b=(uint32_t*)&ctx->vr[{vb}]; "
+                    f"for(int i=0;i<4;i++) d[i]=a[i]>>(b[i]&31u); }}")
         if mn == "vrlb":
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
             return (f"{{ uint8_t* d=(uint8_t*)&ctx->vr[{vd}]; uint8_t* a=(uint8_t*)&ctx->vr[{va}]; "
@@ -2070,8 +2161,11 @@ def main() -> None:
                 loaded += 1
         print(f"  Loaded {loaded} recovered names from {args.names}")
 
-    for start, end in func_bounds:
+    _n_funcs = len(func_bounds)
+    for _i, (start, end) in enumerate(func_bounds):
         lifter.lift_function(all_insns, start, end)
+        if _i % 1000 == 0 or _i == _n_funcs - 1:
+            print(f"  ... lifted {_i + 1}/{_n_funcs} functions", flush=True)
 
     # Resolve mid-function entry points: generate tail-entry functions for
     # branch/trampoline targets that land inside existing function bodies.
@@ -2096,6 +2190,7 @@ def main() -> None:
     with open(header_path, "w") as f:
         f.write(lifter.emit_header())
 
+    print("Building C source (~263 MB in memory — this is the long silent phase)...", flush=True)
     with open(source_path, "w") as f:
         f.write(lifter.emit_source())
 


### PR DESCRIPTION
Note: this branch includes the decode-fix commit from #7, since the handlers depend on those instructions decoding correctly. If PR #7 merges first, this PR reduces to just the handler additions.

These instructions had no translation handler and fell through to the lifter's TODO catch-all. In my game, addc/subfc alone were 86% of all unlifted instructions (63k of 73k), the recompiled output couldn't run without them.

Added (from the PowerPC/AltiVec manuals):

addc/subfc with carry-out into XER[CA] (addc: carry when the unsigned add wraps; subfc: carry when rB >= rA unsigned)
The unaligned vector loads lvlx/lvrx/lvlxl (load the aligned 16-byte block, then shift by the in-block offset, deliberately not implemented as lvx aliases) and ldbrx
vsrw, vsububs, vsum2sws, vupkhsh, vrfim
vand had an implementation but was missing from the dispatch list, so it never ran
Fixed swapped operands in vrefp/vrsqrtefp

Progress logging during the lift (quality of life)

Testing: compiled the new handlers with MSVC and asserted outputs against hand-computed values (9/9 pass). Together with the decode fixes, my game's unlifted-instruction count went from 73,219 to nearly zero.