### PR TITLE
spu: preferred-slot-only link register and rchcnt count

### DIFF
--- a/runtime/spu/spu_helpers.h
+++ b/runtime/spu/spu_helpers.h
@@ -37,6 +37,19 @@ static inline int spu_clz32(uint32_t x) { return x ? __builtin_clz(x) : 32; }
 static inline u128 spu_splat_u32(uint32_t v) {
     u128 r; r._u32[0]=v; r._u32[1]=v; r._u32[2]=v; r._u32[3]=v; return r;
 }
+/* Link register value for brsl/bisl/bisled: the SPU writes the return address
+ * into the PREFERRED word (word 0) and ZEROS the other three slots (matches
+ * RPCS3 v128::from32r, SPUInterpreter.cpp BRSL). Splatting it (the old bug)
+ * corrupts any code that saves/reloads/operates on the full 128-bit link. */
+static inline u128 spu_link(uint32_t addr) {
+    u128 r; r._u32[0]=addr; r._u32[1]=0; r._u32[2]=0; r._u32[3]=0; return r;
+}
+/* Preferred-slot scalar: value in word 0, remaining slots ZERO. CBEA's scalar
+ * channel convention -- rchcnt returns the count this way (RPCS3 measured
+ * {1,0,0,0} where the old splat gave {1,1,1,1}). Same bug class as spu_link. */
+static inline u128 spu_pref_u32(uint32_t v) {
+    u128 r; r._u32[0]=v; r._u32[1]=0; r._u32[2]=0; r._u32[3]=0; return r;
+}
 static inline u128 spu_splat_u16(uint16_t v) {
     u128 r; for (int i=0;i<8;i++) r._u16[i]=v; return r;
 }

--- a/tools/spu_lifter.py
+++ b/tools/spu_lifter.py
@@ -454,7 +454,9 @@ class SPULifter:
         if mn == "rdch":
             return f"{g(rt())} = spu_rdch(ctx, {_chan(ops[1])});"
         if mn == "rchcnt":
-            return f"{g(rt())} = spu_splat_u32(spu_rchcnt(ctx, {_chan(ops[1])}));"
+            # CBEA: the count lands in the PREFERRED word, remaining slots ZERO
+            # (splatting it is the spu_link bug class; RPCS3 = v128::from32r).
+            return f"{g(rt())} = spu_pref_u32(spu_rchcnt(ctx, {_chan(ops[1])}));"
         if mn == "wrch":
             # operands: channel, $rt
             return f"spu_wrch(ctx, {_chan(ops[0])}, {g(_reg(ops[1]))});"
@@ -468,7 +470,9 @@ class SPULifter:
             # recover it from the raw encoding (rt = bits 25-31 = raw & 0x7F).
             link_rt = insn.raw & 0x7F
             tgt = self._branch_target(insn)
-            link = f"{g(link_rt)} = spu_splat_u32(0x{addr + 4:X});"
+            # Link register: preferred word only, other slots ZERO (real HW /
+            # RPCS3 v128::from32r) -- splatting corrupts full-quadword link use.
+            link = f"{g(link_rt)} = spu_link(0x{addr + 4:X});"
             if tgt is not None:
                 self.call_targets.add(tgt)
                 return f"{link} {self.prefix}spu_func_{tgt:08X}(ctx);"
@@ -496,7 +500,7 @@ class SPULifter:
         if mn in ("bisl",):
             link_rt = insn.raw & 0x7F            # link reg dropped from operands
             tgt_reg = _reg(ops[0])
-            return (f"{g(link_rt)} = spu_splat_u32(0x{addr + 4:X}); "
+            return (f"{g(link_rt)} = spu_link(0x{addr + 4:X}); "
                     f"ctx->pc = {g(tgt_reg)}._u32[0]; spu_indirect_branch(ctx);")
         # biz/binz/bihz/bihnz: ops[0] = condition reg, ops[1] = target reg.
         if mn in ("biz", "binz", "bihz", "bihnz"):


### PR DESCRIPTION
The SPU writes scalar results into the PREFERRED word (word 0) with the remaining three slots ZERO (RPCS3 v128::from32r): the brsl/brasl/bisl link register and the rchcnt channel count. The lifter splatted both into all four words. Latent wherever only word 0 is consumed (bi $r0 returns, biz gates), which is why it survived boot validation, but it corrupts any code that saves/reloads/operates on the full 128-bit quadword; Sony's SPURS taskset context save does exactly that with the link (lqd/stqd of r0).  Adds spu_link/spu_pref_u32 to spu_helpers.h 
Validated on the Yakuza: Dead Souls port: all five lifted SPU modules relifted + full boot regression pass.