### PR TITLE
ppu_lifter: correct XER[CA] for subfe/subfme/addme

### DIFF
--- a/tools/ppu_lifter.py
+++ b/tools/ppu_lifter.py
@@ -1200,10 +1200,12 @@ class PPULifter:
 
         if mn in ("subfe", "subfe."):
             rd, ra, rb = _reg_idx(ops[0]), _reg_idx(ops[1]), _reg_idx(ops[2])
+            # XER[CA] = ADC carry-out of (~RA + RB + ca), per PowerISA / RPCS3 add64_flags.
             return (f"{{ uint64_t ca = (ctx->xer >> 29) & 1; "
-                    f"uint64_t result = ~ctx->gpr[{ra}] + ctx->gpr[{rb}] + ca; "
-                    f"ctx->xer = (ctx->xer & ~(1u << 29)) | "
-                    f"((result <= ctx->gpr[{rb}] && ca) ? (1u << 29) : 0); "
+                    f"uint64_t a = ~ctx->gpr[{ra}], b = ctx->gpr[{rb}]; "
+                    f"uint64_t s1 = a + b; uint64_t co = (s1 < a); "
+                    f"uint64_t result = s1 + ca; co |= (result < s1); "
+                    f"ctx->xer = (ctx->xer & ~(1u << 29)) | ((uint32_t)co << 29); "
                     f"ctx->gpr[{rd}] = result; }}")
 
         # ------- addc/subfc (carry arithmetic, carry-out only, no carry-in) -------
@@ -1443,16 +1445,22 @@ class PPULifter:
         # ------- addme/subfme/subfze (carry arithmetic, 2-op) -------
         if mn.startswith("addme"):
             rd, ra = _reg_idx(ops[0]), _reg_idx(ops[1])
+            # addme = RA + CA - 1 = RA + (~0) + CA; XER[CA] = ADC carry-out.
             return (f"{{ uint64_t ca = (ctx->xer >> 29) & 1; "
-                    f"uint64_t result = ctx->gpr[{ra}] + ca - 1; "
-                    f"ctx->xer = (ctx->xer & ~(1u << 29)) | "
-                    f"((result >= ctx->gpr[{ra}]) ? (1u << 29) : 0); "
+                    f"uint64_t a = ctx->gpr[{ra}], b = ~0ULL; "
+                    f"uint64_t s1 = a + b; uint64_t co = (s1 < a); "
+                    f"uint64_t result = s1 + ca; co |= (result < s1); "
+                    f"ctx->xer = (ctx->xer & ~(1u << 29)) | ((uint32_t)co << 29); "
                     f"ctx->gpr[{rd}] = result; }}")
 
         if mn.startswith("subfme"):
             rd, ra = _reg_idx(ops[0]), _reg_idx(ops[1])
+            # subfme = ~RA + CA - 1 = ~RA + (~0) + CA; was MISSING the XER[CA] update.
             return (f"{{ uint64_t ca = (ctx->xer >> 29) & 1; "
-                    f"uint64_t result = ~ctx->gpr[{ra}] + ca - 1; "
+                    f"uint64_t a = ~ctx->gpr[{ra}], b = ~0ULL; "
+                    f"uint64_t s1 = a + b; uint64_t co = (s1 < a); "
+                    f"uint64_t result = s1 + ca; co |= (result < s1); "
+                    f"ctx->xer = (ctx->xer & ~(1u << 29)) | ((uint32_t)co << 29); "
                     f"ctx->gpr[{rd}] = result; }}")
 
         if mn.startswith("subfze"):


### PR DESCRIPTION
The carry-out (XER[CA]) for the subtract/add-extended ops was wrong:

- subfe set CA via `result <= RB && ca` -- wrong for ~42/200 random operand pairs vs a 65-bit reference.
- addme set CA via `result >= RA` -- wrong for ~10/20.
- subfme never wrote XER[CA] at all, leaving it stale.

These ops are RA + RB(or ~0) + CA, and CA is the carry-out of that 65-bit add. Compute it exactly with the two-step ADC model RPCS3 uses in add64_flags (s1 = a+b, co = s1<a; result = s1+ca, co |= result<s1), matching the instruction bodies: subfe = ~RA + RB + CA, addme = RA + ~0 + CA, subfme = ~RA + ~0 + CA. The result value is unchanged; only CA is corrected. subfze was already correct and is left untouched.

A wrong CA silently corrupts any multi-word carry chain (a following adde/subfe/addze reads the bad carry) -- wrong arithmetic, not a crash.

Verified: re-simulated CA and result for all four ops against a 65-bit reference (0 mismatches); ppu_lifter.py parses clean.