### PR TITLE
ppu_lifter: vcmpgtsb/sh/sw/ub/uh/uw handlers (dot forms set CR6)

### DIFF
--- a/tools/ppu_lifter.py
+++ b/tools/ppu_lifter.py
@@ -1708,6 +1708,30 @@ class PPULifter:
                     f"uint32_t* d=(uint32_t*)&ctx->vr[{vd}]; "
                     f"for(int i=0;i<4;i++) d[i]=a[i]==b[i]?~0u:0; }}")
 
+        # Vector compare greater-than, signed/unsigned, byte/half/word.
+        # Previously unhandled (fell to the TODO catch-all = silently skipped
+        # stores, so vD kept stale data). Dot forms set CR6 per the AltiVec
+        # PEM: bit0 (value 8) = all lanes true, bit2 (value 2) = all lanes
+        # false, written to CR field 6 (bits 4-7 of our packed ctx->cr).
+        vcmpgt_family = {
+            "vcmpgtsb": ("int8_t",   16), "vcmpgtsh": ("int16_t",  8),
+            "vcmpgtsw": ("int32_t",   4),
+            "vcmpgtub": ("uint8_t",  16), "vcmpgtuh": ("uint16_t", 8),
+            "vcmpgtuw": ("uint32_t",  4),
+        }
+        base_mn = mn.rstrip(".")
+        if base_mn in vcmpgt_family:
+            ety, n = vcmpgt_family[base_mn]
+            uty = ety.replace("int", "uint") if not ety.startswith("u") else ety
+            vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
+            body = (f"{{ {ety}* a=({ety}*)&ctx->vr[{va}]; {ety}* b=({ety}*)&ctx->vr[{vb}]; "
+                    f"{uty}* d=({uty}*)&ctx->vr[{vd}]; int t=0; "
+                    f"for(int i=0;i<{n};i++){{ {uty} r=a[i]>b[i]?({uty})~({uty})0:0; d[i]=r; t+=r?1:0; }}")
+            if mn.endswith("."):
+                body += (f" uint32_t c6=(t=={n}?8u:0u)|(t==0?2u:0u); "
+                         f"ctx->cr=(ctx->cr & ~(0xFu<<4))|(c6<<4);")
+            return body + " }"
+
         # ------- VMX integer arithmetic (generated from disasm decode table) -------
         # These are simple per-element operations on vector registers.
 


### PR DESCRIPTION
The vector compare-greater-than family (vcmpgtsb/sh/sw, vcmpgtub/uh/uw, and their dot forms) had no handler and fell through to the TODO catch-all, which skips the instruction entirely: vD silently keeps stale data and a branch on the dot form's CR6 result tests whatever CR6 happened to hold -- silent wrong-data failures, not crashes. Added table-driven emission over the six element types in the same shape as the existing vcmpequ* handlers; dot forms write CR6 per the AltiVec PEM (bit 0, value 8, all lanes true; bit 2, value 2, all lanes false). Like the neighboring VMX handlers the lane math uses the repo's host-order lane convention: byte-width compares are unaffected by lane order and the half/word forms are consistent with the existing vcmpequh/w.

Found and validated on the Yakuza: Dead Souls port: 35+ live sites in its effect/particle math and codec-style compare-pack pipelines were being skipped. Full relift plus boot, and conformance-suite cases (PR #37 harness) covering all-true, all-false, and mixed lanes check both the destination lanes and the CR6 nibble.
