### PR TITLE
video/gcm: fix cellGcmGetTiledPitchSize ABI and flip/vblank handler dispatch

### DIFF
--- a/libs/video/cellGcmSys.c
+++ b/libs/video/cellGcmSys.c
@@ -109,6 +109,20 @@ static u32 s_flip_handler_opd     = 0;
 static u32 s_vblank_handler_opd   = 0;
 static u32 s_user_handler_opd     = 0;
 static u32 s_second_v_handler_opd = 0;
+
+/* Resolved {code,toc} captured when each handler is registered. The title's
+ * handler OPDs (0x530D70/78/80) get their code word clobbered in guest memory
+ * by a later lifted store, so re-resolving the OPD at tick time yields the TOC
+ * base instead of the real handler. Capture-at-registration + dispatch by
+ * code+toc runs the real lifted handler regardless. */
+extern unsigned vm_read32(unsigned long long);
+extern unsigned long long ppu_guest_call_ct(u32 code, u32 toc, u64 a0, u64 a1, u64 a2, u64 a3);
+static u32 s_flip_handler_code=0,   s_flip_handler_toc=0;
+static u32 s_vblank_handler_code=0, s_vblank_handler_toc=0;
+static void capture_handler_ct(u32 opd, u32* code, u32* toc) {
+    if (opd) { *code = vm_read32(opd); *toc = vm_read32(opd + 4); }
+    else     { *code = 0; *toc = 0; }
+}
 /* Legacy host-typed slots kept around for any caller still treating
  * these as host pointers. New code should use the _opd slots. */
 static CellGcmFlipHandler    s_flip_handler    = NULL;
@@ -414,16 +428,16 @@ u32 cellGcmGetFlipStatus(void)
 void cellGcmTickVBlank(void)
 {
     s_vblank_count++;
-    if (s_vblank_handler_opd && g_ps3_guest_caller) {
-        g_ps3_guest_caller(s_vblank_handler_opd,
-                           (uint64_t)s_vblank_count, 0, 0, 0);
+    if (s_vblank_handler_code) {
+        ppu_guest_call_ct(s_vblank_handler_code, s_vblank_handler_toc,
+                          (uint64_t)s_vblank_count, 0, 0, 0);
     }
 }
 
 void cellGcmTickFlip(void)
 {
-    if (s_flip_handler_opd && g_ps3_guest_caller) {
-        g_ps3_guest_caller(s_flip_handler_opd, 1, 0, 0, 0);
+    if (s_flip_handler_code) {
+        ppu_guest_call_ct(s_flip_handler_code, s_flip_handler_toc, 1, 0, 0, 0);
     }
 }
 
@@ -562,17 +576,21 @@ void cellGcmSetFlipHandler(CellGcmFlipHandler handler)
      * the legacy host-typed value too for any callers still using
      * the old API style. Real dispatch goes through
      * cellGcmDispatchVBlank()/DispatchFlip() via g_ps3_guest_caller. */
-    printf("[cellGcmSys] SetFlipHandler(opd=0x%08X)\n", (unsigned)(size_t)handler);
     s_flip_handler_opd = (u32)(size_t)handler;
     s_flip_handler = handler;
+    capture_handler_ct(s_flip_handler_opd, &s_flip_handler_code, &s_flip_handler_toc);
+    printf("[cellGcmSys] SetFlipHandler(opd=0x%08X) code=0x%08X toc=0x%08X\n",
+           s_flip_handler_opd, s_flip_handler_code, s_flip_handler_toc);
 }
 
 /* NID: 0xA547ADDE */
 void cellGcmSetVBlankHandler(CellGcmVBlankHandler handler)
 {
-    printf("[cellGcmSys] SetVBlankHandler(opd=0x%08X)\n", (unsigned)(size_t)handler);
     s_vblank_handler_opd = (u32)(size_t)handler;
     s_vblank_handler = handler;
+    capture_handler_ct(s_vblank_handler_opd, &s_vblank_handler_code, &s_vblank_handler_toc);
+    printf("[cellGcmSys] SetVBlankHandler(opd=0x%08X) code=0x%08X toc=0x%08X\n",
+           s_vblank_handler_opd, s_vblank_handler_code, s_vblank_handler_toc);
 }
 
 /* NID: 0xF9BFCDA3 */
@@ -910,24 +928,20 @@ s32 cellGcmUnbindZcull(u8 index)
  * -----------------------------------------------------------------------*/
 
 /* NID: 0x107BF789 */
-s32 cellGcmGetTiledPitchSize(u32 size, u32* pitch)
+/* Real ABI: uint32_t cellGcmGetTiledPitchSize(uint32_t size) -- ONE arg, the
+ * aligned tiled pitch is the RETURN VALUE (r3). The previous 2-arg form treated
+ * r4 as an out-pointer and wrote the pitch through it; at the title's call site
+ * r4 still held the caller's CellVideoOutResolution* (from the preceding
+ * cellVideoOutGetResolution), so it overwrote width/height with the pitch ->
+ * width became 0 -> every downstream tile/display-buffer setup went garbage. */
+u32 cellGcmGetTiledPitchSize(u32 size)
 {
-    /* `pitch` is a GUEST address (the generic HLE adapter passes r4 raw). Write
-     * through vm_write32 so it's byte-swapped to BE and bounds-checked -- a raw
-     * *pitch faults when the game hands us a null-object-derived low pointer. */
-    uint32_t pitch_ea = (uint32_t)(uintptr_t)pitch;
-    if (!pitch_ea)
-        return CELL_GCM_ERROR_INVALID_VALUE;
-
     /* Smallest valid tiled pitch >= size (RSX supports only specific pitches). */
     for (int i = 0; i < s_valid_pitch_count; i++) {
-        if (s_valid_pitches[i] >= size) {
-            vm_write32(pitch_ea, s_valid_pitches[i]);
-            return CELL_OK;
-        }
+        if (s_valid_pitches[i] >= size)
+            return s_valid_pitches[i];
     }
-    vm_write32(pitch_ea, s_valid_pitches[s_valid_pitch_count - 1]);
-    return CELL_OK;
+    return s_valid_pitches[s_valid_pitch_count - 1];
 }
 
 /* NID: 0xBC982946 */

--- a/libs/video/cellGcmSys.h
+++ b/libs/video/cellGcmSys.h
@@ -339,7 +339,7 @@ s32 cellGcmUnbindZcull(u8 index);
 /* Misc */
 
 /* NID: 0x107BF789 */
-s32 cellGcmGetTiledPitchSize(u32 size, u32* pitch);
+u32 cellGcmGetTiledPitchSize(u32 size);
 
 /* NID: 0xBC982946 */
 void cellGcmSetDebugOutputLevel(u32 level);

--- a/runtime/ppu/ppu_loader.cpp
+++ b/runtime/ppu/ppu_loader.cpp
@@ -148,11 +148,7 @@ uint64_t vm_read64(uint64_t a) { if (vm_oob((uint32_t)a,8)) return 0; vm_hotmap(
     return __builtin_bswap64(v); }
 void vm_write8 (uint64_t a, uint8_t  v) { if (vm_oob((uint32_t)a,1)) return; vm_base[(uint32_t)a] = v; }
 void vm_write16(uint64_t a, uint16_t v) { if (vm_oob((uint32_t)a,2)) return; v = __builtin_bswap16(v); memcpy(vm_base + (uint32_t)a, &v, 2); }
-void vm_write32(uint64_t a, uint32_t v) { if (vm_oob((uint32_t)a,4)) return;
-    { static int64_t w=-2; if (w==-2) { const char* e=getenv("YDKJ_WWATCH"); w = e?(int64_t)strtoul(e,0,0):-1; }
-      if (w>=0) { uint32_t ea=(uint32_t)a; if (ea>=(uint32_t)w && ea<(uint32_t)w+0x40)
-        fprintf(stderr,"[WWATCH] write32 0x%08X = 0x%08X  ra=%p\n", ea, v, __builtin_return_address(0)); } }
-    v = __builtin_bswap32(v); memcpy(vm_base + (uint32_t)a, &v, 4); }
+void vm_write32(uint64_t a, uint32_t v) { if (vm_oob((uint32_t)a,4)) return; v = __builtin_bswap32(v); memcpy(vm_base + (uint32_t)a, &v, 4); }
 void vm_write64(uint64_t a, uint64_t v) { if (vm_oob((uint32_t)a,8)) return; v = __builtin_bswap64(v); memcpy(vm_base + (uint32_t)a, &v, 8); }
 }
 
@@ -508,6 +504,33 @@ extern "C" uint64_t ppu_guest_call(uint32_t opd_addr,
     ctx.gpr[13] = PPU_TLS_TP;
     ctx.cia     = code;
     g_active_ctx = &ctx;
+    g_active_ctx = &ctx;
+    fn(&ctx);
+    while (g_trampoline_fn) { void (*tf)(void*) = g_trampoline_fn; g_trampoline_fn = 0; tf(&ctx); }
+    return ctx.gpr[3];
+}
+
+/* Call a guest function by an already-resolved {code, toc} pair. Used for
+ * callbacks whose OPD is captured at registration time and may later be
+ * clobbered in guest memory (e.g. the GCM flip/vblank handler OPDs). Same
+ * scratch-stack + trampoline-drain behaviour as ppu_guest_call. */
+extern "C" uint64_t ppu_guest_call_ct(uint32_t code, uint32_t toc,
+                                      uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3)
+{
+    if (!code) return 0;
+    ppu_fn fn = ppu_lookup(code);
+    if (!fn) { fprintf(stderr, "[ppu] guest_call_ct: code 0x%08X not registered\n", code); return 0; }
+
+    static __declspec(thread) uint32_t s_cb_sp = 0;
+    if (!s_cb_sp) s_cb_sp = 0xCFFE0000u;
+
+    ppu_context ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.gpr[1]  = s_cb_sp;
+    ctx.gpr[2]  = toc;
+    ctx.gpr[3]  = a0; ctx.gpr[4] = a1; ctx.gpr[5] = a2; ctx.gpr[6] = a3;
+    ctx.gpr[13] = PPU_TLS_TP;
+    ctx.cia     = code;
     g_active_ctx = &ctx;
     fn(&ctx);
     while (g_trampoline_fn) { void (*tf)(void*) = g_trampoline_fn; g_trampoline_fn = 0; tf(&ctx); }


### PR DESCRIPTION
## Summary

Two GCM/RSX bugs found while bringing up *You Don't Know Jack* (BLUS30569) under the recompiler. Both prevented the title's RSX command stream from being issued correctly. With these fixes the title's own recompiled code reaches the FIFO and issues real `NV4097_CLEAR_SURFACE` commands (visible clears on screen via the D3D12 backend).

### 1. `cellGcmGetTiledPitchSize` had the wrong ABI

The real export is `uint32_t cellGcmGetTiledPitchSize(uint32_t size)` — **one** argument, with the aligned tiled pitch returned in `r3`. The previous 2-arg form treated `r4` as an out-pointer and wrote the pitch through it.

At the title's call site `r4` still held the caller's `CellVideoOutResolution*` (left over from the preceding `cellVideoOutGetResolution`), so the write clobbered `width`/`height` with the pitch value. `width` became `0`, and every downstream tile / display-buffer setup computed from garbage.

### 2. Flip/vblank handler callbacks dispatched through a clobbered OPD

Handlers were dispatched by re-resolving the handler OPD at tick time. The title's handler OPDs (`0x530D70/78/80`) have their code word clobbered in guest memory by a later lifted store, so re-resolving yields the TOC base instead of the real entry point.

Fix: capture the resolved `{code, toc}` at registration time and dispatch through a new `ppu_guest_call_ct()` (call-by-resolved-code/toc) in the PPU loader, which runs the real lifted handler regardless of the later OPD corruption.

## Testing

- `ps3recomp_runtime` builds clean (Release).
- `ydkj_boot.exe` links clean end-to-end against the new `cellGcmGetTiledPitchSize` signature.
- At runtime the title issues real `CLEAR_SURFACE` from its own recompiled code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)