### PR TITLE
ppu_lifter: mftb/mftbu read a real timebase, not a per-call-site counter

### DIFF
--- a/runtime/syscalls/sys_timer.c
+++ b/runtime/syscalls/sys_timer.c
@@ -25,6 +25,36 @@ static void ensure_qpc_init(void)
 }
 #endif
 
+/* ---------------------------------------------------------------------------
+ * PPU timebase (mftb/mftbu) -- THE guest clock.
+ *
+ * One global monotonic counter scaled to the PS3 timebase (79.8 MHz),
+ * anchored at first use. The old lifter emission was a per-call-site
+ * static that advanced 16667 ticks PER READ -- not a clock at all: every
+ * guest timing loop (media pacers, throttles, profilers) computed garbage
+ * from it, and each call site had a PRIVATE counter that only moved when
+ * polled. Overflow-safe split multiply (rem < qpf, so
+ * rem * 79.8e6 < ~8e14 << 2^63).
+ * -----------------------------------------------------------------------*/
+uint64_t ppu_timebase_now(void)
+{
+#ifdef _WIN32
+    static LONGLONG t0 = 0;
+    ensure_qpc_init();
+    LARGE_INTEGER now;
+    QueryPerformanceCounter(&now);
+    if (!t0) t0 = now.QuadPart;   /* benign race: same anchor either way */
+    uint64_t d = (uint64_t)(now.QuadPart - t0);
+    uint64_t q = (uint64_t)s_qpc_freq.QuadPart;
+    return (d / q) * PS3_TIMEBASE_FREQ + (d % q) * PS3_TIMEBASE_FREQ / q;
+#else
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * PS3_TIMEBASE_FREQ +
+           (uint64_t)ts.tv_nsec * PS3_TIMEBASE_FREQ / 1000000000ull;
+#endif
+}
+
 static void write_be32(uint32_t addr, uint32_t val)
 {
     uint32_t* p = (uint32_t*)vm_to_host(addr);

--- a/runtime/syscalls/sys_timer.h
+++ b/runtime/syscalls/sys_timer.h
@@ -28,6 +28,10 @@ extern "C" {
 /* PS3 timebase frequency */
 #define PS3_TIMEBASE_FREQ  79800000ULL
 
+/* The guest mftb/mftbu clock: one global monotonic counter, host time scaled
+ * to the PS3 timebase. Called from every lifted mftb site (ppu_lifter.py). */
+uint64_t ppu_timebase_now(void);
+
 #define SYS_TIMER_MAX  64
 
 typedef struct sys_timer_info {

--- a/tools/ppu_lifter.py
+++ b/tools/ppu_lifter.py
@@ -116,6 +116,14 @@ SOURCE_PREAMBLE = """\
 #include <string.h>
 #include <math.h>
 
+/* The guest timebase (mftb/mftbu): one global monotonic clock scaled to the
+ * PS3's 79.8 MHz, provided by the runtime (runtime/syscalls/sys_timer.c). */
+#ifdef __cplusplus
+extern "C" uint64_t ppu_timebase_now(void);
+#else
+extern uint64_t ppu_timebase_now(void);
+#endif
+
 /* MSVC compatibility helpers */
 #ifdef _MSC_VER
 #include <intrin.h>
@@ -1416,15 +1424,20 @@ class PPULifter:
                     f"ctx->gpr[{rd}] = (int64_t)(int16_t)vm_read16(ea); ctx->gpr[{ra}] = ea; }}")
 
         # ------- Move from time base -------
+        # THE guest clock. The old emission was a per-call-site static that
+        # advanced 16667 ticks PER READ -- not time: every site had a private
+        # counter that only moved when polled, so all guest elapsed-time math
+        # (media pacers, throttles, profilers, timeout loops) computed garbage
+        # from it. Real semantics: one global monotonic timebase at 79.8 MHz
+        # (runtime ppu_timebase_now, consistent with
+        # sys_time_get_timebase_frequency).
         if mn == "mftb":
             rd = _reg_idx(ops[0])
-            return (f"{{ static uint64_t tb = 79800000ULL; tb += 16667; "
-                    f"ctx->gpr[{rd}] = tb; }}")
+            return f"ctx->gpr[{rd}] = ppu_timebase_now();"
 
         if mn == "mftbu":
             rd = _reg_idx(ops[0])
-            return (f"{{ static uint64_t tb = 79800000ULL; tb += 16667; "
-                    f"ctx->gpr[{rd}] = (tb >> 32); }}")
+            return f"ctx->gpr[{rd}] = (ppu_timebase_now() >> 32);"
 
         # ------- Cache/sync ops (safe to no-op) -------
         # dcbz zeros a 128-byte cache line — MUST be implemented, not no-oped!


### PR DESCRIPTION
The mftb/mftbu emission gave every call site a private static counter advancing 16667 ticks per read. That is not a clock: it only moves when polled (a loop that reads the timebase twice with work in between measures zero elapsed time, while a tight poll measures fast-forwarded time), every call site disagrees with every other, and none of it relates to sys_time_get_timebase_frequency's correctly-reported 79.8 MHz. Any guest code that computes elapsed time from the timebase -- media pacers, frame throttles, profilers, timeout loops -- computes garbage. mftb/mftbu now read ppu_timebase_now(), a global monotonic counter added to runtime/syscalls/sys_timer.c: host time (QPC on Windows, CLOCK_MONOTONIC elsewhere) scaled to the PS3 timebase with an overflow-safe split multiply, anchored at first use; the generated-source preamble declares the extern, and mftbu returns the high word of the same counter so mftbu/mftb pairs stay coherent.

Found and validated on the Yakuza: Dead Souls port: the CRI media pacer computes its scheduling period from mftb deltas, and against the per-site counter its period stretched about a hundredfold, starving the async-file pump it drives and wedging the title's shader-archive streaming. With the real timebase the pacer runs at its intended rate; full relift plus boot, and the instruction conformance suite (PR #37) stays green.
