### PR TITLE
ppu_lifter: cntlzw(0) is 32, not undefined __builtin_clz garbage

### DIFF
--- a/tools/ppu_lifter.py
+++ b/tools/ppu_lifter.py
@@ -123,12 +123,17 @@ SOURCE_PREAMBLE = """\
  * redefining them is a hard error there -- only polyfill for real MSVC. */
 #ifndef __clang__
 static inline int __builtin_clz(unsigned int x) {
+    /* BSR leaves the index undefined for x==0; PowerPC cntlzw(0) is DEFINED
+     * as 32. Without the guard this returned 31 minus an uninitialized
+     * index for zero inputs. */
     unsigned long idx;
+    if (!x) return 32;
     _BitScanReverse(&idx, x);
     return 31 - (int)idx;
 }
 static inline int __builtin_clzll(unsigned long long x) {
     unsigned long idx;
+    if (!x) return 64;
     _BitScanReverse64(&idx, x);
     return 63 - (int)idx;
 }
@@ -623,8 +628,15 @@ class PPULifter:
             return f"ctx->gpr[{ra}] = (int64_t)(int32_t)ctx->gpr[{rs}];"
 
         if mn in ("cntlzw", "cntlzw."):
+            # cntlzw(0) is DEFINED as 32 on PowerPC; raw __builtin_clz(0) is
+            # UB (x86 BSR leaves the index undefined). cntlzd below already
+            # has the guard; mirror it. Sony's SPURS queue code gates its
+            # "queue was empty -> signal the waiting task" wakeup on
+            # cntlzw(pending)>>5, so an unguarded emission silently drops
+            # every such wakeup.
             ra, rs = _reg_idx(ops[0]), _reg_idx(ops[1])
-            return f"ctx->gpr[{ra}] = __builtin_clz((uint32_t)ctx->gpr[{rs}]);"
+            return (f"ctx->gpr[{ra}] = (uint32_t)ctx->gpr[{rs}] ? "
+                    f"__builtin_clz((uint32_t)ctx->gpr[{rs}]) : 32;")
 
         if mn in ("cntlzd", "cntlzd."):
             ra, rs = _reg_idx(ops[0]), _reg_idx(ops[1])


### PR DESCRIPTION
PowerISA defines cntlzw of zero as 32; the lifter emitted a raw __builtin_clz, which is undefined for zero input (x86 BSR leaves the index unset), and the MSVC compat shim additionally ignored _BitScanReverse's found flag and returned 31 minus an uninitialized index. cntlzd already had the zero guard; cntlzw did not, so every cntlzw of a zero value in a lifted game silently computed garbage. Fixed with a guarded emission (x ? clz : 32) mirroring cntlzd, plus zero-safe MSVC clz/clzll shims.

Found and validated on the Yakuza: Dead Souls port: Sony's cellSpursQueuePushBody gates its "queue was empty, wake the registered task" signal on cntlzw(pending)>>5. The garbage result dropped every SPURS queue wakeup, leaving the CRI audio codec task asleep in WAIT_SIGNAL forever. With the guard the push raises the task signal and the codec dispatches.
