### PR TITLE
sys_timer: precise sub-millisecond usleep instead of a single yield

### DIFF
--- a/runtime/syscalls/sys_timer.c
+++ b/runtime/syscalls/sys_timer.c
@@ -75,8 +75,23 @@ int64_t sys_timer_usleep(ppu_context* ctx)
             Sleep((DWORD)(usec / 1000));
         }
     } else if (usec > 0) {
-        /* Very short sleep -- yield */
-        SwitchToThread();
+        /* Sub-millisecond sleep. Sleep()/waitable timers round up to the
+         * ~0.5-1 ms scheduler quantum, far too coarse for a guest that relies
+         * on accurate microsecond pacing -- a short usleep() spin waiting on
+         * another thread to make progress otherwise collapses to a single yield
+         * and busy-spins at full speed (so the wait is effectively a no-op).
+         * Busy-wait to a precise QPC deadline, yielding inside the spin
+         * (SwitchToThread) so a sibling host thread the guest may be waiting on
+         * still gets the core. Mirrors RPCS3's "Usleep Only" TSC busy-tail. */
+        ensure_qpc_init();
+        LARGE_INTEGER qpc_start, qpc_now;
+        QueryPerformanceCounter(&qpc_start);
+        const int64_t qpc_deadline = qpc_start.QuadPart +
+            (int64_t)((usec * (uint64_t)s_qpc_freq.QuadPart) / 1000000ULL);
+        do {
+            SwitchToThread();
+            QueryPerformanceCounter(&qpc_now);
+        } while (qpc_now.QuadPart < qpc_deadline);
     }
 #else
     if (usec > 0) {


### PR DESCRIPTION
sys_timer_usleep with usec < 1000 did a single SwitchToThread() and returned, so any sub-millisecond guest sleep was effectively a no-op: a guest spin like `while (!ready) sys_timer_usleep(30);` busy-spins at full host speed instead of pacing ~30us per iteration.

This matters whenever the guest paces itself against another thread. In the Yakuza port, Sony's libgcm FIFO segment-recycle reserve spins on sys_timer_usleep(30) waiting for the RSX GET register to advance; with the no-op sleep the producer outruns and laps the FIFO consumer, which deadlocks the boot. Restoring the 30us cadence keeps them coupled.

Busy-wait to a precise QueryPerformanceCounter deadline (the >= 1ms path already uses QPC/waitable timers; this reuses the same s_qpc_freq) and call SwitchToThread() inside the spin so a sibling host thread the guest is waiting on still gets the core, since a pure pause-spin would pace this thread in wall-time but still starve the other. Mirrors RPCS3's microsecond busy-tail ("Sleep Timers Accuracy: Usleep Only"). The pthread path uses nanosleep and is unchanged.

Complements the v0.6.5 event-poll timer-resolution fix: that one covers sub-ms timeouts on sys_event_queue_receive, this covers sub-ms sleeps. Verified: with this in place the libgcm reserve spin paces correctly and the FIFO producer/consumer stay coupled through boot, the lap-deadlock no longer reproduces.
