### PR TITLE
spu_disasm: fix RRR operand order and a-form address scaling

### DIFF
--- a/tools/spu_disasm.py
+++ b/tools/spu_disasm.py
@@ -368,7 +368,11 @@ def spu_decode(insn: int, addr: int = 0) -> SPUInstruction:
         mne = RI16_TABLE[op9]
         result.mnemonic = mne
         if mne in ("lqa", "stqa"):
-            lsa = (i16 & 0x3FFF) << 4
+            # a-form absolute: LSA = (I16 << 2) & 0x3FFF0 (I16 is a word offset,
+            # scaled x4, forced to a 16-byte boundary). Matches RPCS3
+            # spu_ls_target(0, i16). NB: x4, not x16 — the immediate is a word
+            # index, and the result is 16-byte aligned.
+            lsa = ((i16 & 0xFFFF) << 2) & 0x3FFF0
             result.operands = f"$r{rt}, 0x{lsa:X}"
         elif mne in ("hbra", "hbrr"):
             result.operands = f"0x{i16 & 0xFFFF:X}, $r{rt}"
@@ -386,8 +390,10 @@ def spu_decode(insn: int, addr: int = 0) -> SPUInstruction:
             target = (i16 * 4) & 0x3FFFF
             result.operands = f"0x{target:X}"
         elif mne in ("lqr", "stqr"):
-            target = i16 * 4 + addr
-            result.operands = f"$r{rt}, 0x{target & 0x3FFFF:X}"
+            # r-form: LSA = (pc + (I16 << 2)) & 0x3FFF0 (16-byte aligned, per
+            # RPCS3 spu_ls_target(pc, i16)). I16 is sign-extended (relative).
+            target = (i16 * 4 + addr) & 0x3FFF0
+            result.operands = f"$r{rt}, 0x{target:X}"
         else:
             result.operands = f"$r{rt}, 0x{i16 & 0xFFFF:X}"
         return result

--- a/tools/spu_disasm.py
+++ b/tools/spu_disasm.py
@@ -72,14 +72,20 @@ class SPUInstruction:
 #   - 11-bit (bits 0-10) -- RR, RRR, special
 # ---------------------------------------------------------------------------
 
-# RRR format: opcd(4) rt(7) rb(7) ra(7) rc(7)
+# RRR format, reading the word from the MSB: OP(4) RT(7) RB(7) RA(7) RC(7)
+# -- the DESTINATION (RT) is the field right after the opcode (bits >>21,
+# RPCS3's op.rt4); the low 7 bits are RC. Opcode values per the SPU ISA
+# (verified against RPCS3 SPUOpcodes.h and by hand-decoding Sony's SPURS
+# kernel entry, whose cdd/cwd+shufb insert idiom only decodes sanely with
+# selb=0b1000, shufb=0b1011 -- the old table had them swapped AND printed
+# the RC field as the destination).
 RRR_TABLE: dict[int, str] = {
+    0b1000: "selb",       # select bits
+    0b1011: "shufb",      # shuffle bytes
     0b1100: "mpya",       # multiply and add
+    0b1101: "fnms",       # floating negative multiply-subtract
     0b1110: "fma",        # floating multiply-add
     0b1111: "fms",        # floating multiply-subtract
-    0b1101: "fnms",       # floating negative multiply-subtract
-    0b1011: "selb",       # select bits
-    0b1000: "shufb",      # shuffle bytes
 }
 
 # RI18 format: opcd(7) i18(18) rt(7)
@@ -327,7 +333,8 @@ def spu_decode(insn: int, addr: int = 0) -> SPUInstruction:
     if op4 in RRR_TABLE:
         mne = RRR_TABLE[op4]
         result.mnemonic = mne
-        result.operands = f"$r{rt}, $r{ra}, $r{rb}, $r{rc}"
+        # RRR destination is the high field (>>21); low 7 bits are RC.
+        result.operands = f"$r{rc}, $r{ra}, $r{rb}, $r{rt}"
         return result
 
     # ---- RI18 format (7-bit opcode) ----


### PR DESCRIPTION
Two silent SPU decode miscompiles. RRR-form: selb/shufb were swapped in the table (selb=0b1000, shufb=0b1011 per the SPU ISA) and the destination printed the RC field instead of RT. a-form: lqa/stqa/lqr/stqr scaled the immediate x16 instead of x4 (LSA = I16<<2, 16-byte aligned, per RPCS3 spu_ls_target), producing out-of-range local-store addresses. Verified in the Yakuza port: Sony's SPURS kernel decodes/executes correctly.