### PR TITLE
fix NID computation: correct suffix constant and use little-endian di…

### DIFF
--- a/tools/nid_database.py
+++ b/tools/nid_database.py
@@ -32,10 +32,12 @@ import sys
 # ---------------------------------------------------------------------------
 
 # The suffix that Sony appends before hashing.
-# This is the well-known suffix used for PS3 NID generation.
+# This is the well-known 16-byte suffix used for PS3 NID generation
+# (verified against a real EBOOT import table and RPCS3's ppu_generate_id;
+# matches PS3_NID_SUFFIX in include/ps3emu/nid.h).
 NID_SUFFIX = bytes([
-    0x67, 0x59, 0x65, 0x99, 0x04, 0x25, 0x04, 0x01,
-    0xC0, 0xA8, 0x43, 0x09,
+    0x67, 0x59, 0x65, 0x99, 0x04, 0x25, 0x04, 0x90,
+    0x56, 0x64, 0x27, 0x49, 0x94, 0x89, 0x74, 0x1A,
 ])
 
 
@@ -46,8 +48,9 @@ def compute_nid(name: str, suffix: bytes = NID_SUFFIX) -> int:
     """
     h = hashlib.sha1(name.encode("utf-8") + suffix)
     digest = h.digest()
-    # NID = first 4 bytes, big-endian
-    return struct.unpack(">I", digest[:4])[0]
+    # NID = first 4 bytes, LITTLE-endian (matches RPCS3 ppu_generate_id and
+    # the NIDs found in real import tables).
+    return struct.unpack("<I", digest[:4])[0]
 
 # ---------------------------------------------------------------------------
 # Built-in database


### PR DESCRIPTION
Fix NID computation in nid_database.py

While resolving imports for Yakuza port, nid_database.py matched 0 of 354 import NIDs. Two bugs: the hash suffix constant was truncated or corrupted (12 bytes, wrong from byte 8 — include/ps3emu/nid.h has the correct 16-byte value), and the first 4 digest bytes were unpacked big-endian instead of little-endian.

Verification: sha1("cellSysmoduleLoadModule" + suffix)[0:4] little-endian gives 0x32267A31, which matches the NID in a real EBOOT import table. With the fix, 343/354 of my game's import NIDs resolve to names.