### PR TITLE
cellFs: write out-params big-endian and pack CellFsStat to the PS3 ABI

### DIFF
--- a/libs/filesystem/cellFs.c
+++ b/libs/filesystem/cellFs.c
@@ -6,6 +6,7 @@
  */
 
 #include "cellFs.h"
+#include "ps3emu/endian.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -157,6 +158,23 @@ int cellfs_translate_path(const char* ps3_path, char* host_buf, size_t buf_size)
 /* ---------------------------------------------------------------------------
  * Host stat -> CellFsStat conversion
  * -----------------------------------------------------------------------*/
+
+/* CellFsStat is written into guest (big-endian) memory; byte-swap every
+ * multi-byte field in place. The game reads st_size etc. via lwz/ld which
+ * byte-swap, so a host-endian struct yields garbage (e.g. a 0x...00 size that
+ * fails asset parsing). Call after filling the struct natively. */
+static void cellfs_stat_to_be(CellFsStat* sb)
+{
+    sb->st_mode    = (s32)ps3_bswap32((u32)sb->st_mode);
+    sb->st_uid     = (s32)ps3_bswap32((u32)sb->st_uid);
+    sb->st_gid     = (s32)ps3_bswap32((u32)sb->st_gid);
+    sb->st_atime   = (s64)ps3_bswap64((u64)sb->st_atime);
+    sb->st_mtime   = (s64)ps3_bswap64((u64)sb->st_mtime);
+    sb->st_ctime   = (s64)ps3_bswap64((u64)sb->st_ctime);
+    sb->st_size    = ps3_bswap64(sb->st_size);
+    sb->st_blksize = ps3_bswap64(sb->st_blksize);
+}
+
 static void fill_cellfs_stat(CellFsStat* sb, const HOST_STAT_T* hst)
 {
     memset(sb, 0, sizeof(CellFsStat));
@@ -205,6 +223,8 @@ static void fill_cellfs_stat(CellFsStat* sb, const HOST_STAT_T* hst)
 #endif
     sb->st_size  = (u64)hst->st_size;
     sb->st_blksize = 4096;
+
+    cellfs_stat_to_be(sb);
 }
 
 /* ---------------------------------------------------------------------------
@@ -364,7 +384,7 @@ s32 cellFsOpen(const char* path, s32 flags, CellFsFd* fd, const void* arg, u64 s
     s_files[slot].flags   = flags;
     s_files[slot].host_fp = fp;
 
-    *fd = slot;
+    *fd = (CellFsFd)ps3_bswap32((u32)slot);   /* guest reads the fd big-endian */
     printf("[cellFs] Open: fd=%d -> '%s'\n", slot, host_path);
     return CELL_OK;
 }
@@ -402,7 +422,7 @@ s32 cellFsRead(CellFsFd fd, void* buf, u64 nbytes, u64* nread)
     }
 
     if (nread)
-        *nread = bytes_read;
+        *nread = ps3_bswap64(bytes_read);
 
     return CELL_OK;
 }
@@ -424,7 +444,7 @@ s32 cellFsWrite(CellFsFd fd, const void* buf, u64 nbytes, u64* nwrite)
     }
 
     if (nwrite)
-        *nwrite = bytes_written;
+        *nwrite = ps3_bswap64(bytes_written);
 
     return CELL_OK;
 }
@@ -448,7 +468,7 @@ s32 cellFsLseek(CellFsFd fd, s64 offset, s32 whence, u64* pos)
         s64 cur = (s64)ftello(s_files[fd].host_fp);
 #endif
         if (pos)
-            *pos = (u64)cur;
+            *pos = ps3_bswap64((u64)cur);
     } else {
         if (pos)
             *pos = 0;
@@ -489,6 +509,7 @@ s32 cellFsFstat(CellFsFd fd, CellFsStat* sb)
     memset(sb, 0, sizeof(CellFsStat));
     sb->st_mode = CELL_FS_S_IFREG | CELL_FS_S_IRUSR | CELL_FS_S_IWUSR;
     sb->st_blksize = 4096;
+    cellfs_stat_to_be(sb);
     return CELL_OK;
 }
 
@@ -576,8 +597,8 @@ s32 cellFsGetBlockSize(const char* path, u64* sector_size, u64* block_size)
     if (!path)
         return CELL_EFAULT;
 
-    if (sector_size) *sector_size = 512;
-    if (block_size)  *block_size  = 4096;
+    if (sector_size) *sector_size = ps3_bswap64(512);
+    if (block_size)  *block_size  = ps3_bswap64(4096);
 
     return CELL_OK;
 }
@@ -590,10 +611,10 @@ s32 cellFsGetFreeSize(const char* path, u32* block_size, u64* free_block_count)
     if (!path)
         return CELL_EFAULT;
 
-    if (block_size) *block_size = 4096;
+    if (block_size) *block_size = ps3_bswap32(4096);
 
     /* Report ~1GB free by default */
-    if (free_block_count) *free_block_count = (u64)(1024ULL * 1024 * 1024 / 4096);
+    u64 free_blocks = (u64)(1024ULL * 1024 * 1024 / 4096);
 
 #ifdef _WIN32
     {
@@ -601,11 +622,13 @@ s32 cellFsGetFreeSize(const char* path, u32* block_size, u64* free_block_count)
         if (translate_path(path, host_path, sizeof(host_path)) == 0) {
             ULARGE_INTEGER free_bytes;
             if (GetDiskFreeSpaceExA(host_path, &free_bytes, NULL, NULL)) {
-                if (free_block_count) *free_block_count = (u64)(free_bytes.QuadPart / 4096);
+                free_blocks = (u64)(free_bytes.QuadPart / 4096);
             }
         }
     }
 #endif
+
+    if (free_block_count) *free_block_count = ps3_bswap64(free_blocks);
 
     return CELL_OK;
 }
@@ -667,7 +690,7 @@ s32 cellFsOpendir(const char* path, CellFsDir* fd)
     }
 #endif
 
-    *fd = slot;
+    *fd = (CellFsDir)ps3_bswap32((u32)slot);   /* guest reads the dir fd big-endian */
     printf("[cellFs] Opendir: dir_fd=%d -> '%s'\n", slot, host_path);
     return CELL_OK;
 }
@@ -713,8 +736,9 @@ s32 cellFsReaddir(CellFsDir fd, CellFsDirectoryEntry* entry, u64* nread)
         entry->attribute.st_size = (u64)file_size.QuadPart;
     }
     entry->attribute.st_blksize = 4096;
+    cellfs_stat_to_be(&entry->attribute);
 
-    *nread = 1;
+    *nread = ps3_bswap64(1);
 #else
     struct dirent* de = readdir(s_dirs[fd].host_dir);
     if (!de) {
@@ -736,9 +760,10 @@ s32 cellFsReaddir(CellFsDir fd, CellFsDirectoryEntry* entry, u64* nread)
         /* Minimal fallback */
         entry->attribute.st_mode = CELL_FS_S_IFREG | CELL_FS_S_IRUSR | CELL_FS_S_IWUSR;
         entry->attribute.st_blksize = 4096;
+        cellfs_stat_to_be(&entry->attribute);
     }
 
-    *nread = 1;
+    *nread = ps3_bswap64(1);
 #endif
 
     return CELL_OK;

--- a/libs/filesystem/cellFs.h
+++ b/libs/filesystem/cellFs.h
@@ -65,6 +65,12 @@ extern "C" {
  * Structures
  * -----------------------------------------------------------------------*/
 
+/* The PS3 ABI packs CellFsStat to 4-byte alignment: the 64-bit fields sit at
+ * 4-byte (not 8-byte) offsets, so st_size is at +0x24 and the struct is 52
+ * bytes (RPCS3 sys_fs.h: be_t<s64,4>, CHECK_SIZE_ALIGN(CellFsStat,52,4)).
+ * Without #pragma pack the host would 8-align the s64s, putting st_size at +0x28
+ * (56-byte struct) and the guest would read its size from the wrong offset. */
+#pragma pack(push, 4)
 typedef struct CellFsStat {
     s32  st_mode;
     s32  st_uid;
@@ -80,6 +86,7 @@ typedef struct CellFsDirectoryEntry {
     CellFsStat attribute;
     char       entry_name[CELL_FS_MAX_FS_FILE_NAME_LENGTH];
 } CellFsDirectoryEntry;
+#pragma pack(pop)
 
 /* Opaque file/directory descriptors */
 typedef s32 CellFsFd;


### PR DESCRIPTION
The HLE wrote out-params and CellFsStat host-endian, so the guest read garbage. Byte-swap fd/nread/nwrite/pos/sizes and all CellFsStat fields; pack the struct to 4-byte alignment so st_size lands at +0x24 (52-byte struct, per RPCS3 sys_fs.h be_t<s64,4>). Same class as the merged cellVideoOut fix. Verified: the game reads the shader archive and asset sizes correctly.