### PR TITLE
libs: big-endian guest structs in cellVideoOut; fix CellGcmContextData layout

### DIFF
--- a/libs/video/cellGcmSys.h
+++ b/libs/video/cellGcmSys.h
@@ -93,12 +93,15 @@ typedef struct CellGcmControl {
 /* GCM context data — the game reads/writes this to submit RSX commands.
  * On PS3, gCellGcmCurrentContext points to one of these.
  * All pointer fields are guest addresses (u32) in the recomp.
- * Layout verified from compiled PS3 SDK inline functions: callback is at offset 0. */
+ * Layout verified against compiled SDK inline code (Yakuza: Dead Souls
+ * EBOOT, command-write helper at 0xEBC0C8) and RPCS3's CellGcmContextData:
+ * begin/end/current/callback, with callback LAST (offset 0xC). The fields
+ * are big-endian in guest memory — byte-swap on host access. */
 typedef struct CellGcmContextData {
-    u32 callback;   /* overflow callback function OPD (guest addr) */
     u32 begin;      /* start of command buffer (guest addr) */
     u32 end;        /* end of command buffer (guest addr) */
     u32 current;    /* current write position (guest addr) */
+    u32 callback;   /* overflow callback function OPD (guest addr) */
 } CellGcmContextData;
 
 /* Display buffer configuration */

--- a/libs/video/cellVideoOut.c
+++ b/libs/video/cellVideoOut.c
@@ -6,6 +6,7 @@
  */
 
 #include "cellVideoOut.h"
+#include "ps3emu/endian.h"
 #include <stdio.h>
 #include <string.h>
 
@@ -18,6 +19,8 @@ static u8  s_color_format   = CELL_VIDEO_OUT_BUFFER_COLOR_FORMAT_X8R8G8B8;
 static u8  s_aspect         = CELL_VIDEO_OUT_ASPECT_16_9;
 static u32 s_pitch          = 1280 * 4;
 
+static void get_resolution_wh(u32 resId, u16* w, u16* h);
+
 /* ---------------------------------------------------------------------------
  * Configuration
  * -----------------------------------------------------------------------*/
@@ -26,10 +29,11 @@ void cellVideoOut_set_resolution(u8 resolutionId)
 {
     s_resolution_id = resolutionId;
 
-    /* Update pitch based on resolution */
-    CellVideoOutResolution res;
-    cellVideoOutGetResolution(resolutionId, &res);
-    s_pitch = (u32)res.width * 4;
+    /* Update pitch based on resolution (host-endian helper; the public
+     * cellVideoOutGetResolution writes guest big-endian now) */
+    u16 w, h;
+    get_resolution_wh(resolutionId, &w, &h);
+    s_pitch = (u32)w * 4;
 }
 
 /* ---------------------------------------------------------------------------
@@ -78,25 +82,27 @@ s32 cellVideoOutGetState(u32 videoOut, u32 deviceIndex, CellVideoOutState* state
     memset(state, 0, sizeof(CellVideoOutState));
 
     if (videoOut == CELL_VIDEO_OUT_PRIMARY) {
+        u32 mode;
         state->state      = 2; /* enabled */
         state->colorSpace = CELL_VIDEO_OUT_COLOR_SPACE_RGB;
 
         /* Set display mode based on current resolution */
         switch (s_resolution_id) {
         case CELL_VIDEO_OUT_RESOLUTION_1080:
-            state->displayMode = CELL_VIDEO_OUT_DISPLAY_MODE_1920_1080_59_94HZ;
+            mode = CELL_VIDEO_OUT_DISPLAY_MODE_1920_1080_59_94HZ;
             break;
         case CELL_VIDEO_OUT_RESOLUTION_480:
-            state->displayMode = CELL_VIDEO_OUT_DISPLAY_MODE_720_480_59_94HZ;
+            mode = CELL_VIDEO_OUT_DISPLAY_MODE_720_480_59_94HZ;
             break;
         case CELL_VIDEO_OUT_RESOLUTION_576:
-            state->displayMode = CELL_VIDEO_OUT_DISPLAY_MODE_720_576_50HZ;
+            mode = CELL_VIDEO_OUT_DISPLAY_MODE_720_576_50HZ;
             break;
         case CELL_VIDEO_OUT_RESOLUTION_720:
         default:
-            state->displayMode = CELL_VIDEO_OUT_DISPLAY_MODE_1280_720_59_94HZ;
+            mode = CELL_VIDEO_OUT_DISPLAY_MODE_1280_720_59_94HZ;
             break;
         }
+        state->displayMode = ps3_bswap32(mode);  /* guest BE struct */
     } else {
         state->state = 0; /* disabled */
     }
@@ -109,10 +115,16 @@ s32 cellVideoOutGetResolution(u32 resolutionId, CellVideoOutResolution* resoluti
     if (!resolution)
         return CELL_VIDEO_OUT_ERROR_ILLEGAL_PARAMETER;
 
-    get_resolution_wh(resolutionId, &resolution->width, &resolution->height);
+    /* The out-struct lives in guest memory: fields are big-endian.
+     * (Host-endian writes here fed the game byte-swapped width/height —
+     * 0xD002x0xE001 instead of 720x480 — which wrecked its display-buffer
+     * setup.) */
+    u16 w, h;
+    get_resolution_wh(resolutionId, &w, &h);
+    resolution->width  = ps3_bswap16(w);
+    resolution->height = ps3_bswap16(h);
 
-    printf("[cellVideoOut] GetResolution(id=%u) -> %ux%u\n",
-           resolutionId, resolution->width, resolution->height);
+    printf("[cellVideoOut] GetResolution(id=%u) -> %ux%u\n", resolutionId, w, h);
 
     return CELL_OK;
 }
@@ -132,8 +144,9 @@ s32 cellVideoOutConfigure(u32 videoOut, CellVideoOutConfiguration* config,
     s_color_format  = config->format;
     s_aspect        = config->aspect;
 
-    if (config->pitch > 0) {
-        s_pitch = config->pitch;
+    /* config is a guest BE struct: byte-swap multi-byte reads */
+    if (ps3_bswap32(config->pitch) > 0) {
+        s_pitch = ps3_bswap32(config->pitch);
     } else {
         u16 w, h;
         get_resolution_wh(s_resolution_id, &w, &h);
@@ -161,7 +174,7 @@ s32 cellVideoOutGetConfiguration(u32 videoOut, CellVideoOutConfiguration* config
     config->resolutionId = s_resolution_id;
     config->format       = s_color_format;
     config->aspect       = s_aspect;
-    config->pitch        = s_pitch;
+    config->pitch        = ps3_bswap32(s_pitch);  /* guest BE struct */
 
     return CELL_OK;
 }


### PR DESCRIPTION
Out-param structs live in guest memory, so multi-byte fields must be written big-endian. GetResolution wrote host-endian width/height - on x86 the guest reads 720x480 as 53250x57345 and sizes its display buffers from garbage. Fixes GetResolution, GetState.displayMode, GetConfiguration.pitch, and reads config->pitch as BE; libs-internal callers keep a host-endian helper. Also corrects CellGcmContextData: callback was at offset 0, but compiled SDK inline code (verified in a commercial EBOOT) and the gcm ABI place begin/end/current/callback with callback at +0xC.

Evidence: before, Yakuza's display-buffer setup produced 53250x57345; after, 720p configures coherently (pitch 5120) and flips run with correct buffer ids.