### PR TITLE
exclude runtime test harnesses from the library build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,10 @@ file(GLOB_RECURSE RUNTIME_SOURCES
     "runtime/*.c"
     "runtime/*.cpp"
 )
+# Exclude test harnesses (e.g. runtime/spu/tests/*): they have their own main()
+# and #include per-game generated headers (spu_recomp.h) that don't exist in a
+# plain runtime-library build.
+list(FILTER RUNTIME_SOURCES EXCLUDE REGEX "/tests/")
 
 # ---------------------------------------------------------------------------
 # Static library


### PR DESCRIPTION
runtime/spu/tests/ harnesses define their own main() and include per-game generated headers, so a plain runtime-library build fails; exclude them from the glob.

After this the runtime library builds clean with MSVC, and I've linked a complete game executable against it.