### PR TITLE
sys_rwlock: return EDEADLK on writer self-relock and EPERM on bad unlock

### DIFF
--- a/runtime/syscalls/sys_rwlock.c
+++ b/runtime/syscalls/sys_rwlock.c
@@ -171,8 +171,13 @@ int64_t sys_rwlock_wlock(ppu_context* ctx)
         return (int64_t)(int32_t)CELL_ESRCH;
 
 #ifdef _WIN32
+    /* A thread that already holds the write lock re-acquiring it would deadlock
+     * the (non-recursive) SRWLock. Real lv2 returns CELL_EDEADLK. */
+    if (r->writer && r->writer_tid == ctx->thread_id)
+        return (int64_t)(int32_t)CELL_EDEADLK;
     AcquireSRWLockExclusive(&r->srw);
     InterlockedExchange(&r->writer, 1);
+    r->writer_tid = ctx->thread_id;
 #else
     pthread_rwlock_wrlock(&r->rwl);
 #endif
@@ -192,9 +197,12 @@ int64_t sys_rwlock_trywlock(ppu_context* ctx)
         return (int64_t)(int32_t)CELL_ESRCH;
 
 #ifdef _WIN32
+    if (r->writer && r->writer_tid == ctx->thread_id)
+        return (int64_t)(int32_t)CELL_EDEADLK;
     if (!TryAcquireSRWLockExclusive(&r->srw))
         return (int64_t)(int32_t)CELL_EBUSY;
     InterlockedExchange(&r->writer, 1);
+    r->writer_tid = ctx->thread_id;
 #else
     int rc = pthread_rwlock_trywrlock(&r->rwl);
     if (rc != 0)
@@ -216,6 +224,11 @@ int64_t sys_rwlock_wunlock(ppu_context* ctx)
         return (int64_t)(int32_t)CELL_ESRCH;
 
 #ifdef _WIN32
+    /* Only the owning thread may write-unlock (releasing an SRWLock not held in
+     * exclusive mode by this thread is UB). Real lv2 returns CELL_EPERM. */
+    if (!r->writer || r->writer_tid != ctx->thread_id)
+        return (int64_t)(int32_t)CELL_EPERM;
+    r->writer_tid = 0;
     InterlockedExchange(&r->writer, 0);
     ReleaseSRWLockExclusive(&r->srw);
 #else

--- a/runtime/syscalls/sys_rwlock.h
+++ b/runtime/syscalls/sys_rwlock.h
@@ -35,6 +35,7 @@ typedef struct sys_rwlock_info {
     /* Track exclusive ownership for proper unlock dispatch */
     volatile LONG  readers;
     volatile LONG  writer;
+    uint64_t       writer_tid;   /* owning thread of the write lock (EDEADLK/EPERM) */
 #else
     pthread_rwlock_t rwl;
 #endif


### PR DESCRIPTION
The Win32 write-lock path used a non-recursive SRWLock with no ownership tracking, so two lv2-defined error conditions were mishandled:

- A thread that already holds the write lock calling sys_rwlock_wlock again would AcquireSRWLockExclusive on a lock it owns -> hard host deadlock. lv2 returns CELL_EDEADLK.
- sys_rwlock_wunlock by a thread that is not the writer (or with no writer) called ReleaseSRWLockExclusive, which is undefined behaviour for an SRWLock not held exclusively by the caller. lv2 returns CELL_EPERM.

Track the owning thread (writer_tid, set under the lock, using the same ctx->thread_id convention as sys_mutex's owner_tid) and check it in wlock/trywlock (EDEADLK) and wunlock (EPERM). The pthread path is unchanged (glibc rwlocks already return EDEADLK/EPERM).