### PR TITLE
runtime: correct SYS_TTY_READ/WRITE syscall numbers (402/403)

### DIFF
--- a/runtime/syscalls/lv2_syscall_table.h
+++ b/runtime/syscalls/lv2_syscall_table.h
@@ -209,8 +209,8 @@ extern "C" {
 #define SYS_FS_GET_BLOCK_SIZE           841
 
 /* Misc */
-#define SYS_TTY_READ                    400
-#define SYS_TTY_WRITE                   402
+#define SYS_TTY_READ                    402
+#define SYS_TTY_WRITE                   403
 #define SYS_DBG_GET_THREAD_LIST         610
 
 /* Upper limit for the dispatch table */


### PR DESCRIPTION
The header defined 400/402; the real lv2 numbers are 402 (read) and 403 (write) - confirmed against RPCS3's syscall table (lv2.cpp). Yakuza's EBOOT issues syscall 403 directly 17 times, so the wrong constant routes TTY writes to the read handler.