### PR TITLE
Improve function detection: seed from the .opd table

### DIFF
--- a/tools/find_functions.py
+++ b/tools/find_functions.py
@@ -10,14 +10,14 @@ Analyses a PPU ELF or raw binary for function entry/exit points by:
   - Detecting standard PPU prologues (mflr r0; stw/std r0, X(r1); stwu/stdu r1, -Y(r1))
   - Detecting epilogues (lwz/ld r0, X(r1); mtlr r0; blr)
   - Following bl (branch-and-link) targets to discover called functions
-  - Closing inter-function gaps so no text bytes go unattributed (stray data
-    lifts harmlessly as .word)
+  - Clipping overlapping ranges so every byte belongs to at most one function
+    (inter-function padding/data is deliberately left unattributed; the
+    lifter's discovery pass picks up any genuinely reachable stragglers)
   - Building a call graph
 
 Usage:
     python find_functions.py <input_elf_or_bin> [--raw] [--base ADDR] [--json]
                              [--call-graph] [--min-size N] [--no-opd]
-                             [--no-close-gaps] [--gap-cap N]
 """
 
 import argparse
@@ -139,14 +139,11 @@ class FunctionFinder:
 
     def __init__(self, instructions: list[Instruction], min_size: int = 8,
                  seeds: set[int] | None = None,
-                 exec_ranges: list[tuple[int, int]] | None = None,
-                 close_gaps: bool = True, gap_cap: int = 0x10000):
+                 exec_ranges: list[tuple[int, int]] | None = None):
         self.instructions = instructions
         self.min_size = min_size  # minimum function size in bytes
         self.seeds = seeds or set()           # known-true starts (.opd, entry)
         self.exec_ranges = exec_ranges or []  # [(lo, hi)] of executable text
-        self.close_gaps_enabled = close_gaps
-        self.gap_cap = gap_cap                # max gap (bytes) to sweep into a function
 
         # Build addr -> index lookup
         self._addr_to_idx: dict[int, int] = {}
@@ -401,14 +398,33 @@ class FunctionFinder:
     def apply_seeds(self) -> int:
         """Register every seed address (.opd descriptors, ELF entry) as a
         function start. Seeds are ground truth, so they bypass min_size.
-        Ends are placeholders here; close_gaps assigns the real ones."""
+        Each seeded function ends at its first blr (a return), bounded by
+        the next known start -- the same rule the other passes use. Code
+        reachable past a first blr is picked up as branch-target entries or
+        by the lifter's discovery pass, never by blind range extension
+        (extending ranges sweeps inter-function padding/data in as garbage
+        instructions)."""
+        import bisect
+        live_seeds = [a for a in self.seeds
+                      if a in self._addr_to_idx and a not in self.functions]
+        all_starts = sorted(set(self.functions.keys()) | set(live_seeds))
         added = 0
-        for addr in self.seeds:
-            if addr in self.functions:
-                continue
-            if addr not in self._addr_to_idx:
-                continue
-            self.functions[addr] = Function(start=addr, end=addr + 4)
+        for addr in live_seeds:
+            k = bisect.bisect_right(all_starts, addr)
+            nxt = all_starts[k] if k < len(all_starts) else None
+            idx = self._addr_to_idx[addr]
+            end = None
+            for j in range(idx, min(idx + 2000, len(self.instructions))):
+                cur = self.instructions[j]
+                if nxt is not None and cur.addr >= nxt:
+                    end = nxt
+                    break
+                if _is_blr(cur):
+                    end = cur.addr + 4
+                    break
+            if end is None:
+                end = nxt if nxt is not None else addr + 4
+            self.functions[addr] = Function(start=addr, end=max(end, addr + 4))
             added += 1
         return added
 
@@ -442,33 +458,24 @@ class FunctionFinder:
             dropped += 1
         return dropped
 
-    def close_all_gaps(self) -> int:
-        """Extend each function's end to the next function's start so no
-        text bytes go unattributed (also clips overlaps). Gaps larger than
-        gap_cap are assumed to be data and left open."""
+    def clip_overlaps(self) -> int:
+        """Trim any function whose detected end runs past the next function's
+        start, so every byte belongs to at most one function. Gaps between
+        functions (alignment padding, embedded data) are left unattributed
+        on purpose -- lifting them produces garbage code."""
         if not self.functions:
             return 0
-
-        def seg_end(addr: int) -> int:
-            for lo, hi in self.exec_ranges:
-                if lo <= addr < hi:
-                    return hi
-            return addr + 4
-
         starts = sorted(self.functions.keys())
-        closed = 0
+        clipped = 0
         for i, start in enumerate(starts):
             func = self.functions[start]
-            nxt = starts[i + 1] if i + 1 < len(starts) else seg_end(start)
-            if func.end > nxt:
-                func.end = nxt           # clip overlap
-            elif func.end < nxt:
-                if nxt - max(func.end, start + 4) <= self.gap_cap or func.end <= start:
-                    func.end = nxt
-                    closed += 1
+            nxt = starts[i + 1] if i + 1 < len(starts) else None
+            if nxt is not None and func.end > nxt:
+                func.end = nxt
+                clipped += 1
             if func.end <= start:
-                func.end = min(start + 4, nxt)
-        return closed
+                func.end = start + 4 if nxt is None else min(start + 4, nxt)
+        return clipped
 
     def run(self) -> list[Function]:
         """Run all detection passes and return sorted function list."""
@@ -496,10 +503,9 @@ class FunctionFinder:
                   f"-{dropped} prologue slivers -> {len(self.functions)} "
                   f"({time.time() - t:.1f}s)")
 
-        if self.close_gaps_enabled:
-            t = time.time()
-            closed = self.close_all_gaps()
-            _note(f"gap closure: {closed} gaps closed ({time.time() - t:.1f}s)")
+        t = time.time()
+        clipped = self.clip_overlaps()
+        _note(f"overlap clipping: {clipped} ranges trimmed ({time.time() - t:.1f}s)")
 
         self.build_call_graph()
         _note(f"done: {len(self.functions)} functions total "
@@ -590,11 +596,6 @@ def main() -> None:
                         help="Minimum function size in bytes (default: 8)")
     parser.add_argument("--no-opd", action="store_true",
                         help="Skip .opd descriptor seeding (ELF inputs)")
-    parser.add_argument("--no-close-gaps", action="store_true",
-                        help="Leave inter-function gaps open")
-    parser.add_argument("--gap-cap", type=lambda x: int(x, 0), default=0x10000,
-                        help="Largest gap (bytes) to sweep into the preceding "
-                             "function (default: 0x10000)")
     parser.add_argument("--output", "-o", metavar="FILE",
                         help="Write function list to JSON file (for use with ppu_lifter)")
     args = parser.parse_args()
@@ -648,9 +649,7 @@ def main() -> None:
           f"{len(exec_ranges)} executable segment(s)")
 
     finder = FunctionFinder(all_insns, min_size=args.min_size, seeds=seeds,
-                            exec_ranges=exec_ranges,
-                            close_gaps=not args.no_close_gaps,
-                            gap_cap=args.gap_cap)
+                            exec_ranges=exec_ranges)
     functions = finder.run()
 
     if seeds:

--- a/tools/find_functions.py
+++ b/tools/find_functions.py
@@ -3,14 +3,21 @@
 PPU function boundary detector for PS3 binaries.
 
 Analyses a PPU ELF or raw binary for function entry/exit points by:
+  - Seeding from the .opd function-descriptor table (ELF inputs) -- the
+    authoritative list of every address-taken function, located by scanning
+    data segments for {code, TOC} descriptor pairs
+  - Seeding the ELF entry point (also an OPD descriptor)
   - Detecting standard PPU prologues (mflr r0; stw/std r0, X(r1); stwu/stdu r1, -Y(r1))
   - Detecting epilogues (lwz/ld r0, X(r1); mtlr r0; blr)
   - Following bl (branch-and-link) targets to discover called functions
+  - Closing inter-function gaps so no text bytes go unattributed (stray data
+    lifts harmlessly as .word)
   - Building a call graph
 
 Usage:
     python find_functions.py <input_elf_or_bin> [--raw] [--base ADDR] [--json]
-                             [--call-graph] [--min-size N]
+                             [--call-graph] [--min-size N] [--no-opd]
+                             [--no-close-gaps] [--gap-cap N]
 """
 
 import argparse
@@ -18,6 +25,8 @@ import json
 import os
 import struct
 import sys
+import time
+from collections import Counter
 from dataclasses import dataclass, field
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -120,12 +129,24 @@ class Function:
 # Function finder
 # ---------------------------------------------------------------------------
 
+def _note(msg: str) -> None:
+    """Progress heartbeat on stderr (stdout stays clean for --json)."""
+    print(f"[find_functions] {msg}", file=sys.stderr, flush=True)
+
+
 class FunctionFinder:
     """Detect function boundaries in a PPU instruction stream."""
 
-    def __init__(self, instructions: list[Instruction], min_size: int = 8):
+    def __init__(self, instructions: list[Instruction], min_size: int = 8,
+                 seeds: set[int] | None = None,
+                 exec_ranges: list[tuple[int, int]] | None = None,
+                 close_gaps: bool = True, gap_cap: int = 0x10000):
         self.instructions = instructions
         self.min_size = min_size  # minimum function size in bytes
+        self.seeds = seeds or set()           # known-true starts (.opd, entry)
+        self.exec_ranges = exec_ranges or []  # [(lo, hi)] of executable text
+        self.close_gaps_enabled = close_gaps
+        self.gap_cap = gap_cap                # max gap (bytes) to sweep into a function
 
         # Build addr -> index lookup
         self._addr_to_idx: dict[int, int] = {}
@@ -246,9 +267,12 @@ class FunctionFinder:
         for func in self.functions.values():
             bl_targets.update(func.calls)
 
-        # Also scan all instructions for bl
+        # Also scan instructions for bl -- but only trust calls that sit
+        # inside an already-detected function (raw data in the executable
+        # segment decodes into phantom bl instructions otherwise).
+        covered = self._coverage_fn()
         for insn in self.instructions:
-            if _is_bl(insn):
+            if _is_bl(insn) and covered(insn.addr):
                 target = _bl_target(insn)
                 if target is not None:
                     bl_targets.add(target)
@@ -291,20 +315,41 @@ class FunctionFinder:
                 if call_target in self.functions:
                     self.functions[call_target].callers.append(addr)
 
+    def _coverage_fn(self):
+        """Return a fast addr-inside-a-known-function predicate."""
+        import bisect
+        starts_sorted = sorted(self.functions)
+        ends = [self.functions[s].end for s in starts_sorted]
+
+        def covered(addr: int) -> bool:
+            i = bisect.bisect_right(starts_sorted, addr) - 1
+            return i >= 0 and addr < ends[i]
+
+        return covered
+
     def find_branch_target_functions(self) -> None:
         """Third pass: find branch targets that fall outside known function boundaries.
 
         When the lifter generates code, any branch target that isn't inside a
         known function becomes a missing stub (empty function). This pass scans
-        all instructions for branch targets (b, bc, etc.) and creates minimal
-        function entries for any that aren't already covered.
-        """
-        all_targets: set[int] = set()
+        for branch targets (b, bc, etc.) and creates minimal function entries
+        for any that aren't already covered.
 
+        Only branches that themselves sit INSIDE a detected function are
+        trusted as sources: executable segments also contain read-only data,
+        and raw data decoded as instructions yields phantom branch targets.
+        Real code never branches into data, so filtering by source kills the
+        phantoms without losing real targets.
+        """
+        covered = self._coverage_fn()
+
+        all_targets: set[int] = set()
         for insn in self.instructions:
             mn = insn.mnemonic
             # Collect targets of conditional and unconditional branches
             if mn.startswith("b") and mn not in ("bl", "blr", "bctr", "bctrl", "blrl"):
+                if not covered(insn.addr):
+                    continue
                 ops = insn.operands.strip()
                 # Target is usually the last operand
                 parts = [p.strip() for p in ops.split(",")]
@@ -315,18 +360,9 @@ class FunctionFinder:
                         except ValueError:
                             pass
 
-        # Filter out targets that are already inside known functions
         new_targets: list[int] = []
-        sorted_funcs = sorted(self.functions.values(), key=lambda f: f.start)
-
-        sorted_targets = sorted(all_targets)
-        for target in sorted_targets:
-            inside = False
-            for func in sorted_funcs:
-                if func.start <= target < func.end:
-                    inside = True
-                    break
-            if not inside and target not in self.functions:
+        for target in sorted(all_targets):
+            if not covered(target) and target not in self.functions:
                 new_targets.append(target)
 
         # Create minimal functions for uncovered targets
@@ -353,13 +389,184 @@ class FunctionFinder:
             if found_end and func.size >= 4:
                 self.functions[target] = func
 
+    def _all_bl_targets(self) -> set[int]:
+        targets: set[int] = set()
+        for insn in self.instructions:
+            if _is_bl(insn):
+                t = _bl_target(insn)
+                if t is not None:
+                    targets.add(t)
+        return targets
+
+    def apply_seeds(self) -> int:
+        """Register every seed address (.opd descriptors, ELF entry) as a
+        function start. Seeds are ground truth, so they bypass min_size.
+        Ends are placeholders here; close_gaps assigns the real ones."""
+        added = 0
+        for addr in self.seeds:
+            if addr in self.functions:
+                continue
+            if addr not in self._addr_to_idx:
+                continue
+            self.functions[addr] = Function(start=addr, end=addr + 4)
+            added += 1
+        return added
+
+    def drop_prologue_slivers(self, bl_targets: set[int]) -> int:
+        """Remove heuristic-only starts that sit a few instructions after a
+        seeded start with no intervening return -- those are mid-prologue
+        anchors (e.g. the mflr after a stdu), not real functions. Starts
+        that are themselves seeds or bl targets are kept."""
+        if not self.seeds:
+            return 0
+        seed_sorted = sorted(self.seeds)
+        import bisect
+        dropped = 0
+        for start in list(self.functions.keys()):
+            if start in self.seeds or start in bl_targets:
+                continue
+            i = bisect.bisect_right(seed_sorted, start) - 1
+            if i < 0:
+                continue
+            seed = seed_sorted[i]
+            if seed == start or start - seed > 32:
+                continue
+            idx0 = self._addr_to_idx.get(seed)
+            idx1 = self._addr_to_idx.get(start)
+            if idx0 is None or idx1 is None:
+                continue
+            if any(self.instructions[k].mnemonic in ("blr", "b", "rfid")
+                   for k in range(idx0, idx1)):
+                continue
+            del self.functions[start]
+            dropped += 1
+        return dropped
+
+    def close_all_gaps(self) -> int:
+        """Extend each function's end to the next function's start so no
+        text bytes go unattributed (also clips overlaps). Gaps larger than
+        gap_cap are assumed to be data and left open."""
+        if not self.functions:
+            return 0
+
+        def seg_end(addr: int) -> int:
+            for lo, hi in self.exec_ranges:
+                if lo <= addr < hi:
+                    return hi
+            return addr + 4
+
+        starts = sorted(self.functions.keys())
+        closed = 0
+        for i, start in enumerate(starts):
+            func = self.functions[start]
+            nxt = starts[i + 1] if i + 1 < len(starts) else seg_end(start)
+            if func.end > nxt:
+                func.end = nxt           # clip overlap
+            elif func.end < nxt:
+                if nxt - max(func.end, start + 4) <= self.gap_cap or func.end <= start:
+                    func.end = nxt
+                    closed += 1
+            if func.end <= start:
+                func.end = min(start + 4, nxt)
+        return closed
+
     def run(self) -> list[Function]:
         """Run all detection passes and return sorted function list."""
+        t0 = time.time()
         self.find_prologue_functions()
+        _note(f"prologue pass: {len(self.functions)} functions "
+              f"({time.time() - t0:.1f}s)")
+
+        t = time.time()
         self.find_leaf_functions()
+        _note(f"leaf pass: {len(self.functions)} functions "
+              f"({time.time() - t:.1f}s)")
+
+        t = time.time()
         self.find_branch_target_functions()
+        _note(f"branch-target pass: {len(self.functions)} functions "
+              f"({time.time() - t:.1f}s)")
+
+        if self.seeds:
+            t = time.time()
+            added = self.apply_seeds()
+            bl_targets = self._all_bl_targets()
+            dropped = self.drop_prologue_slivers(bl_targets)
+            _note(f"seed pass: +{added} seeded starts, "
+                  f"-{dropped} prologue slivers -> {len(self.functions)} "
+                  f"({time.time() - t:.1f}s)")
+
+        if self.close_gaps_enabled:
+            t = time.time()
+            closed = self.close_all_gaps()
+            _note(f"gap closure: {closed} gaps closed ({time.time() - t:.1f}s)")
+
         self.build_call_graph()
+        _note(f"done: {len(self.functions)} functions total "
+              f"({time.time() - t0:.1f}s)")
         return sorted(self.functions.values(), key=lambda f: f.start)
+
+# ---------------------------------------------------------------------------
+# OPD descriptor seeding (ELF inputs)
+# ---------------------------------------------------------------------------
+
+def collect_opd_seeds(elf, exec_ranges: list[tuple[int, int]],
+                      big_endian: bool = True) -> set[int]:
+    """Find function starts listed in the .opd descriptor table.
+
+    PPC64 ELFv1 requires a {code, TOC} descriptor for every address-taken
+    function; PS3 EBOOTs keep them in .opd within a data segment. Section
+    names are unreliable in stripped binaries, so locate descriptors by
+    shape instead: scan data segments for pairs where the first word is an
+    aligned text address and the second is a data address, keep only TOC
+    values that repeat (real .opd tables share a handful of TOC values),
+    then collect every code address paired with one of those TOCs.
+    """
+    from elf_parser import PT_LOAD
+
+    fmt = ">II" if big_endian else "<II"
+    data_segs: list[tuple[int, bytes]] = []
+    for i, ph in enumerate(elf.program_headers):
+        if ph.p_type == PT_LOAD and ph.p_filesz > 0 and not (ph.p_flags & 1):
+            data_segs.append((ph.p_vaddr, elf.get_segment_data(i)))
+
+    data_ranges = [(v, v + len(d)) for v, d in data_segs]
+
+    def in_exec(a: int) -> bool:
+        return any(lo <= a < hi for lo, hi in exec_ranges)
+
+    def in_data(a: int) -> bool:
+        return any(lo <= a < hi for lo, hi in data_ranges)
+
+    toc_freq: Counter = Counter()
+    for vaddr, dat in data_segs:
+        for off in range(0, len(dat) - 7, 4):
+            code, toc = struct.unpack_from(fmt, dat, off)
+            if code % 4 == 0 and in_exec(code) and in_data(toc):
+                toc_freq[toc] += 1
+
+    keep = {t for t, c in toc_freq.items() if c >= 16}
+    seeds: set[int] = set()
+    if keep:
+        for vaddr, dat in data_segs:
+            for off in range(0, len(dat) - 7, 4):
+                code, toc = struct.unpack_from(fmt, dat, off)
+                if toc in keep and code % 4 == 0 and in_exec(code):
+                    seeds.add(code)
+
+    # The ELF entry is a descriptor too; resolve and include its code addr.
+    entry = elf.elf_header.e_entry
+    for vaddr, dat in data_segs:
+        if vaddr <= entry and entry + 4 <= vaddr + len(dat):
+            code = struct.unpack_from(fmt[0] + "I", dat, entry - vaddr)[0]
+            if in_exec(code) and code % 4 == 0:
+                seeds.add(code)
+            break
+    if in_exec(entry):
+        seeds.add(entry)
+
+    return seeds
+
 
 # ---------------------------------------------------------------------------
 # CLI
@@ -381,6 +588,13 @@ def main() -> None:
                         help="Include call graph in output")
     parser.add_argument("--min-size", type=int, default=8,
                         help="Minimum function size in bytes (default: 8)")
+    parser.add_argument("--no-opd", action="store_true",
+                        help="Skip .opd descriptor seeding (ELF inputs)")
+    parser.add_argument("--no-close-gaps", action="store_true",
+                        help="Leave inter-function gaps open")
+    parser.add_argument("--gap-cap", type=lambda x: int(x, 0), default=0x10000,
+                        help="Largest gap (bytes) to sweep into the preceding "
+                             "function (default: 0x10000)")
     parser.add_argument("--output", "-o", metavar="FILE",
                         help="Write function list to JSON file (for use with ppu_lifter)")
     args = parser.parse_args()
@@ -391,8 +605,12 @@ def main() -> None:
     big_endian = not args.little_endian
     base_addr = args.base
 
+    seeds: set[int] = set()
+    exec_ranges: list[tuple[int, int]] = []
+
     if args.raw:
         all_insns = disassemble_bytes(file_data, base_addr, big_endian)
+        exec_ranges = [(base_addr, base_addr + len(file_data))]
     else:
         try:
             from elf_parser import ELFFile, PT_LOAD
@@ -404,22 +622,45 @@ def main() -> None:
                 if ph.p_type == PT_LOAD and (ph.p_flags & 1):
                     seg_data = elf.get_segment_data(elf.program_headers.index(ph))
                     all_insns.extend(disassemble_bytes(seg_data, ph.p_vaddr, big_endian))
+                    exec_ranges.append((ph.p_vaddr, ph.p_vaddr + ph.p_filesz))
             if not all_insns:
                 for ph in elf.program_headers:
                     if ph.p_type == PT_LOAD and ph.p_filesz > 0:
                         seg_data = elf.get_segment_data(elf.program_headers.index(ph))
                         all_insns.extend(disassemble_bytes(seg_data, ph.p_vaddr, big_endian))
+                        exec_ranges.append((ph.p_vaddr, ph.p_vaddr + ph.p_filesz))
                         break
+            if not args.no_opd:
+                t = time.time()
+                seeds = collect_opd_seeds(elf, exec_ranges, big_endian)
+                _note(f"opd scan: {len(seeds)} descriptor code addresses "
+                      f"({time.time() - t:.1f}s)")
         except Exception as exc:
             print(f"Warning: ELF parse failed ({exc}), treating as raw", file=sys.stderr)
             all_insns = disassemble_bytes(file_data, base_addr, big_endian)
+            exec_ranges = [(base_addr, base_addr + len(file_data))]
 
     if not all_insns:
         print("No instructions to analyse.", file=sys.stderr)
         sys.exit(1)
 
-    finder = FunctionFinder(all_insns, min_size=args.min_size)
+    _note(f"disassembled {len(all_insns)} instructions across "
+          f"{len(exec_ranges)} executable segment(s)")
+
+    finder = FunctionFinder(all_insns, min_size=args.min_size, seeds=seeds,
+                            exec_ranges=exec_ranges,
+                            close_gaps=not args.no_close_gaps,
+                            gap_cap=args.gap_cap)
     functions = finder.run()
+
+    if seeds:
+        starts = {f.start for f in functions}
+        unseated = [a for a in seeds if a not in starts]
+        if unseated:
+            _note(f"WARNING: {len(unseated)} seed addresses are not function "
+                  f"starts (first: 0x{min(unseated):08X})")
+        else:
+            _note("verified: every .opd descriptor address is a function start")
 
     if args.output:
         # Write function list for ppu_lifter


### PR DESCRIPTION
Why: my recompiled game crashed on its first call through a function pointer, the target function was never detected, so it was never lifted. Found that PS3 executables carry a .opd section listing a descriptor for every address-taken function (every C++ virtual, every callback). My game has 21,893 of them; exactly 1 matched a detected function start. The prologue scan anchors on mflr r0 and registers starts late when the frame is set up first, and pointer-only functions are invisible to bl following.

Changes:
Seed starts from .opd, located by shape (data-segment pairs of valid code address + repeating TOC value), since section names are often stripped. The ELF entry point descriptor is seeded too.
Seeded functions end at their first blr, bounded by the next known start.
Only trust bl/branch targets found inside already-detected functions , executable segments contain read-only data, and data decoded as instructions yields phantom branch targets; real code never branches into data.

Clip overlapping ranges so each byte belongs to one function.

Binary search instead of a linear scan in the branch-target pass (Multiple minutes is now less than one second on my game; whole tool now is now just a few seconds).

Testing: the tool now self-checks and reports that every .opd address is a function start. On my game: 30,721 became 45,425 functions, and the recompiled build went from crashing on the first virtual call to running the entire C++ global constructor pass.