### PR TITLE
ppu_disasm: opcodes 33/225 are crnor/crnand, not crnand/crnor

### DIFF
--- a/tools/ppu_disasm.py
+++ b/tools/ppu_disasm.py
@@ -251,7 +251,7 @@ def decode(insn: int, addr: int = 0) -> Instruction:
         bb = bits(insn, 16, 20)
         cr_ops = {
             257: "crand", 449: "cror", 193: "crxor",
-            33: "crnand", 225: "crnor", 289: "creqv",
+            33: "crnor", 225: "crnand", 289: "creqv",
             129: "crandc", 417: "crorc",
             0: "mcrf",
         }


### PR DESCRIPTION
The CR-logical opcode table mapped extended opcode 33 to crnand and 225 to crnor, but PowerISA and RPCS3's PPUOpcodes.h define 0x021 (33) as CRNOR and 0x0e1 (225) as CRNAND. The lifter dispatches on the decoded mnemonic string and its crnand/crnor emitters are each individually correct, so the swap handed every one of these instructions the wrong emitter, silently computing the inverted condition-register bit. There was no conformance coverage for either opcode, so it went undetected; across a lifted title it is on the order of a thousand sites (967 crnand + 20 crnor in Yakuza: Dead Souls), each corrupting whatever branch consumes that CR bit.

Found and validated on the Yakuza: Dead Souls port: the inverted logic derailed control flow wherever these ops feed a conditional. In the disc loader's stream producer, the crnand that combines the loop's "more work" and "buffer not full" tests was emitted as NOR, flipping its continue/exit condition, so the loader stalled mid-batch and the boot froze on an asset load. Correcting the table clears it and the boot advances into the intro-movie stage. 