### PR TITLE
tools: add a lifter/HLE audit kit (decode cross-checks, operand audits, HLE ABI audit, endianness heuristics, lift-structure census) and an lv2 sync stress test

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -62,6 +62,22 @@ wrong. Landed in **v0.6.1 "Many Hands"**:
 - **`tools/show_func.py`** — dump a single lifted function's C and/or its
   original PowerPC disassembly from the chunked output.
 
+*Also incorporated (**v0.6.5**)* — cellFs big-endian out-params + `CellFsStat`
+PS3 packing (#22), cellGame title id read from `PARAM.SFO` (#24), `sys_rwlock`
+`EDEADLK`/`EPERM` lv2 semantics (#25), and the `crnor`/`crnand` opcode-33/225
+disassembler fix (#40).
+
+### sagemono — [@sagemono](https://github.com/sagemono)
+Real-controller correctness surfaced by a DualShock-as-XInput bring-up
+(**v0.6.5**):
+- **cellPad DIGITAL2 packing** — `hs->buttons` carries DIGITAL1 in its low byte
+  and DIGITAL2 (the face buttons cross/circle/triangle/square + L1/L2/R1/R2) in
+  the high byte; the whole value was being written into DIGITAL1 with DIGITAL2
+  forced to 0, so every face button was dead. Split correctly (#42).
+- **analog-Y centering** — reflect the inverted Y about 128 (`256 - x`) instead
+  of `255 - x`, which turned a centered stick into 127 (`0x7F`, aliasing
+  SELECT+START self-exit + TRIANGLE).
+
 ### Paulo Adriano Alves — [@pauloadrianoalves](https://github.com/pauloadrianoalves)
 Initial **PPU boot path** and supporting tooling (PR #3, partially incorporated
 in **v0.6.2** — the SPU portions were superseded by the v0.6.0 SPU subsystem and

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ See [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md) for the full walkthrough.
 | **flOw** (thatgamecompany) | NPUA80001 | 92K functions, game reaches main() init, module loading + sysutil callbacks working, trampoline system for split-function chains, ~10K TODOs, D3D12 backend ready | [sp00nznet/flow](https://github.com/sp00nznet/flow) |
 | **Tokyo Jungle** (Crispy's/SCE Japan) | NPUA80523 | 33K functions lifted, CRT init + HLE framework wired, indirect call dispatch | [sp00nznet/tokyojungle](https://github.com/sp00nznet/tokyojungle) |
 | **The Simpsons Arcade Game** (Konami) | NPUB30563 | 14.7K functions; boots through CRT + GCM init with a live D3D12 window; a Konami arcade *emulator* EBOOT that routes rendering through CRI middleware on SPURS SPU tasks — drove the SPU recompilation work; blocked on the SPU-task pipeline | [sp00nznet/simpsonsarcade-ps3](https://github.com/sp00nznet/simpsonsarcade-ps3) |
+| **You Don't Know Jack** (Jellyvision/THQ) | BLUS30569 | 5,859 functions; **boots the full init stack to its main game loop** and runs a live D3D12 clear+flip at 60 Hz. Scaleform Flash UI + FMOD audio — a menu/UI-heavy title, an ideal recomp target. Frontier: GCM ring-wrap flush callback + a `0xC708C708` scene-dispatch poison gate the first real draws | [sp00nznet/youdontknowjack](https://github.com/sp00nznet/youdontknowjack) |
 
 Want to port a game? Start with the [Getting Started](#getting-started) section, check [docs/MODULE_STATUS.md](docs/MODULE_STATUS.md) for system library coverage, and see the [flOw case study](docs/GAME_PORTING_GUIDE.md#case-study-flow) for a real-world walkthrough.
 
@@ -337,6 +338,22 @@ ps3recomp is built by a growing community. See **[CONTRIBUTORS.md](CONTRIBUTORS.
 for who did what — thank you, everyone.
 
 ## Changelog
+
+### v0.6.5 — *"The Fifteen-Millisecond Tax"* (July 2026)
+*Driving **You Don't Know Jack** (Scaleform UI + FMOD, 5,859 functions) from an instant crash to its running main loop surfaced one global performance bug worth more than any single lift fix — plus a batch of community lifter/HLE correctness PRs.*
+
+**Runtime — the event-poll timer-resolution fix** (`sys_event.c`, `tests/boot_main.cpp`):
+- Titles that poll an event queue every frame with a **sub-millisecond timeout** (YDKJ uses 30 µs) were throttled ~**500× game-wide**. `sys_event_queue_receive` floored the timeout to a 1 ms `SleepConditionVariableCS`, but Windows' default ~15.6 ms timer granularity inflates *any* sub-15 ms wait to a full tick — a two-queue-per-frame poll loop burned ~30 ms/frame doing nothing. Sub-millisecond timeouts now do a true non-blocking check (immediate `ETIMEDOUT` when empty), and the harness calls `timeBeginPeriod(1)`. YDKJ went from ~0.5 fps effective to ~60 Hz, reaching online-init ~6× faster.
+- GCM FIFO drain moved into the 60 Hz vblank tick, so RSX sync-fence labels advance regardless of `present()` latency.
+
+**Community PRs incorporated** — thank you:
+- **cellFs big-endian out-params + `CellFsStat` PS3 packing** — *[@canersaka](https://github.com/canersaka)* (#22)
+- **cellGame reads the real title id from `PARAM.SFO`** — *[@canersaka](https://github.com/canersaka)* (#24)
+- **`sys_rwlock` → `EDEADLK`/`EPERM`** on writer self-relock / bad unlock — *[@canersaka](https://github.com/canersaka)* (#25)
+- **`ppu_disasm`: opcodes 33/225 are `crnor`/`crnand`** (were swapped) — *[@canersaka](https://github.com/canersaka)* (#40)
+- **cellPad DIGITAL2 face-button packing + analog-Y reflect-about-128** — *[@sagemono](https://github.com/sagemono)* (#42)
+
+**You Don't Know Jack port** — now public at [sp00nznet/youdontknowjack](https://github.com/sp00nznet/youdontknowjack): boots the full init stack to its **main game loop** with a live D3D12 clear+flip at 60 Hz. Current frontier: the GCM command buffer's ring-wrap flush callback is `null` and a computed `0xC708C708` poison reaches the scene-graph dispatch — so only black clears render so far.
 
 ### v0.6.4 — *"Carry the One"* (July 2026)
 *A pass of hard-won correctness fixes surfaced by driving flOw (PhyreEngine, ~104k functions) deep into its boot — plus the SPU-side plumbing to get a SPURS taskset actually dispatching. Most of these are silent-corruption bugs: the lift produced valid C for the *wrong* computation, so nothing crashed until a data structure quietly filled with garbage thousands of frames later.*

--- a/README.md
+++ b/README.md
@@ -338,6 +338,33 @@ for who did what — thank you, everyone.
 
 ## Changelog
 
+### v0.6.4 — *"Carry the One"* (July 2026)
+*A pass of hard-won correctness fixes surfaced by driving flOw (PhyreEngine, ~104k functions) deep into its boot — plus the SPU-side plumbing to get a SPURS taskset actually dispatching. Most of these are silent-corruption bugs: the lift produced valid C for the *wrong* computation, so nothing crashed until a data structure quietly filled with garbage thousands of frames later.*
+
+**PPU lift — the carry/borrow bug class** (`ppu_lifter.py`):
+- **64-bit `add` never wrote XER[CA]** and truncated the carry-out to 32 bits. Any `adde`/`addze`/`subfe` consumer downstream (bignum math, 64-bit pointer arithmetic, the CRT's own `__eabi` helpers) then read a stale carry. Now sets CA from the true unsigned 64-bit carry-out.
+- **`subfic` computed a 32-bit result and dropped the borrow** — rewritten as `EXTS(SI) - RA` over the full 64 bits with `XER[CA] = NOT borrow` (`EXTS(SI) >= RA`).
+- **`subfme` was missing its XER[CA] update entirely**; `adde`/`addme` carry-out recomputed to match the PowerISA / RPCS3 `add64_flags` ADC semantics.
+- **`sraw`/`srad`/`srawi`/`sradi` now set XER[CA]** (was never written) via new `ppc_sraw`/`ppc_srad` helpers — CA = `rS<0 AND any 1-bits shifted out`, which feeds the same `adde`/`subfe` consumers.
+- **Fall-through tail-call / computed-`bctr` dispatch leaked the frame**: these were lifted as `ps3_indirect_call(ctx); return;` *without* the function epilogue, leaking `r1` and the callee-saved GPRs on every jump-table `switch` and tail call. Now emits the full epilogue before the tail jump.
+- **`ppu_disasm.py --va`**: disassemble a window at a *virtual* address, mapping va→file offset through the ELF's `PT_LOAD` segments — fixing the long-standing footgun where `--raw --offset <vaddr>` read the wrong bytes (off by the `.text` segment base).
+
+**SPU lift — computed jumps & wide ops** (`spu_lifter.py`, `spu_disasm.py`):
+- **`bi $r0` computed tail-jumps vs. returns**: a `bi $r0` whose `r0` was just reloaded via `lqa`/`lqr` is a *computed tail jump*, not a return. Treating them all as returns made the SPURS taskset launcher fall through and the dispatcher loop forever — the exact SPU analogue of the PPU tail-call bug above. `compute_bi_r0_jumps()` now classifies them by backward-scanning for the nearest `r0` writer.
+- **RRR 4-operand destination register** decoded from bits 21–27 (the low 7 bits are the `RC` *source*, not the dest) — every `selb`/`shufb`/`fma`-family op wrote the wrong register.
+- **Double-precision family**: `fesd`/`frds` single↔double convert, and the `dfma`/`dfms`/`dfnms`/`dfnma` double FMA ops (3-register, `RT` is the accumulator).
+- **`cgx` extended carry-generate** (RT is also a source), **`mpyhha`/`mpyhhau`** high-half multiply-accumulate, and a **`br .` self-loop trap** (target == self is a deliberate infinite-hang trap on real SPU, not forward progress).
+
+**Runtime robustness**:
+- **PPU function-hash table widened** (`ppu_loader.cpp`, `PPU_HASH_BITS` 16→18): the open-addressed registration table live-locked filling past 65,536 functions — flOw registers ~104k. Titles above ~50k functions now register in bounded time.
+- **`/app_home/` VFS mapping** (`sys_fs.c`): the install-dir prefix (opened as `/app_home/...`, `app_home/...`, `e:/app_home/...`) now maps to the USRDIR root instead of appending a literal `app_home` directory that isn't on disk.
+- **Page-guard watchpoint** (`ppu_guard_page()`, Windows): arm a guest EA and a VEH logs the faulting host RIP of any raw store into that 4 KB page — catches vector/`memcpy` stores that `vm_write*` instrumentation can't see. Env-gated; a diagnostic aid, off by default.
+- **`cellGcmGetTiledPitchSize` ABI fix** + real flip/vblank handler dispatch (see prior commits) — the wrong return convention was corrupting the caller's stack.
+
+**SPU SPURS plumbing**: new `libs/spurs/spurs_taskset.{c,h}` + `spurs_pm.c` (taskset descriptor + power-management scaffolding) and `runtime/spu/` workload-dispatch wiring toward running a real SPURS task kernel. Still in progress — the taskset dispatches but completion-event delivery back to the PPU isn't verified yet.
+
+**Tooling**: `tools/test_ppu_lift.py` (PPU lifter unit harness) and `tools/rpcs3_probe/` oracle-introspection scripts used to diff our lift against the running RPCS3 reference.
+
 ### v0.6.3 — *"Knowing the Names"* (June 2026)
 - **NID resolution, doubled+**: `nid_database` now auto-scans `libs/` + `runtime/` for every function the toolkit implements (`load_implemented()`), and ships 44 more curated names recovered by exact-NID brute-force against the harness corpus. Resolution went from 175 → 421 of the 660 distinct NIDs the sample titles import; the harness stub-prioritization ranking is now fully named through the high-frequency tiers.
 - **Harness stub-prioritization ranking**: a new non-gating `imports` stage (via `ppu_loader`'s `proc_prx_param` → libstub walk) extracts each EBOOT's firmware imports and resolves them, and the report ranks the most-imported libraries and functions across titles — the data that says which stubs to write next.

--- a/libs/filesystem/cellFs.c
+++ b/libs/filesystem/cellFs.c
@@ -6,6 +6,7 @@
  */
 
 #include "cellFs.h"
+#include "ps3emu/endian.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -157,6 +158,23 @@ int cellfs_translate_path(const char* ps3_path, char* host_buf, size_t buf_size)
 /* ---------------------------------------------------------------------------
  * Host stat -> CellFsStat conversion
  * -----------------------------------------------------------------------*/
+
+/* CellFsStat is written into guest (big-endian) memory; byte-swap every
+ * multi-byte field in place. The game reads st_size etc. via lwz/ld which
+ * byte-swap, so a host-endian struct yields garbage (e.g. a 0x...00 size that
+ * fails asset parsing). Call after filling the struct natively. */
+static void cellfs_stat_to_be(CellFsStat* sb)
+{
+    sb->st_mode    = (s32)ps3_bswap32((u32)sb->st_mode);
+    sb->st_uid     = (s32)ps3_bswap32((u32)sb->st_uid);
+    sb->st_gid     = (s32)ps3_bswap32((u32)sb->st_gid);
+    sb->st_atime   = (s64)ps3_bswap64((u64)sb->st_atime);
+    sb->st_mtime   = (s64)ps3_bswap64((u64)sb->st_mtime);
+    sb->st_ctime   = (s64)ps3_bswap64((u64)sb->st_ctime);
+    sb->st_size    = ps3_bswap64(sb->st_size);
+    sb->st_blksize = ps3_bswap64(sb->st_blksize);
+}
+
 static void fill_cellfs_stat(CellFsStat* sb, const HOST_STAT_T* hst)
 {
     memset(sb, 0, sizeof(CellFsStat));
@@ -205,6 +223,8 @@ static void fill_cellfs_stat(CellFsStat* sb, const HOST_STAT_T* hst)
 #endif
     sb->st_size  = (u64)hst->st_size;
     sb->st_blksize = 4096;
+
+    cellfs_stat_to_be(sb);
 }
 
 /* ---------------------------------------------------------------------------
@@ -364,7 +384,7 @@ s32 cellFsOpen(const char* path, s32 flags, CellFsFd* fd, const void* arg, u64 s
     s_files[slot].flags   = flags;
     s_files[slot].host_fp = fp;
 
-    *fd = slot;
+    *fd = (CellFsFd)ps3_bswap32((u32)slot);   /* guest reads the fd big-endian */
     printf("[cellFs] Open: fd=%d -> '%s'\n", slot, host_path);
     return CELL_OK;
 }
@@ -402,7 +422,7 @@ s32 cellFsRead(CellFsFd fd, void* buf, u64 nbytes, u64* nread)
     }
 
     if (nread)
-        *nread = bytes_read;
+        *nread = ps3_bswap64(bytes_read);
 
     return CELL_OK;
 }
@@ -424,7 +444,7 @@ s32 cellFsWrite(CellFsFd fd, const void* buf, u64 nbytes, u64* nwrite)
     }
 
     if (nwrite)
-        *nwrite = bytes_written;
+        *nwrite = ps3_bswap64(bytes_written);
 
     return CELL_OK;
 }
@@ -448,7 +468,7 @@ s32 cellFsLseek(CellFsFd fd, s64 offset, s32 whence, u64* pos)
         s64 cur = (s64)ftello(s_files[fd].host_fp);
 #endif
         if (pos)
-            *pos = (u64)cur;
+            *pos = ps3_bswap64((u64)cur);
     } else {
         if (pos)
             *pos = 0;
@@ -489,6 +509,7 @@ s32 cellFsFstat(CellFsFd fd, CellFsStat* sb)
     memset(sb, 0, sizeof(CellFsStat));
     sb->st_mode = CELL_FS_S_IFREG | CELL_FS_S_IRUSR | CELL_FS_S_IWUSR;
     sb->st_blksize = 4096;
+    cellfs_stat_to_be(sb);
     return CELL_OK;
 }
 
@@ -576,8 +597,8 @@ s32 cellFsGetBlockSize(const char* path, u64* sector_size, u64* block_size)
     if (!path)
         return CELL_EFAULT;
 
-    if (sector_size) *sector_size = 512;
-    if (block_size)  *block_size  = 4096;
+    if (sector_size) *sector_size = ps3_bswap64(512);
+    if (block_size)  *block_size  = ps3_bswap64(4096);
 
     return CELL_OK;
 }
@@ -590,10 +611,10 @@ s32 cellFsGetFreeSize(const char* path, u32* block_size, u64* free_block_count)
     if (!path)
         return CELL_EFAULT;
 
-    if (block_size) *block_size = 4096;
+    if (block_size) *block_size = ps3_bswap32(4096);
 
     /* Report ~1GB free by default */
-    if (free_block_count) *free_block_count = (u64)(1024ULL * 1024 * 1024 / 4096);
+    u64 free_blocks = (u64)(1024ULL * 1024 * 1024 / 4096);
 
 #ifdef _WIN32
     {
@@ -601,11 +622,13 @@ s32 cellFsGetFreeSize(const char* path, u32* block_size, u64* free_block_count)
         if (translate_path(path, host_path, sizeof(host_path)) == 0) {
             ULARGE_INTEGER free_bytes;
             if (GetDiskFreeSpaceExA(host_path, &free_bytes, NULL, NULL)) {
-                if (free_block_count) *free_block_count = (u64)(free_bytes.QuadPart / 4096);
+                free_blocks = (u64)(free_bytes.QuadPart / 4096);
             }
         }
     }
 #endif
+
+    if (free_block_count) *free_block_count = ps3_bswap64(free_blocks);
 
     return CELL_OK;
 }
@@ -667,7 +690,7 @@ s32 cellFsOpendir(const char* path, CellFsDir* fd)
     }
 #endif
 
-    *fd = slot;
+    *fd = (CellFsDir)ps3_bswap32((u32)slot);   /* guest reads the dir fd big-endian */
     printf("[cellFs] Opendir: dir_fd=%d -> '%s'\n", slot, host_path);
     return CELL_OK;
 }
@@ -713,8 +736,9 @@ s32 cellFsReaddir(CellFsDir fd, CellFsDirectoryEntry* entry, u64* nread)
         entry->attribute.st_size = (u64)file_size.QuadPart;
     }
     entry->attribute.st_blksize = 4096;
+    cellfs_stat_to_be(&entry->attribute);
 
-    *nread = 1;
+    *nread = ps3_bswap64(1);
 #else
     struct dirent* de = readdir(s_dirs[fd].host_dir);
     if (!de) {
@@ -736,9 +760,10 @@ s32 cellFsReaddir(CellFsDir fd, CellFsDirectoryEntry* entry, u64* nread)
         /* Minimal fallback */
         entry->attribute.st_mode = CELL_FS_S_IFREG | CELL_FS_S_IRUSR | CELL_FS_S_IWUSR;
         entry->attribute.st_blksize = 4096;
+        cellfs_stat_to_be(&entry->attribute);
     }
 
-    *nread = 1;
+    *nread = ps3_bswap64(1);
 #endif
 
     return CELL_OK;

--- a/libs/filesystem/cellFs.h
+++ b/libs/filesystem/cellFs.h
@@ -65,6 +65,12 @@ extern "C" {
  * Structures
  * -----------------------------------------------------------------------*/
 
+/* The PS3 ABI packs CellFsStat to 4-byte alignment: the 64-bit fields sit at
+ * 4-byte (not 8-byte) offsets, so st_size is at +0x24 and the struct is 52
+ * bytes (RPCS3 sys_fs.h: be_t<s64,4>, CHECK_SIZE_ALIGN(CellFsStat,52,4)).
+ * Without #pragma pack the host would 8-align the s64s, putting st_size at +0x28
+ * (56-byte struct) and the guest would read its size from the wrong offset. */
+#pragma pack(push, 4)
 typedef struct CellFsStat {
     s32  st_mode;
     s32  st_uid;
@@ -80,6 +86,7 @@ typedef struct CellFsDirectoryEntry {
     CellFsStat attribute;
     char       entry_name[CELL_FS_MAX_FS_FILE_NAME_LENGTH];
 } CellFsDirectoryEntry;
+#pragma pack(pop)
 
 /* Opaque file/directory descriptors */
 typedef s32 CellFsFd;

--- a/libs/input/cellPad.c
+++ b/libs/input/cellPad.c
@@ -144,11 +144,14 @@ static void pad_poll_xinput(void)
 
         s_host_state[i].buttons = btns;
 
-        /* Analog sticks */
+        /* Analog sticks. PS3 Y axis is inverted vs XInput (up = 0). Reflect about
+         * 128 (256 - x), NOT 255 - x: the latter turns a centered stick into 127,
+         * whose bits (0x7F) alias SELECT+START and can make the guest self-exit.
+         * (via sagemono, PR #42) */
         s_host_state[i].analog_lx = pad_xinput_stick_to_u8(gp->sThumbLX, PAD_STICK_DEADZONE);
-        s_host_state[i].analog_ly = (u8)(255 - pad_xinput_stick_to_u8(gp->sThumbLY, PAD_STICK_DEADZONE)); /* Y inverted */
+        s_host_state[i].analog_ly = (u8)(256 - pad_xinput_stick_to_u8(gp->sThumbLY, PAD_STICK_DEADZONE));
         s_host_state[i].analog_rx = pad_xinput_stick_to_u8(gp->sThumbRX, PAD_STICK_DEADZONE);
-        s_host_state[i].analog_ry = (u8)(255 - pad_xinput_stick_to_u8(gp->sThumbRY, PAD_STICK_DEADZONE));
+        s_host_state[i].analog_ry = (u8)(256 - pad_xinput_stick_to_u8(gp->sThumbRY, PAD_STICK_DEADZONE));
 
         /* Triggers */
         s_host_state[i].trigger_l2 = gp->bLeftTrigger;
@@ -411,9 +414,13 @@ s32 cellPadGetData(u32 port_no, CellPadData* data_guest)
     data->button[0] = (u16)len;
     data->button[1] = 0; /* reserved */
 
-    /* Digital buttons */
-    data->button[CELL_PAD_BTN_OFFSET_DIGITAL1] = hs->buttons;
-    data->button[CELL_PAD_BTN_OFFSET_DIGITAL2] = 0; /* PS button etc. */
+    /* Digital buttons. hs->buttons packs both halves into one 16-bit mask
+     * (SELECT=bit0..LEFT=bit7 = DIGITAL1; L2=bit8..SQUARE=bit15 = DIGITAL2).
+     * Split correctly — writing the whole value into DIGITAL1 with DIGITAL2=0
+     * left every face button (cross/circle/triangle/square, L1/L2/R1/R2) dead.
+     * (via sagemono, PR #42) */
+    data->button[CELL_PAD_BTN_OFFSET_DIGITAL1] = (u16)(hs->buttons & 0xFF);
+    data->button[CELL_PAD_BTN_OFFSET_DIGITAL2] = (u16)((hs->buttons >> 8) & 0xFF);
 
     /* Analog sticks */
     data->button[CELL_PAD_BTN_OFFSET_ANALOG_RIGHT_X] = hs->analog_rx;

--- a/libs/input/cellPad.c
+++ b/libs/input/cellPad.c
@@ -368,24 +368,35 @@ void cellPad_poll(void)
     }
 }
 
-s32 cellPadGetData(u32 port_no, CellPadData* data)
+/* HLE args are GUEST effective addresses; guest structs are BIG-ENDIAN. These
+ * runtime helpers translate + byte-swap. (cellPad was written for host pointers
+ * and was never actually invoked until its NIDs were fixed.) */
+extern void vm_write8 (unsigned long long a, unsigned char  v);
+extern void vm_write16(unsigned long long a, unsigned short v);
+extern void vm_write32(unsigned long long a, unsigned int   v);
+
+s32 cellPadGetData(u32 port_no, CellPadData* data_guest)
 {
     if (!s_pad_initialized)
         return CELL_PAD_ERROR_NOT_OPENED;
 
-    if (port_no >= s_max_connect || !data)
+    if (port_no >= s_max_connect || !data_guest)
         return CELL_PAD_ERROR_INVALID_PARAMETER;
 
+    /* Build in a local host struct, then copy to guest memory big-endian. */
+    CellPadData _d; CellPadData* data = &_d;
     memset(data, 0, sizeof(CellPadData));
 
     /* Poll fresh state */
     pad_poll_backend();
 
-    if (port_no >= PAD_MAX_HOST_PORTS || !s_host_state[port_no].connected) {
-        data->len = 0;
-        return CELL_OK;
+    if (port_no >= PAD_MAX_HOST_PORTS || (!s_host_state[port_no].connected && port_no != 0)) {
+        goto emit;   /* data stays zeroed -> len=0 */
     }
+    /* port 0 is always a valid (virtual) pad; s_host_state[0] is neutral if no
+     * physical device, which yields no-buttons-pressed data below. */
 
+    {
     PadHostState* hs = &s_host_state[port_no];
     u32 setting = s_port_setting[port_no];
 
@@ -434,27 +445,40 @@ s32 cellPadGetData(u32 port_no, CellPadData* data)
         data->button[CELL_PAD_BTN_OFFSET_SENSOR_Z] = 512;
         data->button[CELL_PAD_BTN_OFFSET_SENSOR_G] = 512;
     }
+    }  /* end connected block */
 
+emit:
+    {
+        unsigned int ea = (unsigned int)(uintptr_t)data_guest;
+        vm_write32((unsigned long long)ea + 0, (unsigned int)data->len);   /* len (s32) */
+        for (int _i = 0; _i < CELL_PAD_MAX_CODES; _i++)                    /* button[] u16 */
+            vm_write16((unsigned long long)ea + 4 + (unsigned int)_i * 2, data->button[_i]);
+    }
     return CELL_OK;
 }
 
-s32 cellPadGetInfo2(CellPadInfo2* info)
+s32 cellPadGetInfo2(CellPadInfo2* info_guest)
 {
     if (!s_pad_initialized)
         return CELL_PAD_ERROR_NOT_OPENED;
 
-    if (!info)
+    if (!info_guest)
         return CELL_PAD_ERROR_INVALID_PARAMETER;
 
     /* Poll to get latest connection state */
     pad_poll_backend();
 
+    /* Build in a local host struct, then copy to guest memory big-endian. */
+    CellPadInfo2 _in; CellPadInfo2* info = &_in;
     memset(info, 0, sizeof(CellPadInfo2));
     info->max_connect = s_max_connect;
 
     u32 connected = 0;
     for (u32 i = 0; i < s_max_connect && i < PAD_MAX_HOST_PORTS; i++) {
-        if (s_host_state[i].connected) {
+        /* Always present a virtual pad on port 0 (standard emulator behavior) so
+         * boot flows that block until a controller is connected can proceed even
+         * with no physical device attached. */
+        if (s_host_state[i].connected || i == 0) {
             info->port_status[i]       = CELL_PAD_STATUS_CONNECTED;
             info->port_setting[i]      = s_port_setting[i];
             info->device_capability[i] = CELL_PAD_CAPABILITY_PS3_CONFORMITY
@@ -470,6 +494,12 @@ s32 cellPadGetInfo2(CellPadInfo2* info)
     }
     info->now_connect = connected;
 
+    /* copy to guest big-endian (CellPadInfo2 is all u32 fields) */
+    {
+        unsigned int ea = (unsigned int)(uintptr_t)info_guest;
+        for (unsigned int _o = 0; _o < sizeof(CellPadInfo2); _o += 4)
+            vm_write32((unsigned long long)ea + _o, *(u32*)((char*)info + _o));
+    }
     return CELL_OK;
 }
 

--- a/libs/network/sceNpBasic.c
+++ b/libs/network/sceNpBasic.c
@@ -54,16 +54,20 @@ s32 sceNpBasicTerm(void)
     return CELL_OK;
 }
 
-/* The title's main loop drains PSN events with `while (sceNpBasicGetEvent(...)
- * == CELL_OK) { ... }`. Unregistered, this returned 0 (CELL_OK) forever -> the
- * loop never terminated and the game idled instead of advancing to its frame
- * work. Return "no pending event" (any non-zero error ends the drain). We don't
- * dereference the out-params (we report no event), so no translation needed. */
+/* The title's main loop drains PSN events with a loop that exits ONLY when
+ * sceNpBasicGetEvent returns the specific code 0x8002A66A (SCE_NP_BASIC_ERROR_NO_EVENT)
+ * -- verified in the recompiled drain loop func_00063E34 (cmpwi r3, 0x8002A66A ->
+ * exit). Returning any OTHER error (e.g. 0x8002AA09) is NOT recognized: the game
+ * then reads a STALE/garbage event out-param and loops forever, hanging the boot
+ * before NP-init/trophy/GThread. So the exact value matters. We report no event
+ * and don't touch the out-params. */
 #ifndef SCE_NP_BASIC_ERROR_NO_EVENT
-#define SCE_NP_BASIC_ERROR_NO_EVENT 0x8002AA09
+#define SCE_NP_BASIC_ERROR_NO_EVENT 0x8002A66A
 #endif
 s32 sceNpBasicGetEvent(u32* event, void* from, void* data, u32* size)
 {
+    /* out-params are GUEST EAs; the game checks the return (0x8002A66A) and
+     * exits the drain BEFORE reading them, so we leave them untouched. */
     (void)event; (void)from; (void)data; (void)size;
     return (s32)SCE_NP_BASIC_ERROR_NO_EVENT;
 }

--- a/libs/network/sceNpTrophy.c
+++ b/libs/network/sceNpTrophy.c
@@ -288,8 +288,33 @@ s32 sceNpTrophyDestroyHandle(SceNpTrophyHandle handle)
     return CELL_OK;
 }
 
+/* Fire a guest SceNpTrophyStatusCallback via the OPD in `statusCb`.
+ * Callback ABI: int cb(context, status, completed, total, arg). */
+extern unsigned long long ppu_guest_call_ct(u32 code, u32 toc,
+                                            u64 a0, u64 a1, u64 a2, u64 a3);
+
+static void trophy_fire_status_cb(u32 statusCb, u32 arg,
+                                  SceNpTrophyContext context,
+                                  u32 status, u32 completed, u32 total)
+{
+    if (!statusCb) return;
+    /* Resolve the guest OPD (big-endian: [code][toc]). */
+    const u8* opd = (const u8*)(vm_base + statusCb);
+    u32 code = ((u32)opd[0] << 24) | ((u32)opd[1] << 16) |
+               ((u32)opd[2] <<  8) |  (u32)opd[3];
+    u32 toc  = ((u32)opd[4] << 24) | ((u32)opd[5] << 16) |
+               ((u32)opd[6] <<  8) |  (u32)opd[7];
+    (void)arg;  /* real game passes arg=0; ppu_guest_call_ct leaves r7=0 */
+    printf("[sceNpTrophy] firing status cb: opd=0x%08X code=0x%08X toc=0x%08X "
+           "status=%u (%u/%u)\n", statusCb, code, toc, status, completed, total);
+    ppu_guest_call_ct(code, toc,
+                      (u64)(u32)context, (u64)status, (u64)completed, (u64)total);
+}
+
 s32 sceNpTrophyRegisterContext(SceNpTrophyContext context,
                                SceNpTrophyHandle handle,
+                               u32 statusCb,
+                               u32 arg,
                                u64 options)
 {
     (void)options;
@@ -312,8 +337,19 @@ s32 sceNpTrophyRegisterContext(SceNpTrophyContext context,
     trophy_load(&s_contexts[context]);
     s_contexts[context].registered = 1;
 
-    printf("[sceNpTrophy] RegisterContext(ctx=%d, handle=%d) -> loaded saved data\n",
-           context, handle);
+    printf("[sceNpTrophy] RegisterContext(ctx=%d, handle=%d, statusCb=0x%08X, "
+           "arg=0x%08X) -> loaded saved data\n", context, handle, statusCb, arg);
+
+    /* The game blocks (TrophyThread poll on 0x543580) until registration
+     * completes.  Real fw drives that completion by invoking the guest status
+     * callback synchronously on this thread.  Matching the RPCS3 oracle, we
+     * fire it once with INSTALLED (trp_status=3). */
+    {
+        u32 total = s_contexts[context].total_trophies;
+        trophy_fire_status_cb(statusCb, arg, context,
+                              SCE_NP_TROPHY_STATUS_INSTALLED, total, total);
+    }
+
     return CELL_OK;
 }
 

--- a/libs/network/sceNpTrophy.h
+++ b/libs/network/sceNpTrophy.h
@@ -120,9 +120,21 @@ s32 sceNpTrophyDestroyContext(SceNpTrophyContext context);
 s32 sceNpTrophyCreateHandle(SceNpTrophyHandle* handle);
 s32 sceNpTrophyDestroyHandle(SceNpTrophyHandle handle);
 
+/* Real ABI: (context, handle, statusCb, arg, options).  statusCb is a guest
+ * OPD for SceNpTrophyStatusCallback(context, status, completed, total, arg);
+ * the game blocks on registration-complete which is signalled via this cb. */
 s32 sceNpTrophyRegisterContext(SceNpTrophyContext context,
                                SceNpTrophyHandle handle,
+                               u32 statusCb,
+                               u32 arg,
                                u64 options);
+
+/* SceNpTrophyStatus values fired to the status callback */
+#define SCE_NP_TROPHY_STATUS_UNKNOWN            0
+#define SCE_NP_TROPHY_STATUS_NOT_INSTALLED      1
+#define SCE_NP_TROPHY_STATUS_DATA_CORRUPT       2
+#define SCE_NP_TROPHY_STATUS_INSTALLED          3
+#define SCE_NP_TROPHY_STATUS_REQUIRES_UPDATE    4
 
 s32 sceNpTrophyGetRequiredDiskSpace(SceNpTrophyContext context,
                                     SceNpTrophyHandle handle,

--- a/libs/spurs/cellSpurs.c
+++ b/libs/spurs/cellSpurs.c
@@ -11,10 +11,18 @@
 
 #include "cellSpurs.h"
 #include "spu_workload.h"   /* SPU image -> lifted-entry dispatch (runtime/spu) */
+#include "spurs_taskset.h"  /* REAL BE CellSpursTaskset layout builders (fork Option-B) */
 #include "../../runtime/ppu/ppu_memory.h"   /* vm_base (guest mem) */
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
+
+/* Bridge the real (BE) taskset EA + selected taskId from CreateTask to the image-22
+ * SPU dispatch (spu_workload.c), so spurs_pm_build_context can build the leaf's
+ * SpursTasksetContext from the real taskset. Set right before dispatch_async (the PPU
+ * create path is sequential here). Gated by YDKJ_REAL_TASKSET in the dispatch. */
+uint32_t g_ydkj_real_taskset_ea = 0;
+uint32_t g_ydkj_real_taskid     = 0;
 
 /* Generic HLE adapter passes GUEST addresses; translate pointer args. CellSpurs
  * is treated opaquely by the game (passed back as a handle), so translating the
@@ -356,6 +364,11 @@ s32 cellSpursCreateTaskset(CellSpurs* spurs, CellSpursTaskset* taskset,
 {
     (void)args; (void)priority; (void)maxContention;
 
+    /* Capture the GUEST EAs (raw register values) BEFORE host translation -- the real
+     * BE taskset builder writes to guest memory at these EAs. */
+    uint32_t taskset_ea = (uint32_t)(uintptr_t)taskset;
+    uint32_t spurs_ea   = (uint32_t)(uintptr_t)spurs;
+
     /* Args arrive as guest effective addresses (ps3_hle_call passes raw guest
      * register values); translate to host before dereferencing. */
     spurs   = GUEST_PTR(spurs, CellSpurs*);
@@ -371,7 +384,14 @@ s32 cellSpursCreateTaskset(CellSpurs* spurs, CellSpursTaskset* taskset,
     taskset->initialized = 1;
     taskset->spurs = spurs;
 
-    printf("[cellSpurs] CreateTaskset()\n");
+    /* Write the REAL big-endian CellSpursTaskset layout (fork Option-B) so the lifted
+     * SPU leaf + spurs_pm_build_context read valid data (the native writes above are
+     * little-endian = garbage to the SPU). Overwrites 0x00-0x80 with BE fields. */
+    spurs_taskset_init(taskset_ea, spurs_ea, args, /*wid*/0,
+                       (uint32_t)sizeof(CellSpursTaskset), /*evf1*/0, /*evf2*/0);
+    g_ydkj_real_taskset_ea = taskset_ea;
+
+    printf("[cellSpurs] CreateTaskset() ea=0x%08X spurs=0x%08X (real BE layout)\n", taskset_ea, spurs_ea);
     return CELL_OK;
 }
 
@@ -443,6 +463,12 @@ s32 cellSpursCreateTask(CellSpursTaskset* taskset, CellSpursTaskId* taskId,
 {
     (void)context; (void)sizeContext; (void)attr;
 
+    /* Capture guest EAs BEFORE host translation (the real BE taskset builder + the
+     * SPU DMA use guest EAs). */
+    uint32_t taskset_ea = (uint32_t)(uintptr_t)taskset;
+    uint32_t elf_ea     = (uint32_t)(uintptr_t)elf;
+    uint32_t context_ea = (uint32_t)(uintptr_t)context;
+
     /* taskId/taskset are guest EAs; translate before deref. elf/context stay
      * guest EAs (handled below — elf is translated for load, context kept EA). */
     taskset = GUEST_PTR(taskset, CellSpursTaskset*);
@@ -451,7 +477,7 @@ s32 cellSpursCreateTask(CellSpursTaskset* taskset, CellSpursTaskId* taskId,
     if (!taskset)
         return CELL_SPURS_TASK_ERROR_NULL_POINTER;
 
-    if (!taskset->initialized)
+    if (!g_ydkj_real_taskset_ea)   /* real-BE init flag (native ->initialized clobbered by BE layout) */
         return CELL_SPURS_TASK_ERROR_STAT;
 
     /* Find a free task slot */
@@ -466,6 +492,15 @@ s32 cellSpursCreateTask(CellSpursTaskset* taskset, CellSpursTaskId* taskId,
 
             if (taskId_h) *taskId_h = s_tasks[i].id;
             taskset->taskCount++;
+
+            /* Register the task in the REAL BE taskset: writes task_info[slot]
+             * (args/elf/context/ls_pattern) + sets enabled+ready bits so the PM's
+             * SELECT_TASK picks it. Slot index i = the SPURS taskId (bitset bit). */
+            spurs_taskset_add_task(taskset_ea, i, (uint64_t)elf_ea,
+                                   (uint64_t)context_ea, /*arg*/NULL, /*ls_pattern*/NULL);
+            /* Bridge to the image-22 dispatch so build_context uses this taskset+task. */
+            g_ydkj_real_taskset_ea = taskset_ea;
+            g_ydkj_real_taskid     = i;
 
             printf("[cellSpurs] CreateTask(id=%u, entry=%p) - task logged\n",
                    s_tasks[i].id, elf);

--- a/libs/spurs/spurs_pm.c
+++ b/libs/spurs/spurs_pm.c
@@ -1,0 +1,88 @@
+/* spurs_pm.c -- SPURS taskset Policy Module logic (Option B, phase B3), clean-room
+ * reimplementation of the parts of RPCS3 cellSpursSpu.cpp our HLE needs. Operates on
+ * the BE shared-memory layout (spurs_taskset.h); all guest access via the vm_read /
+ * vm_write byte-swapping accessors.
+ *
+ * This module is the "SPU kernel" that schedules our real lifted leaf task: it selects a
+ * ready task and builds the SpursTasksetContext at LS 0x2700, then the dispatcher loads
+ * the task's context and runs it. Selection logic cross-referenced vs RPCS3
+ * spursTasksetProcessRequest(SELECT_TASK): readyButNotRunning = ready & ~running, scanned
+ * round-robin starting after last_scheduled_task; task N occupies bitset bit (127-N).
+ */
+#include "spurs_taskset.h"
+#include <stdint.h>
+
+/* Select the next task to run: first task that is ready and not running, scanning
+ * round-robin from (last_scheduled_task + 1). Returns the taskId (0..127) or -1 if none
+ * is runnable. (The wkl_flag_wait_task exclusion is a refinement we add when needed.) */
+int spurs_pm_select_task(uint32_t taskset_ea, uint32_t last_scheduled_task)
+{
+    uint32_t ready_ea   = taskset_ea + CSTS_READY;
+    uint32_t running_ea = taskset_ea + CSTS_RUNNING;
+    for (uint32_t i = 1; i <= 128; i++) {
+        uint32_t t = (last_scheduled_task + i) & 127;     /* round-robin, wrap at 128 */
+        if (spurs_bitset_test(ready_ea, t) && !spurs_bitset_test(running_ea, t))
+            return (int)t;
+    }
+    return -1;
+}
+
+/* Mark a task as the running one: clear ready, set running, record last_scheduled_task.
+ * (RPCS3 moves the task ready->running on dispatch.) last_scheduled_task is the byte at
+ * CSTS_LAST_SCHEDULED (0x73) = the low byte of the big-endian word at 0x70. */
+void spurs_pm_mark_running(uint32_t taskset_ea, uint32_t taskId)
+{
+    spurs_bitset_clear(taskset_ea + CSTS_READY, taskId);
+    spurs_bitset_set(taskset_ea + CSTS_RUNNING, taskId);
+    uint32_t w = vm_read32(taskset_ea + 0x70);
+    w = (w & 0xFFFFFF00u) | (taskId & 0xFFu);
+    vm_write32(taskset_ea + 0x70, w);
+}
+
+/* Build the SpursTasksetContext at LS 0x2700 for the selected task, and DMA its TaskInfo
+ * into LS 0x2780. ls = the SPU local store (256 KB). Returns the task ELF EA (low 3 bits
+ * are flags, masked off for loading). */
+uint64_t spurs_pm_build_context(uint8_t* ls, uint32_t taskset_ea, uint32_t taskId,
+                                uint32_t spuNum, uint32_t dmaTagId)
+{
+    /* SpursTasksetContext header fields (LS-local, written big-endian like guest mem). */
+    /* taskset ptr @0x27B8 (be u64), spuNum @0x27CC, dmaTagId @0x27D0, taskId @0x27D4,
+     * tasksetMgmtAddr @0x2FB8, x2FC0 cleared. We write directly into ls[] big-endian. */
+    #define LS_BE32(off, v) do { uint32_t _v=(v); ls[(off)+0]=(uint8_t)(_v>>24); ls[(off)+1]=(uint8_t)(_v>>16); \
+                                 ls[(off)+2]=(uint8_t)(_v>>8); ls[(off)+3]=(uint8_t)_v; } while(0)
+    #define LS_BE64(off, v) do { uint64_t _w=(v); LS_BE32((off), (uint32_t)(_w>>32)); LS_BE32((off)+4,(uint32_t)_w); } while(0)
+
+    /* Copy the CellSpursTaskset HEADER (first 0x80 bytes: the 6 bitsets, spurs@0x60,
+     * args@0x68, wid@0x74, x78@0x78) from the main-memory taskset into LS 0x2700. RPCS3
+     * spursTasksetStartTask reads taskset->spurs / taskset->args from LS 0x2700+0x60/0x68
+     * to build the leaf's r4 = {args (d0), spurs EA (d1)}; without this the leaf gets a
+     * garbage SPURS base and DMAs from a bad address. The STC fields written below sit at
+     * offsets >= 0x80 (TaskInfo array region in the union view) so they don't overlap. */
+    for (int o = 0; o < 0x80; o += 4)
+        LS_BE32(STC_BASE + o, vm_read32(taskset_ea + o));
+
+    LS_BE64(STC_TASKSET_PTR,  (uint64_t)taskset_ea);
+    LS_BE32(STC_SPU_NUM,      spuNum);
+    LS_BE32(STC_DMA_TAG_ID,   dmaTagId);
+    LS_BE32(STC_TASK_ID,      taskId);
+    LS_BE32(STC_TASKSET_MGMT_ADDR, STC_BASE);
+    LS_BE64(STC_X2FC0, 0);
+    /* Task-syscall path: a SPURS task reads syscallAddr from its context and branches to
+     * it (e.g. to EXIT). The real kernel sets it to the PM's in-LS syscall entry (0xA70);
+     * we don't have the PM resident, so we set the same address and INTERCEPT a branch to
+     * it in spu_indirect_branch (spu_channels.c) to HLE the syscall. Without this the task
+     * branches to 0 -> null call -> halt (image=7's NULL_POINTER cascade). kernelMgmtAddr
+     * -> the SPURS kernel context (LS 0x100). */
+    LS_BE32(STC_KERNEL_MGMT_ADDR, 0x100);
+    LS_BE32(STC_SYSCALL_ADDR,     CELL_SPURS_TASKSET_PM_SYSCALL_ADDR);
+
+    /* DMA the selected task's TaskInfo (48 bytes) into LS 0x2780 (the kernel temp area).
+     * Read each word BE and re-store BE -> the raw bytes are preserved verbatim. */
+    uint32_t ti = spurs_taskset_taskinfo_ea(taskset_ea, taskId);
+    for (int o = 0; o < TI_SIZE; o += 4)
+        LS_BE32(STC_TEMP_TASKINFO + o, vm_read32(ti + o));
+
+    return vm_read64(ti + TI_ELF);       /* caller masks elf & ~7 to load */
+    #undef LS_BE32
+    #undef LS_BE64
+}

--- a/libs/spurs/spurs_taskset.c
+++ b/libs/spurs/spurs_taskset.c
@@ -1,0 +1,53 @@
+/* spurs_taskset.c -- build the real CellSpursTaskset shared-memory layout (Option B,
+ * phase B2). These functions write the BE structures that the reimplemented PM (B3)
+ * and the real lifted leaf task read. ALL writes go through the byte-swapping
+ * vm_write32/vm_write64 accessors (see the BIG-ENDIAN WARNING in spurs_taskset.h);
+ * no native struct writes. Layout cross-referenced vs RPCS3 cellSpurs.h.
+ *
+ * Pure layout builders -- unit-tested in tests/test_spurs_taskset_main.c. cellSpurs.c
+ * (the PPU create path) and the PM dispatcher call these.
+ */
+#include "spurs_taskset.h"
+#include <stdint.h>
+
+/* Initialize a fresh taskset: clear all task bitsets and write the header fields.
+ * spurs_ea = the CellSpurs object EA; args = taskset args doubleword; wid = workload
+ * id; size = taskset size; evf1/evf2 = attached event-flag ids (0 if none). */
+void spurs_taskset_init(uint32_t taskset_ea, uint32_t spurs_ea, uint64_t args,
+                        uint32_t wid, uint32_t size, uint32_t evf1, uint32_t evf2)
+{
+    /* clear running/ready/pending_ready/enabled/signalled/waiting (each 16 bytes) */
+    for (uint32_t off = CSTS_RUNNING; off <= CSTS_WAITING; off += 0x10) {
+        vm_write64(taskset_ea + off + 0, 0);
+        vm_write64(taskset_ea + off + 8, 0);
+    }
+    vm_write64(taskset_ea + CSTS_SPURS, (uint64_t)spurs_ea); /* CellSpurs* (be u64) */
+    vm_write64(taskset_ea + CSTS_ARGS,  args);
+    vm_write32(taskset_ea + CSTS_WID,   wid);
+    vm_write64(taskset_ea + CSTS_X78,   0);                  /* on-exit handler EA */
+    vm_write32(taskset_ea + CSTS_SIZE_FIELD,     size);
+    vm_write32(taskset_ea + CSTS_EVENT_FLAG_ID1, evf1);
+    vm_write32(taskset_ea + CSTS_EVENT_FLAG_ID2, evf2);
+}
+
+/* Register a task: write task_info[taskId] (args/elf/context/ls_pattern) and mark the
+ * task enabled + ready so the PM's SELECT_TASK picks it. arg/ls_pattern may be NULL. */
+void spurs_taskset_add_task(uint32_t taskset_ea, uint32_t taskId, uint64_t elf_ea,
+                            uint64_t context, const uint32_t arg[4],
+                            const uint32_t ls_pattern[4])
+{
+    uint32_t ti = spurs_taskset_taskinfo_ea(taskset_ea, taskId);
+    for (int i = 0; i < 4; i++) vm_write32(ti + TI_ARGS + i * 4, arg ? arg[i] : 0);
+    vm_write64(ti + TI_ELF, elf_ea);
+    vm_write64(ti + TI_CONTEXT, context);
+    for (int i = 0; i < 4; i++)
+        vm_write32(ti + TI_LS_PATTERN + i * 4, ls_pattern ? ls_pattern[i] : 0);
+    spurs_bitset_set(taskset_ea + CSTS_ENABLED, taskId);
+    spurs_bitset_set(taskset_ea + CSTS_READY,   taskId);
+}
+
+/* Set the taskset's on-task-exit handler EA (CellSpursTaskset.x78). */
+void spurs_taskset_set_exit_handler(uint32_t taskset_ea, uint64_t handler_ea)
+{
+    vm_write64(taskset_ea + CSTS_X78, handler_ea);
+}

--- a/libs/spurs/spurs_taskset.h
+++ b/libs/spurs/spurs_taskset.h
@@ -1,0 +1,147 @@
+/* spurs_taskset.h -- SPURS taskset Policy-Module shared-memory layout (Option B).
+ *
+ * ============================ BIG-ENDIAN WARNING ============================
+ * These structures live in GUEST memory and are read by REAL lifted SPU code (the
+ * leaf task) and by our reimplemented PM. The guest (PPC/SPU) is BIG-ENDIAN; the
+ * host (x86) is little-endian. Therefore EVERY multi-byte field MUST be accessed
+ * byte-swapped. Do NOT define native C structs over guest memory and write fields
+ * directly (that stores little-endian -> the SPU reads garbage) -- that mismatch is
+ * exactly why our prior HLE (which memset/native-wrote simplified structs) left the
+ * SPU reading zeros/garbage (docs/12 root cause).
+ *
+ * RULE: access taskset/context fields ONLY via the BE accessors vm_read32/vm_read64/
+ * vm_write32/vm_write64 (ppu_loader.cpp -- they byte-swap), at guest_EA + the offset
+ * constants below. The offsets are the source of truth (reimplemented clean from the
+ * public SDK / RPCS3 cellSpurs.h contracts; no GPL code copied).
+ * ===========================================================================
+ */
+#ifndef SPURS_TASKSET_H
+#define SPURS_TASKSET_H
+
+#include <stdint.h>
+
+/* BE guest-memory accessors (defined in runtime/ppu/ppu_loader.cpp). */
+uint32_t vm_read32(uint64_t ea);
+uint64_t vm_read64(uint64_t ea);
+void     vm_write32(uint64_t ea, uint32_t v);
+void     vm_write64(uint64_t ea, uint64_t v);
+
+/* ---- CellSpursTaskset (main memory, 128-byte aligned) --------------------
+ * The PM reads the task bitsets to pick a ready task and the TaskInfo array for
+ * its ELF/context/args. Max 128 tasks; each TaskInfo is 48 bytes. */
+enum {
+    CSTS_RUNNING        = 0x00,   /* atomic 128-bit bitset (4 BE u32) */
+    CSTS_READY          = 0x10,
+    CSTS_PENDING_READY  = 0x20,
+    CSTS_ENABLED        = 0x30,
+    CSTS_SIGNALLED      = 0x40,
+    CSTS_WAITING        = 0x50,
+    CSTS_SPURS          = 0x60,   /* be u64: CellSpurs* */
+    CSTS_ARGS           = 0x68,   /* be u64 */
+    CSTS_ENABLE_CLEAR_LS= 0x70,   /* u8  */
+    CSTS_WKL_FLAG_WAIT  = 0x72,   /* u8  */
+    CSTS_LAST_SCHEDULED = 0x73,   /* u8  */
+    CSTS_WID            = 0x74,   /* be u32: workload id */
+    CSTS_X78            = 0x78,   /* be u64: on-task-exit handler EA */
+    CSTS_TASKINFO       = 0x80,   /* TaskInfo[128] */
+    CSTS_EXC_HANDLER    = 0x1880, /* be u64 */
+    CSTS_EXC_HANDLER_ARG= 0x1888, /* be u64 */
+    CSTS_SIZE_FIELD     = 0x1890, /* be u32 */
+    CSTS_EVENT_FLAG_ID1 = 0x1898, /* be u32 */
+    CSTS_EVENT_FLAG_ID2 = 0x189C, /* be u32 */
+    CSTS_STRUCT_END     = 0x1900,
+};
+
+/* CellSpursTaskset::TaskInfo (48 bytes), at CSTS_TASKINFO + taskId*48 */
+enum {
+    TI_SIZE       = 48,
+    TI_ARGS       = 0x00,   /* CellSpursTaskArgument (16 bytes) */
+    TI_ELF        = 0x10,   /* be u64: task ELF EA (low 3 bits = flags) */
+    TI_CONTEXT    = 0x18,   /* be u64: context_save_storage | alloc_ls_blocks */
+    TI_LS_PATTERN = 0x20,   /* CellSpursTaskLsPattern (16 bytes) */
+};
+
+static inline uint32_t spurs_taskset_taskinfo_ea(uint32_t taskset_ea, uint32_t taskId)
+{ return taskset_ea + CSTS_TASKINFO + taskId * TI_SIZE; }
+
+/* set/clear/test a task bit in a 128-bit bitset (bit 0 = MSB of word 0, per RPCS3
+ * atomic_tasks_bitset::get_bit). bitset_ea = taskset_ea + CSTS_READY etc. */
+static inline void spurs_bitset_set(uint32_t bitset_ea, uint32_t taskId)
+{
+    uint32_t word_ea = bitset_ea + (taskId / 32) * 4;
+    uint32_t mask = (1u << 31) >> (taskId % 32);
+    vm_write32(word_ea, vm_read32(word_ea) | mask);
+}
+static inline void spurs_bitset_clear(uint32_t bitset_ea, uint32_t taskId)
+{
+    uint32_t word_ea = bitset_ea + (taskId / 32) * 4;
+    uint32_t mask = (1u << 31) >> (taskId % 32);
+    vm_write32(word_ea, vm_read32(word_ea) & ~mask);
+}
+static inline int spurs_bitset_test(uint32_t bitset_ea, uint32_t taskId)
+{
+    uint32_t word_ea = bitset_ea + (taskId / 32) * 4;
+    uint32_t mask = (1u << 31) >> (taskId % 32);
+    return (vm_read32(word_ea) & mask) != 0;
+}
+
+/* ---- SpursTasksetContext (SPU local store @ 0x2700, size 0x900) ----------
+ * Built by the PM in LS before/while running the leaf task. */
+enum {
+    STC_BASE              = 0x2700,
+    STC_TEMP_TASKSET      = 0x2700, /* 0x80 scratch */
+    STC_TEMP_TASKINFO     = 0x2780, /* 0x30 (DMA'd TaskInfo of the selected task) */
+    STC_TASKSET_PTR       = 0x27B8, /* be u64: CellSpursTaskset EA */
+    STC_KERNEL_MGMT_ADDR  = 0x27C0, /* be u32 */
+    STC_SYSCALL_ADDR      = 0x27C4, /* be u32 */
+    STC_SPU_NUM           = 0x27CC, /* be u32 */
+    STC_DMA_TAG_ID        = 0x27D0, /* be u32 */
+    STC_TASK_ID           = 0x27D4, /* be u32 */
+    STC_MODULE_ID         = 0x2840, /* 16 bytes */
+    STC_SAVED_LR          = 0x2C80, /* v128: entry point / saved LR */
+    STC_SAVED_SP          = 0x2C90, /* v128 */
+    STC_SAVED_R80_R127    = 0x2CA0, /* v128[48] */
+    STC_SAVED_FPSCR       = 0x2FA0, /* v128 */
+    STC_SAVED_EVENT_MASK  = 0x2FB4, /* be u32 */
+    STC_TASKSET_MGMT_ADDR = 0x2FB8, /* be u32 */
+    STC_X2FC0             = 0x2FC0, /* be u64 (exit-handler addr alt) */
+    STC_X2FC8             = 0x2FC8, /* be u64 (exit-handler args) */
+    STC_TASK_EXIT_CODE    = 0x2FD0, /* be u32 */
+    STC_X2FD4             = 0x2FD4, /* be u32 */
+    STC_STRUCT_END        = 0x3000,
+};
+
+/* Fixed LS addresses of the taskset Policy Module entry points (RPCS3 cellSpurs.h).
+ * A SPURS task calls its taskset PM's syscall entry via the SpursTasksetContext
+ * syscallAddr field (STC_SYSCALL_ADDR), which the kernel sets to this address.
+ * Our HLE intercepts a branch to CELL_SPURS_TASKSET_PM_SYSCALL_ADDR (spu_channels.c)
+ * to process the task syscall, since we don't have the real PM code resident in LS. */
+enum {
+    CELL_SPURS_TASKSET_PM_ENTRY_ADDR   = 0xA00,
+    CELL_SPURS_TASKSET_PM_SYSCALL_ADDR = 0xA70,
+};
+
+/* CELL_SPURS_TASK_SYSCALL_* (leaf-task `stop <code>` operand low nibble). */
+enum {
+    CELL_SPURS_TASK_SYSCALL_EXIT          = 0,
+    CELL_SPURS_TASK_SYSCALL_YIELD         = 1,
+    CELL_SPURS_TASK_SYSCALL_WAIT_SIGNAL   = 2,
+    CELL_SPURS_TASK_SYSCALL_POLL          = 3,
+    CELL_SPURS_TASK_SYSCALL_RECV_WKL_FLAG = 4,
+};
+
+/* ---- create-path layout builders (spurs_taskset.c, phase B2) ------------- */
+void spurs_taskset_init(uint32_t taskset_ea, uint32_t spurs_ea, uint64_t args,
+                        uint32_t wid, uint32_t size, uint32_t evf1, uint32_t evf2);
+void spurs_taskset_add_task(uint32_t taskset_ea, uint32_t taskId, uint64_t elf_ea,
+                            uint64_t context, const uint32_t arg[4],
+                            const uint32_t ls_pattern[4]);
+void spurs_taskset_set_exit_handler(uint32_t taskset_ea, uint64_t handler_ea);
+
+/* ---- PM logic (spurs_pm.c, phase B3) ------------------------------------- */
+int      spurs_pm_select_task(uint32_t taskset_ea, uint32_t last_scheduled_task);
+void     spurs_pm_mark_running(uint32_t taskset_ea, uint32_t taskId);
+uint64_t spurs_pm_build_context(uint8_t* ls, uint32_t taskset_ea, uint32_t taskId,
+                                uint32_t spuNum, uint32_t dmaTagId);
+
+#endif /* SPURS_TASKSET_H */

--- a/libs/system/cellGame.c
+++ b/libs/system/cellGame.c
@@ -102,6 +102,90 @@ void cellGame_set_content_path(const char* path)
  * API implementations
  * -----------------------------------------------------------------------*/
 
+/* ---------------------------------------------------------------------------
+ * PARAM.SFO -> title id (2026-06-21): the ROBUST fix for title-id paths.
+ *
+ * Root cause of the /dev_hdd0/game/BLES00000 bug: s_title_id was a hardcoded
+ * placeholder and cellGame_set_title_id() was never called, so EVERY title-id
+ * path (cellGameContentPermit/BootCheck/DataCheck/web + cellDiscGameGetBootDiscInfo)
+ * used the wrong id. Fix: read the real id from the game's PARAM.SFO once at boot
+ * (main.cpp -> cellGame_init_from_paramsfo) so it's correct for ANY title.
+ *
+ * SFO format is LITTLE-ENDIAN: header @0 (magic "\0PSF", key_table@0x08,
+ * data_table@0x0C, entries@0x10), then entries[0x10 each]: key_off(u16)@0,
+ * fmt(u16)@2, data_len(u32)@4, data_max(u32)@8, data_off(u32)@0xC.
+ * -----------------------------------------------------------------------*/
+static int sfo_read_string(const char* sfo_path, const char* key,
+                           char* out, int out_size)
+{
+    FILE* fp = fopen(sfo_path, "rb");
+    if (!fp) return -1;
+    fseek(fp, 0, SEEK_END); long sz = ftell(fp); fseek(fp, 0, SEEK_SET);
+    if (sz < 0x14 || sz > (1 << 20)) { fclose(fp); return -1; }
+    unsigned char* d = (unsigned char*)malloc((size_t)sz);
+    if (!d) { fclose(fp); return -1; }
+    int ok = (fread(d, 1, (size_t)sz, fp) == (size_t)sz);
+    fclose(fp);
+    if (!ok) { free(d); return -1; }
+
+    int ret = -1;
+    if (d[0]==0x00 && d[1]==0x50 && d[2]==0x53 && d[3]==0x46) {  /* "\0PSF" */
+        #define SFO_RD32(o) ((u32)d[o] | ((u32)d[(o)+1]<<8) | ((u32)d[(o)+2]<<16) | ((u32)d[(o)+3]<<24))
+        #define SFO_RD16(o) ((u16)d[o] | ((u16)d[(o)+1]<<8))
+        u32 key_tab  = SFO_RD32(0x08);
+        u32 data_tab = SFO_RD32(0x0C);
+        u32 n        = SFO_RD32(0x10);
+        for (u32 i = 0; i < n; i++) {
+            u32 e = 0x14 + i * 0x10;
+            if (e + 0x10 > (u32)sz) break;
+            u32 key_off  = SFO_RD16(e + 0x00);
+            u32 data_len = SFO_RD32(e + 0x04);
+            u32 data_off = SFO_RD32(e + 0x0C);
+            if (key_tab + key_off >= (u32)sz) continue;
+            if (strcmp((const char*)(d + key_tab + key_off), key) != 0) continue;
+            u32 src = data_tab + data_off;
+            if (src >= (u32)sz) break;
+            int copy = (int)data_len;
+            if (copy > (int)((u32)sz - src)) copy = (int)((u32)sz - src);
+            if (copy >= out_size) copy = out_size - 1;
+            if (copy < 0) copy = 0;
+            memcpy(out, d + src, (size_t)copy);
+            out[copy] = '\0';
+            ret = 0;
+            break;
+        }
+        #undef SFO_RD32
+        #undef SFO_RD16
+    }
+    free(d);
+    return ret;
+}
+
+/* Read TITLE_ID / TITLE / APP_VER from the game's PARAM.SFO at boot. Call once
+ * from main.cpp before the guest runs. Falls back to the defaults if the SFO
+ * can't be read (keeps the game working without it). */
+void cellGame_init_from_paramsfo(const char* sfo_path)
+{
+    char tmp[256];
+    if (sfo_read_string(sfo_path, "TITLE_ID", tmp, sizeof(tmp)) == 0 && tmp[0]) {
+        strncpy(s_title_id, tmp, sizeof(s_title_id) - 1);
+        s_title_id[sizeof(s_title_id) - 1] = '\0';
+        printf("[cellGame] title id from PARAM.SFO ('%s'): '%s'\n", sfo_path, s_title_id);
+    } else {
+        printf("[cellGame] PARAM.SFO not read ('%s'); keeping title id '%s'\n",
+               sfo_path, s_title_id);
+    }
+    if (sfo_read_string(sfo_path, "TITLE", tmp, sizeof(tmp)) == 0 && tmp[0]) {
+        strncpy(s_title, tmp, sizeof(s_title) - 1); s_title[sizeof(s_title) - 1] = '\0';
+    }
+    if (sfo_read_string(sfo_path, "APP_VER", tmp, sizeof(tmp)) == 0 && tmp[0]) {
+        strncpy(s_app_ver, tmp, sizeof(s_app_ver) - 1); s_app_ver[sizeof(s_app_ver) - 1] = '\0';
+    }
+}
+
+/* Central title-id accessor so other modules (cellSysutil etc.) don't hardcode it. */
+const char* cellGame_get_title_id(void) { return s_title_id; }
+
 s32 cellGameBootCheck(u32* type, u32* attributes, CellGameContentSize* size,
                        char* dirName)
 {

--- a/libs/system/cellGame.h
+++ b/libs/system/cellGame.h
@@ -87,6 +87,13 @@ typedef struct CellGameContentSize {
 /* Set the game's title ID (e.g., "BLUS30443") */
 void cellGame_set_title_id(const char* title_id);
 
+/* Read TITLE_ID/TITLE/APP_VER from the game's PARAM.SFO at boot (robust title id
+ * for all path building). Falls back to defaults if the SFO can't be read. */
+void cellGame_init_from_paramsfo(const char* sfo_path);
+
+/* Central title-id accessor (so other modules don't hardcode placeholders). */
+const char* cellGame_get_title_id(void);
+
 /* Set the game's title string */
 void cellGame_set_title(const char* title);
 

--- a/libs/system/cellSysutil.c
+++ b/libs/system/cellSysutil.c
@@ -152,55 +152,40 @@ s32 cellSysutilCheckCallback(void)
 
 s32 cellSysutilGetSystemParamInt(s32 id, s32* value)
 {
-    if (!value)
+    /* `value` arrives as a RAW GUEST pointer via the generic HLE adapter (it is
+     * not host-translated). Dereferencing it directly faults; write through the
+     * guest VM (vm_write32 handles vm_base offset + big-endian). */
+    extern void vm_write32(unsigned long long addr, unsigned int val);
+    unsigned int gptr = (unsigned int)(unsigned long long)(uintptr_t)value;
+    if (!gptr)
         return CELL_SYSUTIL_ERROR_VALUE;
 
+    s32 v = 0;
     switch (id) {
     case CELL_SYSUTIL_SYSTEMPARAM_ID_LANG:
-        *value = CELL_SYSUTIL_LANG_ENGLISH_US;
+        v = CELL_SYSUTIL_LANG_ENGLISH_US;
         break;
     case CELL_SYSUTIL_SYSTEMPARAM_ID_ENTER_BUTTON_ASSIGN:
-        *value = CELL_SYSUTIL_ENTER_BUTTON_ASSIGN_CROSS;
+        v = CELL_SYSUTIL_ENTER_BUTTON_ASSIGN_CROSS;
         break;
-    case CELL_SYSUTIL_SYSTEMPARAM_ID_DATE_FORMAT:
-        *value = 0; /* YYYYMMDD */
-        break;
-    case CELL_SYSUTIL_SYSTEMPARAM_ID_TIME_FORMAT:
-        *value = 0; /* 24-hour */
-        break;
-    case CELL_SYSUTIL_SYSTEMPARAM_ID_TIMEZONE:
-        *value = 0; /* UTC */
-        break;
-    case CELL_SYSUTIL_SYSTEMPARAM_ID_SUMMERTIME:
-        *value = 0; /* No DST */
-        break;
-    case CELL_SYSUTIL_SYSTEMPARAM_ID_GAME_PARENTAL_LEVEL:
-        *value = 0; /* No restriction */
-        break;
-    case CELL_SYSUTIL_SYSTEMPARAM_ID_GAME_PARENTAL_LEVEL0_RESTRICT:
-        *value = 0;
-        break;
-    case CELL_SYSUTIL_SYSTEMPARAM_ID_CURRENT_USER_HAS_NP_ACCOUNT:
-        *value = 1; /* Has NP account */
-        break;
-    case CELL_SYSUTIL_SYSTEMPARAM_ID_CAMERA_PLFREQ:
-        *value = 0; /* 60Hz */
-        break;
-    case CELL_SYSUTIL_SYSTEMPARAM_ID_PAD_RUMBLE:
-        *value = 1; /* Rumble on */
-        break;
-    case CELL_SYSUTIL_SYSTEMPARAM_ID_KEYBOARD_TYPE:
-        *value = 0; /* US/101 */
-        break;
-    case CELL_SYSUTIL_SYSTEMPARAM_ID_PAD_AUTOOFF:
-        *value = 0; /* Disabled */
-        break;
+    case CELL_SYSUTIL_SYSTEMPARAM_ID_DATE_FORMAT:    v = 0; break; /* YYYYMMDD */
+    case CELL_SYSUTIL_SYSTEMPARAM_ID_TIME_FORMAT:    v = 0; break; /* 24-hour */
+    case CELL_SYSUTIL_SYSTEMPARAM_ID_TIMEZONE:       v = 0; break; /* UTC */
+    case CELL_SYSUTIL_SYSTEMPARAM_ID_SUMMERTIME:     v = 0; break; /* No DST */
+    case CELL_SYSUTIL_SYSTEMPARAM_ID_GAME_PARENTAL_LEVEL:           v = 0; break;
+    case CELL_SYSUTIL_SYSTEMPARAM_ID_GAME_PARENTAL_LEVEL0_RESTRICT: v = 0; break;
+    case CELL_SYSUTIL_SYSTEMPARAM_ID_CURRENT_USER_HAS_NP_ACCOUNT:   v = 1; break;
+    case CELL_SYSUTIL_SYSTEMPARAM_ID_CAMERA_PLFREQ:  v = 0; break; /* 60Hz */
+    case CELL_SYSUTIL_SYSTEMPARAM_ID_PAD_RUMBLE:     v = 1; break; /* Rumble on */
+    case CELL_SYSUTIL_SYSTEMPARAM_ID_KEYBOARD_TYPE:  v = 0; break; /* US/101 */
+    case CELL_SYSUTIL_SYSTEMPARAM_ID_PAD_AUTOOFF:    v = 0; break; /* Disabled */
     default:
         printf("[cellSysutil] GetSystemParamInt: unknown id 0x%04X\n", id);
-        *value = 0;
+        v = 0;
         break;
     }
 
+    vm_write32(gptr, (unsigned int)v);
     return CELL_OK;
 }
 

--- a/libs/system/cellSysutil.c
+++ b/libs/system/cellSysutil.c
@@ -304,7 +304,10 @@ s32 cellDiscGameGetBootDiscInfo(u32* type, char* titleId, u32 titleIdSize)
         *type = CELL_DISCGAME_TYPE_HDD; /* pretend HDD game */
 
     if (titleId && titleIdSize > 0) {
-        strncpy(titleId, "GAME00000", titleIdSize - 1);
+        /* Use the real title id (from PARAM.SFO at boot) instead of a placeholder. */
+        extern const char* cellGame_get_title_id(void);
+        const char* tid = cellGame_get_title_id();
+        strncpy(titleId, tid && tid[0] ? tid : "GAME00000", titleIdSize - 1);
         titleId[titleIdSize - 1] = '\0';
     }
 

--- a/libs/system/sysPrxForUser.c
+++ b/libs/system/sysPrxForUser.c
@@ -156,6 +156,21 @@ static u32 s_next_heap_id = 1;
 void sys_process_exit(s32 exitcode)
 {
     printf("[sysPrxForUser] sys_process_exit(code=%d)\n", exitcode);
+    /* YDKJ_NOEXIT (diagnostic): the title self-exits after ~2 frames on a
+     * teardown assert triggered by incomplete SPU/SPURS state (a timing race).
+     * Ignoring the exit on the calling thread lets the render loop keep running
+     * so we can see whether sustained execution produces on-screen content. */
+    if (getenv("YDKJ_NOEXIT")) {
+        printf("[sysPrxForUser] sys_process_exit IGNORED (YDKJ_NOEXIT) -- parking thread\n");
+        fflush(stdout);
+        for (;;) {
+#ifdef _WIN32
+            Sleep(1000);
+#else
+            struct timespec ts = {1,0}; nanosleep(&ts,0);
+#endif
+        }
+    }
     exit(exitcode);
 }
 
@@ -349,6 +364,8 @@ s32 sys_lwmutex_create(sys_lwmutex_t_hle* lwmutex, const sys_lwmutex_attribute_t
 {
     printf("[sysPrxForUser] sys_lwmutex_create(name='%.8s', guest=0x%08X)\n",
            attr ? attr->name : "???", YZ_GUEST_ADDR(lwmutex));
+    { extern char* getenv(const char*); static int _lt=-1; if(_lt<0)_lt=getenv("FLOW_LWMTRACE")?1:0;
+      if(_lt){ extern unsigned int ppu_active_lr(void); printf("[LWMTRACE] create guest=0x%08X caller_lr=0x%08X\n", YZ_GUEST_ADDR(lwmutex), ppu_active_lr()); } }
 
     if (!lwmutex)
         return CELL_EFAULT;
@@ -405,6 +422,8 @@ s32 sys_lwmutex_lock(sys_lwmutex_t_hle* lwmutex, u64 timeout)
                YZ_GUEST_ADDR(lwmutex), lwmutex->sleep_queue,
                slot >= MAX_LWMUTEX ? "bad slot" : "slot not in use");
 #endif
+        { extern char* getenv(const char*); static int _lk=-1; if(_lk<0)_lk=getenv("FLOW_LOCKOK")?1:0;
+          if(_lk) return CELL_OK; }   /* diag: treat uninit lwmutex as acquired, see if boot proceeds */
         return CELL_ESRCH;
     }
 

--- a/libs/video/cellGcmSys.c
+++ b/libs/video/cellGcmSys.c
@@ -15,6 +15,19 @@
 /* Guest EA of the GCM context (begin/end/current/callback) the title writes its
  * command stream into; recorded by cellGcmSetupContext, drained by the RSX. */
 static u32 s_gcm_context_ea = 0;
+
+/* Synthetic guest code EA for the FIFO command-buffer-full callback. The title's
+ * inline gcmReserve calls context->callback(context, count) when `current` nears
+ * `end`; cellGcmSetupContext points the context's callback OPD at this EA, and
+ * ppu_sysprx.cpp registers it (ppu_register_function) -> hle_gcm_callback ->
+ * cellGcm_fifo_recycle(). It is only ever a bctr target, never read as memory,
+ * so overlapping the RSX label window is harmless. MUST match
+ * GCM_FIFO_CALLBACK_SENTINEL_EA in ppu_sysprx.cpp.  (via sagemono's fork) */
+#define GCM_FIFO_CALLBACK_SENTINEL_EA 0x03002F00u
+/* EA the ticker's RSX drain (cellGcm_rsx_process_fifo) has consumed up to.
+ * Exposed so cellGcm_fifo_recycle can wait for the RSX to catch up before
+ * recycling the ring, else the frame's just-written commands would be lost. */
+volatile u32 g_gcm_fifo_drained_ea = 0;
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -354,7 +367,21 @@ u32 cellGcmSetupContext(u32 ctx_out_addr, u32 cmdSize, u32 ioSize, u32 ioAddress
         gwrite32(cdata + 0x0, cmdbuf);              /* begin   */
         gwrite32(cdata + 0x4, cmdbuf + cmdSize);    /* end     */
         gwrite32(cdata + 0x8, cmdbuf);              /* current */
-        gwrite32(cdata + 0xC, 0);                   /* callback OPD (bridge fills) */
+        /* Command-buffer-full callback: a guest OPD {func, toc} whose func EA is
+         * the sentinel routed to hle_gcm_callback -> cellGcm_fifo_recycle. Without
+         * a real callback the ring never recycles and the FIFO wedges (a null
+         * callback OPD deref'd guest page 0 -> the 0xC708C708 poison vcall) once
+         * `current` reaches `end`.  (via sagemono's fork) */
+        {
+            u32 opd = galloc ? galloc(8, 8) : 0;
+            if (opd) {
+                gwrite32(opd + 0x0, GCM_FIFO_CALLBACK_SENTINEL_EA);  /* func EA */
+                gwrite32(opd + 0x4, 0);                              /* toc (unused) */
+                gwrite32(cdata + 0xC, opd);                          /* callback OPD */
+            } else {
+                gwrite32(cdata + 0xC, 0);
+            }
+        }
         if (ctx_out_addr)
             gwrite32(ctx_out_addr, cdata);          /* *context = &ctxdata */
         s_gcm_context_ea = cdata;                   /* RSX drains commands from here */
@@ -492,6 +519,7 @@ void cellGcm_rsx_process_fifo(void)
      * (context+0x8) and advance it. Read it (vm_read32 byte-swaps BE->host). */
     u32 current = vm_read32(s_gcm_context_ea + 0x8);
     if (current < s_get) s_get = s_config.ioAddress;   /* wrapped */
+    g_gcm_fifo_drained_ea = s_get;                      /* publish drain progress */
     if (current <= s_get) return;                       /* nothing new */
 
     { static int _f=0; if (_f++ < 24) fprintf(stderr, "[GCM] fifo drain ctx=0x%08X get=0x%08X current=0x%08X words=%u\n", s_gcm_context_ea, s_get, current, (current - s_get)/4); }
@@ -506,6 +534,35 @@ void cellGcm_rsx_process_fifo(void)
 
     rsx_process_command_buffer(&s_state, cmds, words * 4);
     s_get += words * 4;
+    g_gcm_fifo_drained_ea = s_get;                      /* RSX has consumed up to here */
+}
+
+/* FIFO command-buffer-full callback body. The title's inline gcmReserve calls
+ * context->callback(context, count) (routed here via the synthetic OPD +
+ * hle_gcm_callback) when the ring's `current` nears `end`. Real libgcm flushes,
+ * waits for the RSX `get` to catch up, then recycles `current` to `begin`. We
+ * wait for the ticker's drain to reach `current` (bounded) then reset the ring.
+ * (via sagemono's fork) */
+void cellGcm_fifo_recycle(u32 ctx_ea)
+{
+    if (!ctx_ea) return;
+    u32 begin   = vm_read32(ctx_ea + 0x0);
+    u32 current = vm_read32(ctx_ea + 0x8);
+    if (current <= begin) return;                       /* nothing to recycle */
+
+    /* Wait for the RSX drain to catch up to `current` so no commands are lost.
+     * Bounded (~2s) so a stalled ticker degrades to dropped commands, not a
+     * permanent hang. */
+    int spins = 0;
+    while (g_gcm_fifo_drained_ea < current && spins < 2000) { Sleep(1); spins++; }
+    if (spins >= 2000) {
+        static int warned = 0;
+        if (warned++ < 4)
+            fprintf(stderr, "[cellGcmSys] fifo recycle: drain stalled (drained=0x%08X current=0x%08X)\n",
+                    g_gcm_fifo_drained_ea, current);
+    }
+
+    vm_write32(ctx_ea + 0x8, begin);                    /* recycle ring to base */
 }
 
 /* NID: 0xDC09357E */

--- a/libs/video/cellGcmSys.c
+++ b/libs/video/cellGcmSys.c
@@ -81,6 +81,7 @@ static CellGcmConfig s_config;
 
 /* Command buffer control */
 static CellGcmControl s_control;
+static u32 s_control_ea = 0;   /* guest EA of the control register (see getter) */
 
 /* Offset table storage */
 static u16 s_io_address_table[65536];
@@ -123,9 +124,21 @@ extern unsigned vm_read32(unsigned long long);
 extern unsigned long long ppu_guest_call_ct(u32 code, u32 toc, u64 a0, u64 a1, u64 a2, u64 a3);
 static u32 s_flip_handler_code=0,   s_flip_handler_toc=0;
 static u32 s_vblank_handler_code=0, s_vblank_handler_toc=0;
+extern void ppu_register_opd_fixup(u32 opd, u32 code, u32 toc);
 static void capture_handler_ct(u32 opd, u32* code, u32* toc) {
-    if (opd) { *code = vm_read32(opd); *toc = vm_read32(opd + 4); }
+    if (opd) { *code = vm_read32(opd); *toc = vm_read32(opd + 4);
+               /* record so the game's direct calls through this OPD (whose code
+                * word later gets clobbered) still resolve to the real handler. */
+               ppu_register_opd_fixup(opd, *code, *toc); }
     else     { *code = 0; *toc = 0; }
+}
+/* Invoke the title's flip handler. The handler OPD (0x530D70) gets its code word
+ * clobbered in guest memory (read back as the TOC base 0x544370 -> "not
+ * registered"), so calling via the live OPD fails. Use the {code,toc} captured at
+ * registration instead; fall back to the OPD only if nothing was captured. */
+static void invoke_flip_handler(u32 head) {
+    if (s_flip_handler_code)
+        ppu_guest_call_ct(s_flip_handler_code, s_flip_handler_toc, head, 0, 0, 0);
 }
 /* Legacy host-typed slots kept around for any caller still treating
  * these as host pointers. New code should use the _opd slots. */
@@ -345,7 +358,16 @@ u32 cellGcmSetupContext(u32 ctx_out_addr, u32 cmdSize, u32 ioSize, u32 ioAddress
         if (ctx_out_addr)
             gwrite32(ctx_out_addr, cdata);          /* *context = &ctxdata */
         s_gcm_context_ea = cdata;                   /* RSX drains commands from here */
-        fprintf(stderr, "[GCM] SetupContext ctx_ea=0x%08X cmdbuf=0x%08X cmdSize=0x%X ioAddr=0x%08X\n", cdata, cmdbuf, cmdSize, ioAddress);
+        /* Control register in GUEST memory: cellGcmGetControlRegister must hand the
+         * title a guest EA, not &s_control (a host pointer it would truncate to a
+         * garbage guest addr like 0xC708C708). {put,get,ref}. */
+        s_control_ea = galloc ? galloc(16, 16) : 0;
+        if (s_control_ea) {
+            gwrite32(s_control_ea + 0x0, 0);            /* put */
+            gwrite32(s_control_ea + 0x4, 0);            /* get */
+            gwrite32(s_control_ea + 0x8, 0);            /* ref */
+        }
+        fprintf(stderr, "[GCM] SetupContext ctx_ea=0x%08X cmdbuf=0x%08X cmdSize=0x%X ioAddr=0x%08X ctrl_ea=0x%08X\n", cdata, cmdbuf, cmdSize, ioAddress, s_control_ea);
     }
     return cdata;
 }
@@ -375,6 +397,10 @@ s32 cellGcmGetConfiguration(CellGcmConfig* config)
 /* NID: 0x8572A8E0 */
 CellGcmControl* cellGcmGetControlRegister(void)
 {
+    /* Return the GUEST EA (the HLE adapter passes the return straight to r3, which
+     * the title uses as a guest pointer). Returning &s_control (host) would give
+     * the title a 64-bit host pointer truncated to a garbage guest addr. */
+    if (s_control_ea) return (CellGcmControl*)(size_t)s_control_ea;
     return &s_control;
 }
 
@@ -517,9 +543,8 @@ s32 cellGcmSetFlipCommand(u32 bufferId)
     s_flip_status = CELL_GCM_FLIP_STATUS_DONE;
     s_last_flip_time = get_timestamp_ns();
 
-    /* Invoke via OPD resolution, not a raw call into guest code. */
-    if (s_flip_handler_opd && g_ps3_guest_caller)
-        g_ps3_guest_caller(s_flip_handler_opd, 0, 0, 0, 0);  /* head 0 = primary display */
+    /* Use the captured {code,toc} (the live OPD's code word is clobbered). */
+    invoke_flip_handler(0);  /* head 0 = primary display */
 
     return CELL_OK;
 }
@@ -554,11 +579,9 @@ s32 cellGcmSetPrepareFlip(void* ctx, u32 bufferId)
     s_flip_status = CELL_GCM_FLIP_STATUS_DONE;
     s_last_flip_time = get_timestamp_ns();
 
-    /* Invoke the guest flip handler via OPD resolution -- s_flip_handler holds
-     * the raw guest OPD (e.g. 0x530D70); calling it as a host function pointer
-     * jumps into guest code and crashes. */
-    if (s_flip_handler_opd && g_ps3_guest_caller)
-        g_ps3_guest_caller(s_flip_handler_opd, 0, 0, 0, 0);
+    /* Use the captured {code,toc} (the live OPD's code word is clobbered to the
+     * TOC base, so resolving the OPD yields an unregistered code). */
+    invoke_flip_handler(0);
 
     return CELL_OK;
 }
@@ -586,6 +609,12 @@ void cellGcmSetFlipHandler(CellGcmFlipHandler handler)
     s_flip_handler_opd = (u32)(size_t)handler;
     s_flip_handler = handler;
     capture_handler_ct(s_flip_handler_opd, &s_flip_handler_code, &s_flip_handler_toc);
+    /* Diagnostic: arm a page-guard on the handler OPD to catch the raw store that
+     * clobbers its code word to the TOC base (YDKJ_GUARD). */
+    if (getenv("YDKJ_GUARD") && s_flip_handler_opd) {
+        extern void ppu_guard_page(u32 guest_ea);
+        ppu_guard_page(s_flip_handler_opd);
+    }
     printf("[cellGcmSys] SetFlipHandler(opd=0x%08X) code=0x%08X toc=0x%08X\n",
            s_flip_handler_opd, s_flip_handler_code, s_flip_handler_toc);
 }
@@ -667,6 +696,26 @@ s32 cellGcmAddressToOffset(u32 address, u32* offset)
     }
 
     printf("[cellGcmSys] WARNING: AddressToOffset failed for 0x%08X\n", address);
+#ifdef _WIN32
+    /* Trace the caller when the address is near-null (a null render object's
+     * field, e.g. 0x28) so we can find which render-setup object is uninitialized.
+     * Resolve each host frame to the guest func_ via function_table (no symbols). */
+    if (address < 0x10000) {
+        extern const struct { unsigned long long addr; void (*func)(void*); const char* name; } function_table[];
+        extern const unsigned long long function_table_count;
+        char* mb=(char*)GetModuleHandleA(0); void* bt[24]; unsigned short fr=RtlCaptureStackBackTrace(0,24,bt,0);
+        char ln[900]; int p=snprintf(ln,sizeof ln,"[gcm-a2o] near-null addr=0x%08X guest-callers:",address);
+        for(int i=0;i<fr && i<10;i++){
+            uintptr_t tgt=(uintptr_t)bt[i]; uint32_t bg=0; uintptr_t bh=0;
+            for(unsigned long long k=0;k<function_table_count;k++){
+                uintptr_t h=(uintptr_t)function_table[k].func;
+                if(h<=tgt && h>bh){ bh=h; bg=function_table[k].addr; }
+            }
+            if(bg) p+=snprintf(ln+p,sizeof(ln)-p," func_%08X+0x%llX",bg,(unsigned long long)(tgt-bh));
+        }
+        fprintf(stderr,"%s\n",ln);
+    }
+#endif
     vm_write32(off_ea, 0);
     return CELL_GCM_ERROR_FAILURE;
 }

--- a/libs/video/rsx_commands.c
+++ b/libs/video/rsx_commands.c
@@ -256,7 +256,24 @@ static int process_vertex_attrib_method(rsx_state* state, u32 method, u32 data)
 
 int rsx_process_method(rsx_state* state, u32 method, u32 data)
 {
-    /* Surface configuration */
+    { static int _rt=-1; if(_rt<0) _rt=getenv("YDKJ_RSXTRACE")?1:0;
+      if(_rt){ static int _m=0; if(_m++<250) fprintf(stderr,"[rsxm] method=0x%04X data=0x%08X\n", method, data); } }
+    /* Back-end write label / semaphore (cellGcmSetWriteBackEndLabel): the RSX
+     * writes a value to a report/label the CPU polls for CPU<->RSX sync (double
+     * buffering). Real hardware DOES this; without it the game's frame-fence
+     * loop (func_0006E6E0 polling label 0x41 @ 0x03000410) spins forever and
+     * never reaches render. NV4097_SET_SEMAPHORE_OFFSET(0x1D6C)=offset (index*0x10
+     * into the GCM label window @0x03000000); NV4097_BACK_END_WRITE_SEMAPHORE_
+     * RELEASE(0x1D70)=value. Also NV406E semaphore release (0x0010 offset/0x0014
+     * value) for the sub-channel path. */
+    { static u32 s_sem_off = 0;
+      if (method == 0x1D6C) { s_sem_off = data; return 0; }
+      if (method == 0x1D70) {
+        extern void vm_write32(uint32_t a, uint32_t v);
+        vm_write32(0x03000000u + (s_sem_off & 0x00FFFFFFu), data);
+        { static int _l=0; if(_l++<8) fprintf(stderr,"[RSX] label write @0x%08X = 0x%08X (sync fence)\n", 0x03000000u+(s_sem_off&0xFFFFFF), data); }
+        return 0;
+      } }
     if (method >= 0x200 && method <= 0x23C)
         return process_surface_method(state, method, data);
 

--- a/runtime/ppu/ppu_hle.cpp
+++ b/runtime/ppu/ppu_hle.cpp
@@ -18,6 +18,7 @@
  */
 #include "ppu_recomp.h"   /* ppu_context */
 #include "ps3emu/nid.h"   /* ps3_nid_table, ps3_nid_entry */
+#include <stdlib.h>       /* getenv */
 #include <stdint.h>
 #include <stdio.h>
 
@@ -70,17 +71,96 @@ extern "C" const char* g_last_hle_name = "";
 extern "C" uint32_t prx_resolve_export(uint32_t nid);
 extern "C" void     ps3_indirect_call(ppu_context* ctx);
 extern "C" uint32_t vm_read32(uint64_t a);
+extern "C" __declspec(dllimport) void* __stdcall GetModuleHandleA(const char*);
+static inline void* ps3_GetModuleHandleA(const char* m){ return GetModuleHandleA(m); }
 
 extern "C" void ps3_hle_call(uint32_t nid, ppu_context* ctx)
 {
     g_last_hle_nid = nid;
+    /* Bad-lock locator (FLOW_BADLOCK): sys_lwmutex_lock (0x1573DC3F) on a garbage/null
+     * object (r3 < 0x10000 or high-bit set) in m_InitEntityHierarchy — host backtrace
+     * to find the null global it dereferences. Map RVAs via flow.map. */
+    { static int _bl=-1; if(_bl<0)_bl=getenv("FLOW_BADLOCK")?1:0;
+      if(_bl && nid==0x1573DC3Fu){ uint32_t r3=(uint32_t)ctx->gpr[3];
+        if(r3<0x00010000u || r3>=0x80000000u){ static int _n=0; if(_n++<3){
+#ifdef _WIN32
+          extern unsigned short __stdcall RtlCaptureStackBackTrace(unsigned long,unsigned long,void**,unsigned long*);
+          void* bt[44]; unsigned short fr=RtlCaptureStackBackTrace(0,44,bt,0);
+          (void)bt;(void)fr;
+          /* Guest-stack code-ptr scan (EXACT: a lifted func name IS its guest addr) —
+           * the accurate way to recover the caller chain (host-bt nearest-symbol lies). */
+          char ln[1500]; int p=snprintf(ln,sizeof ln,"[BADLOCK] r3=0x%08X guest-codeptrs:",r3);
+          uint32_t sp=(uint32_t)ctx->gpr[1]; uint32_t prev=0; int found=0;
+          for(uint32_t a=sp; a<sp+0x1800 && a<0x0FF00000u && found<40; a+=4){ uint32_t v=vm_read32(a);
+            if(((v>=0x00010000u&&v<0x00900000u)||(v>=0x30000000u&&v<0x30100000u)) && v!=0x008969A8u){
+              if(v!=prev){ p+=snprintf(ln+p,sizeof(ln)-p," %08X",v); prev=v; found++; } } }
+          fprintf(stderr,"%s\n",ln);
+          /* dump the allocator pool table: base ptr at TOC-0x315C (0x008969A8-0x315C=0x0089384C),
+           * entries table[0..4]. Tells us if pool[1] alone is null (corruption) or many (init-miss). */
+          { uint32_t tbase=vm_read32(0x0089384Cu); uint32_t cnt_ptr=vm_read32(0x00893848u);
+            fprintf(stderr,"[BADLOCK] pooltable base=0x%08X state=0x%08X count=0x%08X entries:",
+              tbase,cnt_ptr,cnt_ptr?vm_read32(cnt_ptr):0);
+            for(int i=0;i<5;i++) fprintf(stderr," [%d]=0x%08X",i,tbase?vm_read32(tbase+i*4):0);
+            fprintf(stderr,"\n"); }
+#endif
+        } } } }
+    /* Spin-loop locator: print the guest LR for any HLE call whose r3 lands in the
+     * lwmutex-spin object region (0x0275E000-0x02761000). Env FLOW_SPINLR. */
+    { static int _sl=-1; if(_sl<0)_sl=getenv("FLOW_SPINLR")?1:0;
+      if(_sl){ uint32_t r3=(uint32_t)ctx->gpr[3];
+        if(nid==0x2F85C0EFu && r3>=0x02740000u && r3<0x02780000u){ static int _n=0; if(_n++<3){
+          /* The DRAIN/fragment model leaves the standard LR slots zero, so scan the
+           * guest stack for any word in the lifted code range (game 0x10000-0x900000,
+           * libsre 0x30000000-0x30100000) — those are saved return addresses, and a
+           * lifted func name IS its guest addr (func_XXXXXXXX), so they map directly. */
+          char buf[1400]; int p=snprintf(buf,sizeof buf,"[SPINLR] lwmutex_create r3=0x%08X sp=0x%08X codeptrs:",r3,(uint32_t)ctx->gpr[1]);
+          uint32_t sp=(uint32_t)ctx->gpr[1]; uint32_t prev=0; int found=0;
+          for(uint32_t a=sp; a<sp+0x2400 && a<0x0FF00000u && found<48; a+=4){ uint32_t v=vm_read32(a);
+            if((v>=0x00010000u&&v<0x00900000u)||(v>=0x30000000u&&v<0x30100000u)){
+              if(v!=prev){ p+=snprintf(buf+p,sizeof(buf)-p," %08X",v); prev=v; found++; } } }
+          fprintf(stderr,"%s\n",buf); } } } }
+    { static int tr=-1; if(tr<0){const char*e=getenv("FLOW_HLETRACE"); tr=e?1:0;}
+      if(tr) fprintf(stderr,"[hletrace] nid=0x%08X r3=0x%08X r4=0x%08X r5=0x%08X r6=0x%08X\n",
+          nid,(uint32_t)ctx->gpr[3],(uint32_t)ctx->gpr[4],(uint32_t)ctx->gpr[5],(uint32_t)ctx->gpr[6]); }
+    /* sys_process_exit (abort path): dump the guest back-chain so we see WHO aborted. */
+    if (nid == 0xE6F2C1E7u && getenv("FLOW_EXITCHAIN")) {
+        uint32_t sp = (uint32_t)ctx->gpr[1];
+        fprintf(stderr, "[exit-chain] code=0x%X lr=0x%08X sp=0x%08X\n", (uint32_t)ctx->gpr[3], (uint32_t)ctx->lr, sp);
+        /* Scan the guest stack for words in the lifted code range — saved return
+         * addresses; a lifted func name IS its guest addr. (back-chain LR slots are
+         * 0 under the DRAIN/fragment model, so scan instead of walk.) */
+        { uint32_t prev=0; int found=0; char b[1600]; int p=snprintf(b,sizeof b,"[exit-chain] codeptrs:");
+          for(uint32_t a=sp; a<sp+0x3000 && a<0x0FF00000u && found<60; a+=4){ uint32_t v=vm_read32(a);
+            if(((v>=0x00010000u&&v<0x00900000u)||(v>=0x30000000u&&v<0x30100000u)) && v!=0x008969A8u){
+              if(v!=prev){ p+=snprintf(b+p,sizeof(b)-p," %08X",v); prev=v; found++; } } }
+          fprintf(stderr,"%s\n",b); }
+#ifdef _WIN32
+        { extern unsigned short __stdcall RtlCaptureStackBackTrace(unsigned long,unsigned long,void**,unsigned long*);
+          extern void* __stdcall GetModuleHandleA(const char*);
+          void* bt[40]; unsigned short fr=RtlCaptureStackBackTrace(0,40,bt,0);
+          char* mb=(char*)GetModuleHandleA(0); char line[1100]; int p=snprintf(line,sizeof line,"[exit-chain] HOST-bt rva:");
+          for(int i=0;i<fr;i++) p+=snprintf(line+p,sizeof(line)-p," %llX",(unsigned long long)((char*)bt[i]-mb));
+          fprintf(stderr,"%s\n",line); }
+#endif
+    }
     /* PPC64 ELFv1 cross-module ABI: the caller restores its TOC right after the
      * call with `ld r2, 0x28(r1)`, expecting the import stub to have saved the
      * caller's r2 into that slot. The real .lib.stub trampoline did this; the
      * lifted --hle-stubs body (ps3_hle_call) doesn't, so without this every
      * import call leaves the caller with a garbage r2 -> all later TOC-relative
      * loads (the C++ ctor list, globals, ...) read garbage -> boot corruption. */
-    vm_write64(ctx->gpr[1] + 0x28, ctx->gpr[2]);
+    { static int _h=-1; if(_h<0)_h=getenv("FLOW_HLETOC")?1:0;
+      if(_h && (uint32_t)(ctx->gpr[1]+0x28)==0x0FEFF268u){ static int _n=0; if(_n++<6){
+        char* mb=(char*)ps3_GetModuleHandleA(0); void* ra0=__builtin_return_address(0); void* ra1=__builtin_return_address(1);
+        fprintf(stderr,"[HLETOC] corrupt nid=0x%08X name=%s r1=0x%08X  host_ra0_rva=0x%llX ra1_rva=0x%llX\n",
+          nid,g_last_hle_name?g_last_hle_name:"?",(uint32_t)ctx->gpr[1],
+          (unsigned long long)((char*)ra0-mb),(unsigned long long)((char*)ra1-mb)); } } }
+    /* FLOW_NOSPILL: with the lifted code using a constant main TOC (--main-toc/TOCFIX),
+     * the caller no longer reads [r1+0x28] to restore r2, so this ABI TOC-spill is
+     * unnecessary — and in the frameless-cascade it can clobber a caller frame slot
+     * (e.g. the deserializer's this-pointer). Skip it to test that theory. */
+    { static int _ns=-1; if(_ns<0)_ns=getenv("FLOW_NOSPILL")?1:0;
+      if(!_ns) vm_write64(ctx->gpr[1] + 0x28, ctx->gpr[2]); }
 
     /* Real libsre (loaded PRX) takes priority over the HLE stub. */
     {
@@ -88,9 +168,42 @@ extern "C" void ps3_hle_call(uint32_t nid, ppu_context* ctx)
         if (opd) {
             uint32_t code = vm_read32(opd);
             uint32_t toc  = vm_read32(opd + 4);
+            { static int64_t st=-2; if(st==-2){const char*e=getenv("YDKJ_SPURSTRACE"); st=e?1:0;}
+              if (st) fprintf(stderr, "[SPURSTRACE] nid=0x%08X -> libsre code=0x%08X  r3=0x%08X r4=0x%08X r5=0x%08X r6=0x%08X\n",
+                  nid, code, (uint32_t)ctx->gpr[3],(uint32_t)ctx->gpr[4],(uint32_t)ctx->gpr[5],(uint32_t)ctx->gpr[6]); }
+            /* Arm a page-guard on the CellSpurs struct at cellSpursInitializeWithAttribute2
+             * ENTRY (nid 0xAA6269A8, r3=&spurs) — before the init writes it — to catch
+             * where its struct stores actually land. Env YDKJ_GUARD_INST. */
+            if (nid == 0xAA6269A8u && getenv("YDKJ_GUARD_INST")) {
+                extern void ppu_guard_page(uint32_t);
+                fprintf(stderr, "[GUARD] arming on CellSpurs &spurs=0x%08X at init entry\n", (uint32_t)ctx->gpr[3]);
+                ppu_guard_page((uint32_t)ctx->gpr[3]);
+            }
             ctx->gpr[2] = toc;            /* libsre's own TOC */
             ctx->ctr    = code;
-            ps3_indirect_call(ctx);       /* -> registered lifted libsre fn; r3=ret */
+            /* FLOW_REENTRY_ISO: the libsre fn re-enters lifted guest code at the PPU
+             * caller's r1; if it (or a frameless mid-entry inside it) runs at an
+             * overlapping frame, its stores clobber the caller's live frame (the
+             * deserializer this-ptr corruption). Drop r1 to a fresh guard slice so the
+             * re-entered frame can never overlap the caller. Args are in regs (ABI);
+             * results go via r3 / guest pointers, so isolating the frame is safe. */
+            { static int _ri=-1; if(_ri<0)_ri=getenv("FLOW_REENTRY_ISO")?1:0;
+              if(_ri){ uint64_t _sr1=ctx->gpr[1]; ctx->gpr[1]=(ctx->gpr[1]-0x1000)&~0xFull;
+                ps3_indirect_call(ctx); ctx->gpr[1]=_sr1; }
+              else ps3_indirect_call(ctx); }       /* -> registered lifted libsre fn; r3=ret */
+            { static int64_t st=-2; if(st==-2){const char*e=getenv("YDKJ_SPURSTRACE"); st=e?1:0;}
+              if (st) fprintf(stderr, "[SPURSTRACE] nid=0x%08X RETURNED r3=0x%08X\n",
+                  nid, (uint32_t)ctx->gpr[3]); }
+            /* cellSpursInitialize (0xACFC8DBC) just returned -> the CellSpurs
+             * instance is now populated; spawn the lifted SPURS SPU kernel against
+             * it (flОw libsre never calls group_start; spawning during init reads
+             * an empty context and recurses to a stack overflow). Weak so a build
+             * without flow_spurs_kernel.c still links. */
+            if (nid == 0xACFC8DBCu) {
+                extern void flow_spurs_kernel_spawn_postinit(void) __attribute__((weak));
+                if (getenv("FLOW_SPURSKERNEL") && flow_spurs_kernel_spawn_postinit)
+                    flow_spurs_kernel_spawn_postinit();
+            }
             return;
         }
     }
@@ -117,6 +230,15 @@ extern "C" void ps3_hle_call(uint32_t nid, ppu_context* ctx)
     uint64_t r = fn(ctx->gpr[3], ctx->gpr[4], ctx->gpr[5], ctx->gpr[6],
                     ctx->gpr[7], ctx->gpr[8], ctx->gpr[9], ctx->gpr[10]);
     ctx->gpr[3] = r;   /* PPC return value */
+    /* PTR-LEAK detector (FLOW_PTRLEAK): the game stores HLE return values as
+     * guest pointers; if an HLE returns a value out of guest RAM (>= 0x10000000)
+     * that isn't a CELL_ERROR code (0x8001xxxx), it's leaking a truncated HOST
+     * pointer -> becomes an unresolved guest call later (e.g. 0xC708C708). */
+    { static int _pl=-1; if(_pl<0)_pl=getenv("FLOW_PTRLEAK")?1:0;
+      if(_pl){ uint32_t rv=(uint32_t)r;
+        if(rv>=0x10000000u && (rv & 0xFFFF0000u)!=0x80010000u && (rv & 0xFFFF0000u)!=0x80020000u){
+          static int _n=0; if(_n++<40) fprintf(stderr,"[PTRLEAK] NID 0x%08X %s returned 0x%08X (out-of-guest-RAM host ptr?)\n",
+            nid, e->name?e->name:"?", rv); } } }
 }
 
 /* Populated by the generated registration unit (gen_hle_nids.py). Weak so a

--- a/runtime/ppu/ppu_loader.cpp
+++ b/runtime/ppu/ppu_loader.cpp
@@ -23,8 +23,59 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef _WIN32
+#include <windows.h>
+#endif
 
 extern "C" uint8_t* vm_base;   /* defined by the host */
+
+/* ---- page-guard watchpoint (find raw memcpy/vector stores that vm_write* can't
+ * see, e.g. the lifter bug clobbering the GCM handler OPDs to the TOC base). When
+ * armed via ppu_guard_page(guest_ea), the 4 KB host page is set read-only and a
+ * VEH logs the faulting RIP of any write into it, then single-steps past it and
+ * re-arms. Env-gated by the caller; only active during diagnosis. */
+#ifdef _WIN32
+static volatile uintptr_t s_guard_page = 0;   /* host base of the guarded 4KB page */
+static volatile uint32_t  s_guard_ea   = 0;   /* guest ea being watched */
+static LONG WINAPI ppu_guard_veh(EXCEPTION_POINTERS* ep)
+{
+    DWORD code = ep->ExceptionRecord->ExceptionCode;
+    if (code == EXCEPTION_ACCESS_VIOLATION && s_guard_page &&
+        ep->ExceptionRecord->NumberParameters >= 2) {
+        uintptr_t tgt = (uintptr_t)ep->ExceptionRecord->ExceptionInformation[1];
+        if (tgt >= s_guard_page && tgt < s_guard_page + 0x1000) {
+            uint32_t guest = (uint32_t)(tgt - (uintptr_t)vm_base);
+            char* mbase = (char*)GetModuleHandleA(NULL);
+            fprintf(stderr, "[GUARD] WRITE guest=0x%08X from RIP rva=0x%llX%s\n",
+                    guest, (unsigned long long)((char*)ep->ContextRecord->Rip - mbase),
+                    (guest == s_guard_ea) ? "  <<< watched addr!" : "");
+            fflush(stderr);
+            DWORD old; VirtualProtect((void*)s_guard_page, 0x1000, PAGE_READWRITE, &old);
+            ep->ContextRecord->EFlags |= 0x100;   /* single-step to re-arm after the write */
+            return EXCEPTION_CONTINUE_EXECUTION;
+        }
+    }
+    if (code == EXCEPTION_SINGLE_STEP && s_guard_page) {
+        DWORD old; VirtualProtect((void*)s_guard_page, 0x1000, PAGE_READONLY, &old);
+        ep->ContextRecord->EFlags &= ~0x100u;
+        return EXCEPTION_CONTINUE_EXECUTION;
+    }
+    return EXCEPTION_CONTINUE_SEARCH;
+}
+extern "C" void ppu_guard_page(uint32_t guest_ea)
+{
+    if (!vm_base || s_guard_page) return;
+    s_guard_ea   = guest_ea;
+    s_guard_page = ((uintptr_t)vm_base + guest_ea) & ~(uintptr_t)0xFFF;
+    AddVectoredExceptionHandler(1, ppu_guard_veh);   /* runs before vm_commit_veh */
+    DWORD old;
+    VirtualProtect((void*)s_guard_page, 0x1000, PAGE_READONLY, &old);
+    fprintf(stderr, "[GUARD] armed on guest 0x%08X (host page %p)\n", guest_ea, (void*)s_guard_page);
+    fflush(stderr);
+}
+#else
+extern "C" void ppu_guard_page(uint32_t guest_ea) { (void)guest_ea; }
+#endif
 
 /* Guest address-space size (host sets this); 0 = unchecked. Bounds-checking
  * turns a stray pointer in lifted code into a logged bad-access returning 0
@@ -100,8 +151,23 @@ static void vm_hotmap(uint32_t ea, int width)
         for (uint32_t i = 0; i < NB; i++) cnt[i] = 0;
     }
 }
+extern "C" __declspec(thread) ppu_context* g_active_ctx;  /* fwd decl (defined below) */
+/* Tracks the most recent vm_read32 {addr,value} on this thread, so FLOW_WVAL can
+ * report the SOURCE a copied value came from (poison propagation vs true origin). */
+static __declspec(thread) uint32_t g_last_rd_addr = 0;
+static __declspec(thread) uint32_t g_last_rd_val  = 0;
+/* Stack of currently-executing indirect-call (vtable) targets on this thread, so a
+ * write hook can name the virtual method that is running when it writes a value. */
+static __declspec(thread) uint32_t g_vcall_stk[128];
+static __declspec(thread) int      g_vcall_sp = 0;
 extern "C" {
 uint8_t  vm_read8 (uint64_t a) { if (vm_oob((uint32_t)a,1)) return 0; vm_hotmap((uint32_t)a,1);
+    /* YDKJ_LV2_SAT (diagnostic): the game polls 0x00543580 ("Continue... (Lv-2 is
+     * still N)") for an SPU/worker completion that never arrives in the HLE path,
+     * then exits(1). Force a value here to test whether it then proceeds to draws.
+     * Value via env (e.g. 0x1, 0xFF); default 1. */
+    { static int s_s=-1; static uint8_t s_v=1; if (s_s<0){ const char* e=getenv("YDKJ_LV2_SAT"); s_s=e?1:0; if(e&&*e) s_v=(uint8_t)strtoul(e,0,0); }
+      if (s_s && (uint32_t)a==0x00543580u) return s_v; }
 #ifdef VM_SAMPLE_READS
     { static uint64_t c=0; if ((++c % 2000000ull)==0) fprintf(stderr, "[sample] read8  0x%08X ra0=%p ra1=%p\n", (uint32_t)a, __builtin_return_address(0), __builtin_return_address(1)); }
 #endif
@@ -114,9 +180,40 @@ uint16_t vm_read16(uint64_t a) { if (vm_oob((uint32_t)a,2)) return 0; vm_hotmap(
       if ((uint32_t)a==last) { if (++n==200000) { fprintf(stderr, "[HOTREAD16] spinning on 0x%08X\n", (uint32_t)a); n=0; } } else { last=(uint32_t)a; n=0; } }
     return __builtin_bswap16(v); }
 uint32_t vm_read32(uint64_t a) { if (vm_oob((uint32_t)a,4)) return 0; uint32_t v; memcpy(&v, vm_base + (uint32_t)a, 4);
+    g_last_rd_addr = (uint32_t)a; g_last_rd_val = __builtin_bswap32(v);
     { static int64_t rw=-2; if (rw==-2) { const char* e=getenv("YDKJ_RWATCH"); rw=e?(int64_t)strtoul(e,0,0):-1; }
       if (rw>=0) { uint32_t ea=(uint32_t)a; if (ea>=(uint32_t)rw && ea<(uint32_t)rw+0x80) {
         static int _n=0; if (_n++<40) fprintf(stderr,"[RWATCH] read32 0x%08X = 0x%08X  ra=%p\n", ea, __builtin_bswap32(v), __builtin_return_address(0)); } } }
+    /* FLOW_RVAL=<hex>: catch where a value is READ FROM memory (its source loc) —
+     * the complement to FLOW_WVAL, to find the origin of the 0xC708C708 poison. */
+    { static int64_t rv=-2; if (rv==-2){ const char* e=getenv("FLOW_RVAL"); rv=e?(int64_t)strtoul(e,0,16):-1; }
+      if (rv>=0 && __builtin_bswap32(v)==(uint32_t)rv) { static int _n=0; if(_n++<8){
+        char* mb=(char*)GetModuleHandleA(0); void* bt[20]; unsigned short fr=RtlCaptureStackBackTrace(0,20,bt,0);
+        char ln[820]; int p=snprintf(ln,sizeof ln,"[RVAL] read 0x%08X = 0x%08X guest:",(uint32_t)a,(uint32_t)rv);
+        for(int i=0;i<fr && i<10;i++){ uintptr_t tgt=(uintptr_t)bt[i]; uint32_t bg=0; uintptr_t bh=0;
+          for(uint64_t k=0;k<function_table_count;k++){ uintptr_t h=(uintptr_t)function_table[k].func; if(h<=tgt&&h>bh){bh=h;bg=function_table[k].addr;} }
+          if(bg&&(tgt-bh)<0x1400) p+=snprintf(ln+p,sizeof(ln)-p," func_%08X+0x%llX",bg,(unsigned long long)(tgt-bh)); }
+        fprintf(stderr,"%s\n",ln); } } }
+#ifdef _WIN32
+    { static int64_t vw=-2; if (vw==-2){ const char* e=getenv("FLOW_VALWATCH"); vw=e?(int64_t)strtoul(e,0,16):-1; }
+      if (vw>=0 && __builtin_bswap32(v)==(uint32_t)vw) { static int _vn=0; if(_vn++<2){
+        char* mb=(char*)GetModuleHandleA(0); void* bt[24]; unsigned short fr=RtlCaptureStackBackTrace(0,24,bt,0);
+        char line[760]; int p=snprintf(line,sizeof line,"[VALWATCH] read32 0x%08X = 0x%08X bt:",(uint32_t)a,(uint32_t)vw);
+        for(int i=0;i<fr;i++) p+=snprintf(line+p,sizeof(line)-p," %llX",(unsigned long long)((char*)bt[i]-mb));
+        fprintf(stderr,"%s\n",line);
+        if (g_active_ctx) { fprintf(stderr,"   guest cia=0x%08X lr=0x%08X r2=0x%08X\n",
+              (uint32_t)g_active_ctx->cia,(uint32_t)g_active_ctx->lr,(uint32_t)g_active_ctx->gpr[2]);
+          for(int r=0;r<32;r+=8) fprintf(stderr,"   r%-2d: %08X %08X %08X %08X %08X %08X %08X %08X\n",r,
+              (uint32_t)g_active_ctx->gpr[r+0],(uint32_t)g_active_ctx->gpr[r+1],(uint32_t)g_active_ctx->gpr[r+2],(uint32_t)g_active_ctx->gpr[r+3],
+              (uint32_t)g_active_ctx->gpr[r+4],(uint32_t)g_active_ctx->gpr[r+5],(uint32_t)g_active_ctx->gpr[r+6],(uint32_t)g_active_ctx->gpr[r+7]); }
+        uint32_t base=((uint32_t)a)&~0xFu; base = base>=0x40 ? base-0x40 : 0;
+        for(int row=0;row<10;row++){ uint32_t ea=base+row*16; char asc[17]={0};
+          fprintf(stderr,"   0x%08X:",ea);
+          for(int i=0;i<4;i++){uint32_t w; memcpy(&w,vm_base+ea+i*4,4); fprintf(stderr," %08X",__builtin_bswap32(w));}
+          for(int i=0;i<16;i++){unsigned char c=vm_base[ea+i]; asc[i]=(c>=32&&c<127)?c:'.';}
+          fprintf(stderr,"  |%s|\n",asc); }
+      } } }
+#endif
 #ifdef VM_SAMPLE_READS
     { static uint64_t c=0; if ((++c % 4000000ull)==0) fprintf(stderr, "[sample] read32 0x%08X = 0x%08X\n", (uint32_t)a, __builtin_bswap32(v)); }
 #endif
@@ -144,9 +241,26 @@ uint64_t vm_read64(uint64_t a) { if (vm_oob((uint32_t)a,8)) return 0; vm_hotmap(
     { static uint64_t c=0; if ((++c % 2000000ull)==0) fprintf(stderr, "[sample] read64 0x%08X\n", (uint32_t)a); }
 #endif
     { static __declspec(thread) uint32_t last=0xFFFFFFFFu; static __declspec(thread) uint32_t n=0;
-      if ((uint32_t)a==last) { if (++n==200000) { fprintf(stderr, "[HOTREAD64] spinning on 0x%08X\n", (uint32_t)a); n=0; } } else { last=(uint32_t)a; n=0; } }
+      if ((uint32_t)a==last) { if (++n==200000) { fprintf(stderr, "[HOTREAD64] spinning on 0x%08X (=0x%016llX)\n", (uint32_t)a, (unsigned long long)__builtin_bswap64(v)); n=0;
+#ifdef _WIN32
+        { static int64_t wa=-2; if(wa==-2){const char*e=getenv("YDKJ_SPINBT"); wa=e?(int64_t)strtoul(e,0,0):-1;}
+          if(wa>=0 && (uint32_t)a==(uint32_t)wa){ static int once=0; if(!once){ once=1;
+            void* bt[28]; unsigned short fr=RtlCaptureStackBackTrace(0,28,bt,0);
+            char* mb=(char*)GetModuleHandleA(0); char line[800]; int p=snprintf(line,sizeof line,"[SPINBT 0x%08X] rva:",(uint32_t)a);
+            for(int i=0;i<fr;i++) p+=snprintf(line+p,sizeof(line)-p," %llX",(unsigned long long)((char*)bt[i]-mb));
+            fprintf(stderr,"%s\n",line); } } }
+#endif
+      } } else { last=(uint32_t)a; n=0; } }
     return __builtin_bswap64(v); }
-void vm_write8 (uint64_t a, uint8_t  v) { if (vm_oob((uint32_t)a,1)) return; vm_base[(uint32_t)a] = v; }
+void vm_write8 (uint64_t a, uint8_t  v) { if (vm_oob((uint32_t)a,1)) return;
+    /* AWATCH8: watch byte writes to a specific addr (e.g. the 0x543580 Lv-2
+     * completion flag the worker spins on) — vm_write32-based AWATCH misses these. */
+    { static int64_t aw=-2; if(aw==-2){const char*e=getenv("YDKJ_AWATCH8"); aw=e?(int64_t)strtoul(e,0,16):-1;}
+      if(aw>=0 && (uint32_t)a==(uint32_t)aw){ static int _n=0; if(_n++<16){
+        extern void ppu_dump_guest_stack(ppu_context*, const char*);
+        fprintf(stderr,"[AWATCH8] write8 0x%08X = 0x%02X  tid=%llu\n",(uint32_t)a,v,g_active_ctx?(unsigned long long)g_active_ctx->thread_id:999ull);
+        if(g_active_ctx) ppu_dump_guest_stack(g_active_ctx,"aw8-writer"); } } }
+    vm_base[(uint32_t)a] = v; }
 void vm_write16(uint64_t a, uint16_t v) { if (vm_oob((uint32_t)a,2)) return;
     { static int64_t w=-2; if (w==-2) { const char* e=getenv("YDKJ_WWATCH"); w = e?(int64_t)strtoul(e,0,0):-1; }
       if (w>=0) { uint32_t ea=(uint32_t)a; if (ea>=(uint32_t)w && ea<(uint32_t)w+0x40)
@@ -154,10 +268,138 @@ void vm_write16(uint64_t a, uint16_t v) { if (vm_oob((uint32_t)a,2)) return;
     v = __builtin_bswap16(v); memcpy(vm_base + (uint32_t)a, &v, 2); }
 void vm_write32(uint64_t a, uint32_t v) { if (vm_oob((uint32_t)a,4)) return;
     { static int64_t w=-2; if (w==-2) { const char* e=getenv("YDKJ_WWATCH"); w = e?(int64_t)strtoul(e,0,0):-1; }
-      if (w>=0) { uint32_t ea=(uint32_t)a; if (ea>=(uint32_t)w && ea<(uint32_t)w+0x40)
-        fprintf(stderr,"[WWATCH] write32 0x%08X = 0x%08X  ra=%p\n", ea, v, __builtin_return_address(0)); } }
+      if (w>=0) { uint32_t ea=(uint32_t)a; if (ea>=(uint32_t)w && ea<(uint32_t)w+0x40) {
+#ifdef _WIN32
+        void* ra=__builtin_return_address(0); char* mb=(char*)GetModuleHandleA(NULL);
+        fprintf(stderr,"[WWATCH] write32 0x%08X = 0x%08X  ra_rva=0x%llX\n", ea, v, (unsigned long long)((char*)ra-mb));
+#else
+        fprintf(stderr,"[WWATCH] write32 0x%08X = 0x%08X  ra=%p\n", ea, v, __builtin_return_address(0));
+#endif
+      } } }
+#ifdef _WIN32
+    /* FLOW_WVAL=<hex>: catch the instruction that STORES this value to a non-rodata
+     * dest (e.g. a metaclass list node corrupted with a format-string pointer). */
+    { static int64_t wv=-2; if (wv==-2){ const char* e=getenv("FLOW_WVAL"); wv=e?(int64_t)strtoul(e,0,16):-1; }
+      if (wv>=0 && v==(uint32_t)wv && (uint32_t)a < 0x50000000u) { static int _n=0; if(_n++<6){
+        fprintf(stderr,"[WVAL] write32 0x%08X = 0x%08X  (lastread: [0x%08X]=0x%08X %s)\n",
+                (uint32_t)a,v, g_last_rd_addr, g_last_rd_val,
+                (g_last_rd_val==(uint32_t)wv)?"<-COPIED-FROM-HERE":"(value NOT from last read = COMPUTED/origin)");
+        if (g_active_ctx) {
+            ppu_context* c = g_active_ctx;
+            /* which gpr holds the poison + neighbors (reveals the computation) */
+            char rg[700]; int rp=snprintf(rg,sizeof rg,"      WVAL-gpr:");
+            for(int k=0;k<32;k++) rp+=snprintf(rg+rp,sizeof(rg)-rp," r%d=%08X",k,(uint32_t)c->gpr[k]);
+            fprintf(stderr,"%s\n",rg);
+#ifdef _WIN32
+            /* reliable host-backtrace -> guest func resolution (like AWATCH), since
+             * the guest-stack scan often comes back empty for fresh worker frames. */
+            { void* bt[24]; unsigned short fr=RtlCaptureStackBackTrace(0,24,bt,0);
+              char hl[900]; int hp=snprintf(hl,sizeof hl,"      WVAL-hostbt:");
+              for(int i=0;i<fr && i<12;i++){ uintptr_t tgt=(uintptr_t)bt[i]; uint32_t bg=0; uintptr_t bh=0;
+                for(uint64_t k=0;k<function_table_count;k++){ uintptr_t h=(uintptr_t)function_table[k].func; if(h<=tgt&&h>bh){bh=h;bg=function_table[k].addr;} }
+                if(bg&&(tgt-bh)<0x1400) hp+=snprintf(hl+hp,sizeof(hl)-hp," func_%08X+0x%llX",bg,(unsigned long long)(tgt-bh)); }
+              fprintf(stderr,"%s\n",hl); }
+#endif
+            /* reliable guest-stack scan for the writer chain (low words of 64-bit slots) */
+            char gs[900]; int gp=snprintf(gs,sizeof gs,"      WVAL-stack:"); uint32_t sp=(uint32_t)c->gpr[1]; uint32_t last=0;
+            for(int i=0;i<400 && gp<820;i++){ uint32_t w; if(vm_oob(sp+i*4,4))break; { uint32_t t; memcpy(&t,vm_base+sp+i*4,4); w=__builtin_bswap32(t); }
+                if(w<0x10000||w>=0x600000)continue; uint32_t bg=0;
+                for(uint64_t k=0;k<function_table_count;k++){ uint32_t aa=function_table[k].addr; if(aa<=w&&aa>bg)bg=aa; }
+                if(bg&&(w-bg)>0&&(w-bg)<0x4000&&w!=last){ gp+=snprintf(gs+gp,sizeof(gs)-gp," func_%08X+0x%X",bg,w-bg); last=w; } }
+            fprintf(stderr,"%s\n",gs);
+        } } } }
+    /* YDKJ_AWATCH=<hex addr>: catch writes to a specific guest address, resolving
+     * each backtrace frame to the guest func_ (reliable for lifted frames) so we
+     * can find who assigns e.g. singleton->field_4 (0x40003774) its base object. */
+    { static int64_t aw=-2; if (aw==-2){ const char* e=getenv("YDKJ_AWATCH"); aw=e?(int64_t)strtoul(e,0,16):-1; }
+      if (aw>=0 && (uint32_t)a==(uint32_t)aw) { static int _n=0; if(_n++<10){
+        char* mb=(char*)GetModuleHandleA(0); void* bt[24]; unsigned short fr=RtlCaptureStackBackTrace(0,24,bt,0);
+        char ln[900]; int p=snprintf(ln,sizeof ln,"[AWATCH] write 0x%08X = 0x%08X guest:",(uint32_t)a,v);
+        for(int i=0;i<fr && i<10;i++){
+            uintptr_t tgt=(uintptr_t)bt[i]; uint32_t bg=0; uintptr_t bh=0;
+            for(uint64_t k=0;k<function_table_count;k++){ uintptr_t h=(uintptr_t)function_table[k].func; if(h<=tgt&&h>bh){bh=h;bg=function_table[k].addr;} }
+            if(bg && (tgt-bh)<0x1400) p+=snprintf(ln+p,sizeof(ln)-p," func_%08X+0x%llX",bg,(unsigned long long)(tgt-bh));
+        }
+        fprintf(stderr,"%s\n",ln);
+        /* Dump the active context's regs: gpr[30] is func_0007D78C's vector ptr;
+         * if it points into the object 0x400240A0 the "vector" aliases the object. */
+        if (g_active_ctx) fprintf(stderr, "         ctx r30=0x%08X r29=0x%08X r3=0x%08X r4=0x%08X r5=0x%08X r31=0x%08X\n",
+            (uint32_t)g_active_ctx->gpr[30],(uint32_t)g_active_ctx->gpr[29],(uint32_t)g_active_ctx->gpr[3],
+            (uint32_t)g_active_ctx->gpr[4],(uint32_t)g_active_ctx->gpr[5],(uint32_t)g_active_ctx->gpr[31]);
+      } } }
+    /* YDKJ_VTWATCH=<hex vtable>: catch the store that installs this vtable pointer
+     * (to any obj+0), dumping the guest r2 (TOC) + cia so we can tell if a wrong-TOC
+     * construction path installed a base vtable (the cri_mpv MI-object crash root). */
+    { static int64_t vtw=-2; if (vtw==-2){ const char* e=getenv("YDKJ_VTWATCH"); vtw=e?(int64_t)strtoul(e,0,16):-1; }
+      if (vtw>=0 && v==(uint32_t)vtw) { static int _n=0; if(_n++<12){
+        uint32_t r2 = g_active_ctx ? (uint32_t)g_active_ctx->gpr[2] : 0;
+        uint32_t cia = g_active_ctx ? (uint32_t)g_active_ctx->cia : 0;
+        uint32_t lr  = g_active_ctx ? (uint32_t)g_active_ctx->lr : 0;
+        char* mb=(char*)GetModuleHandleA(0); void* bt[26]; unsigned short fr=RtlCaptureStackBackTrace(0,26,bt,0);
+        char ln[900]; int p=snprintf(ln,sizeof ln,"[VTWATCH] install vtable 0x%08X -> obj 0x%08X  r2(TOC)=0x%08X cia=0x%08X lr=0x%08X bt:",v,(uint32_t)a,r2,cia,lr);
+        for(int i=0;i<fr && i<8;i++) p+=snprintf(ln+p,sizeof(ln)-p," %llX",(unsigned long long)((char*)bt[i]-mb));
+        fprintf(stderr,"%s\n",ln); } } }
+    /* FLOW_HEAPWVAL=<hex>: catch a store of this value into the HEAP (0x10000000-0x10200000)
+     * — e.g. a stack-frame address corrupting a heap object's object-pointer field. */
+    { static int64_t hv=-2; if (hv==-2){ const char* e=getenv("FLOW_HEAPWVAL"); hv=e?(int64_t)strtoul(e,0,16):-1; }
+      if (hv>=0 && v==(uint32_t)hv && (uint32_t)a>=0x10000000u && (uint32_t)a<0x10200000u) { static int _n=0; if(_n++<10){
+        char* mb=(char*)GetModuleHandleA(0); void* bt[28]; unsigned short fr=RtlCaptureStackBackTrace(0,28,bt,0);
+        char ln[900]; int p=snprintf(ln,sizeof ln,"[HEAPWVAL] write32 dst=0x%08X = 0x%08X bt:",(uint32_t)a,v);
+        for(int i=0;i<fr;i++) p+=snprintf(ln+p,sizeof(ln)-p," %llX",(unsigned long long)((char*)bt[i]-mb));
+        fprintf(stderr,"%s\n",ln); } } }
+#endif
     v = __builtin_bswap32(v); memcpy(vm_base + (uint32_t)a, &v, 4); }
-void vm_write64(uint64_t a, uint64_t v) { if (vm_oob((uint32_t)a,8)) return; v = __builtin_bswap64(v); memcpy(vm_base + (uint32_t)a, &v, 8); }
+void vm_write64(uint64_t a, uint64_t v) { if (vm_oob((uint32_t)a,8)) return;
+    { static int64_t w=-2; if (w==-2) { const char* e=getenv("YDKJ_WWATCH"); w = e?(int64_t)strtoul(e,0,0):-1; }
+      if (w>=0) { uint32_t ea=(uint32_t)a; if (ea>=(uint32_t)w && ea<(uint32_t)w+0x40) {
+        void* ra=__builtin_return_address(0); char* mb=(char*)GetModuleHandleA(NULL);
+        fprintf(stderr,"[WWATCH] write64 0x%08X = 0x%016llX  ra_rva=0x%llX\n", ea, (unsigned long long)v, (unsigned long long)((char*)ra-mb)); } } }
+    /* FLOW_WVAL (64-bit): catch a 64-bit store whose HIGH or LOW 32-bit half equals
+     * the watched value — the blind spot for the vm_write32-only FLOW_WVAL hook. */
+    { static int64_t wv=-2; if(wv==-2){const char*e=getenv("FLOW_WVAL"); wv=e?(int64_t)strtoul(e,0,16):-1;}
+      if(wv>=0 && (uint32_t)a<0x50000000u){ uint32_t hi=(uint32_t)(v>>32), lo=(uint32_t)v;
+        if(hi==(uint32_t)wv||lo==(uint32_t)wv){ static int _n=0; if(_n++<8){
+          uint32_t dst=(hi==(uint32_t)wv)?(uint32_t)a:(uint32_t)a+4;
+          uint32_t vtgt = g_vcall_sp>0 ? g_vcall_stk[g_vcall_sp-1] : 0;
+          fprintf(stderr,"[WVAL64] write64 0x%08X (poison half @0x%08X) v=0x%016llX  active-vcall=func_%08X (depth %d)\n",(uint32_t)a,dst,(unsigned long long)v,vtgt,g_vcall_sp);
+#ifdef _WIN32
+          void* bt[20]; unsigned short fr=RtlCaptureStackBackTrace(0,20,bt,0);
+          char ln[760]; int p=snprintf(ln,sizeof ln,"      WVAL64-hostbt:");
+          for(int i=0;i<fr&&i<12;i++){ uintptr_t tgt=(uintptr_t)bt[i]; uint32_t bg=0; uintptr_t bh=0;
+            for(uint64_t k=0;k<function_table_count;k++){ uintptr_t h=(uintptr_t)function_table[k].func; if(h<=tgt&&h>bh){bh=h;bg=function_table[k].addr;} }
+            if(bg&&(tgt-bh)<0x1400) p+=snprintf(ln+p,sizeof(ln)-p," func_%08X+0x%llX",bg,(unsigned long long)(tgt-bh)); }
+          fprintf(stderr,"%s\n",ln);
+#endif
+        } } } }
+    v = __builtin_bswap64(v); memcpy(vm_base + (uint32_t)a, &v, 8); }
+}
+
+/* ---- malloc allocation tracker (FLOW_ALLOCTAG) -------------------------------
+ * Records recent guest malloc results {ptr,size,lr,id} in a ring so we can ask,
+ * for a garbage object, which allocation it belongs to and where it came from --
+ * to distinguish a use-after-free (ptr not in any LIVE alloc) from a constructor
+ * that fails to init a field (ptr IS a fresh alloc but a field is stale). */
+struct flow_alloc_rec { uint32_t ptr, size, lr, id; };
+static flow_alloc_rec g_alloc_ring[8192];
+static uint32_t       g_alloc_ring_idx = 0;
+void flow_record_alloc(unsigned int ptr, unsigned int size, unsigned int lr) {
+    static int en = -1; if (en < 0) en = getenv("FLOW_ALLOCTAG") ? 1 : 0;
+    if (!en || !ptr) return;
+    flow_alloc_rec& r = g_alloc_ring[g_alloc_ring_idx & 8191];
+    r.ptr = ptr; r.size = size; r.lr = lr; r.id = ++g_alloc_ring_idx;
+}
+void flow_lookup_alloc(unsigned int p) {
+    static int en = -1; if (en < 0) en = getenv("FLOW_ALLOCTAG") ? 1 : 0;
+    if (!en) return;
+    static int n = 0; if (n++ >= 4) return;
+    const flow_alloc_rec* best = 0;
+    for (int i = 0; i < 8192; i++) {
+        const flow_alloc_rec& r = g_alloc_ring[i];
+        if (r.ptr && p >= r.ptr && p < r.ptr + r.size) { if (!best || r.id > best->id) best = &r; }
+    }
+    if (best) fprintf(stderr, "[alloc-tag] garbage obj 0x%08X is in alloc 0x%08X size=%u off=0x%X allocLR=0x%08X id=%u\n",
+                      p, best->ptr, best->size, p - best->ptr, best->lr, best->id);
+    else      fprintf(stderr, "[alloc-tag] garbage obj 0x%08X is in NO live alloc -> use-after-free or pool/untracked\n", p);
 }
 
 /* Cross-fragment trampoline pointer (matches the lifted header's TLS decl). */
@@ -180,7 +422,10 @@ extern "C" uint32_t ppu_active_lr(void)
  * -----------------------------------------------------------------------*/
 typedef void (*ppu_fn)(ppu_context*);
 
-#define PPU_HASH_BITS 16
+/* 2^18 = 262144 slots. MUST exceed the lifted function count or the open-addressing
+ * insertion loop below spins forever (the re-lifted flОw has 104,415 functions; a
+ * 2^16=65536 table overflowed -> infinite loop -> early-boot hang). */
+#define PPU_HASH_BITS 18
 #define PPU_HASH_SIZE (1u << PPU_HASH_BITS)
 #define PPU_HASH_MASK (PPU_HASH_SIZE - 1)
 
@@ -212,18 +457,110 @@ static ppu_fn ppu_lookup(uint32_t a)
 
 extern "C" uint32_t ppu_function_count(void) { return g_fn_count; }
 
+/* Correct native memmove override for the game's hand-optimized memmove at
+ * guest 0x0036FA74. The lifted 1306-instruction version is mis-lifted (flagged
+ * elsewhere as writing OPDs byte-swapped); it corrupts bulk copies -- notably a
+ * std::vector element-shift (func_0007D78C) that CLOBBERS a C++ object's vtable
+ * pointer with an off-by-0x20 value (0x520BC4 -> 0x520BE4, whose slot[4] is null),
+ * causing the func_003DAA58 double-dispatch crash. ABI: r3=dst, r4=src, r5=size;
+ * returns dst in r3 (memcpy convention). This is a REAL correctness fix (a valid
+ * memmove replacing a broken lift), not a shim. */
+extern "C" void ydkj_memmove_0036FA74(ppu_context* ctx)
+{
+    uint32_t dst = (uint32_t)ctx->gpr[3];
+    uint32_t src = (uint32_t)ctx->gpr[4];
+    uint32_t n   = (uint32_t)ctx->gpr[5];
+    /* Diagnostic: if this copy covers 0x400240A8 (the clobbered vtable slot),
+     * log dst/src/size + the source value landing there, so we can tell a
+     * legitimate copy (src already holds 0x520BE4) from a size overrun. */
+    if (vm_base && dst <= 0x400240A8u && 0x400240A8u < dst + n) {
+        uint32_t soff = 0x400240A8u - dst + src;
+        uint32_t sval = __builtin_bswap32(*(volatile uint32_t*)(vm_base + soff));
+        static int _n=0; if(_n++<8)
+            fprintf(stderr,"[memfix] copy dst=0x%08X src=0x%08X n=0x%X -> 0x400240A8 gets src[0x%08X]=0x%08X\n",
+                    dst, src, n, soff, sval);
+    }
+    if (n && vm_base) memmove(vm_base + dst, vm_base + src, n);
+    /* r3 (dst) is preserved as the return value. */
+}
+
 /* Bridge the lifter-emitted function_table[] (declared in ppu_recomp.h) into the
  * address->function hash map. The host boot harness calls this once at startup. */
 extern "C" void ppu_recomp_register(void)
 {
     for (uint64_t i = 0; i < function_table_count; i++)
         ppu_register_function(function_table[i].addr, function_table[i].func);
+    /* Override the mis-lifted optimized memmove with a correct native one. */
+    if (getenv("YDKJ_MEMFIX")) {
+        ppu_register_function(0x0036FA74u, ydkj_memmove_0036FA74);
+        fprintf(stderr, "[ppu] YDKJ_MEMFIX: overrode func_0036FA74 with native memmove\n");
+    }
+}
+
+/* Reusable guest-stack dumper: scan the guest stack for saved return addresses
+ * (words landing inside a lifted function) and resolve them via function_table.
+ * Callable from other TUs (e.g. sys_event.c) to identify a blocked thread's chain. */
+extern "C" void ppu_dump_guest_stack(ppu_context* ctx, const char* tag)
+{
+    if (!ctx || !vm_base) return;
+    uint32_t sp = (uint32_t)ctx->gpr[1];
+    /* also show cia/lr and a few key regs (r3/r31 = likely 'this'/object) + raw stack */
+    fprintf(stderr, "[GSTACK:%s] sp=0x%08X cia=0x%08X lr=0x%08X r3=0x%08X r31=0x%08X r30=0x%08X\n",
+            tag?tag:"?", sp, (uint32_t)ctx->cia, (uint32_t)ctx->lr,
+            (uint32_t)ctx->gpr[3], (uint32_t)ctx->gpr[31], (uint32_t)ctx->gpr[30]);
+    if (!vm_oob(sp,4)) { char rw[600]; int rp=snprintf(rw,sizeof rw,"      rawstk:");
+        for (int i=0;i<24 && !vm_oob(sp+i*4,4);i++){ uint32_t t; memcpy(&t,vm_base+sp+i*4,4); rp+=snprintf(rw+rp,sizeof(rw)-rp," %08X",__builtin_bswap32(t)); }
+        fprintf(stderr,"%s\n",rw); }
+    /* Identify the worker's dispatched method: func_000750A8 vcalls
+     * [[arg+0xC]+0] (code) with toc [[arg+0xC]+4]. Dump for the known thread
+     * arg-objects (AsyncLoad=0x40003450, Trophy=0x40003E80) so we can trace the
+     * receive-loop function even though the thread stack has no return addrs. */
+    { const uint32_t args[2] = {0x40003450u, 0x40003E80u};
+      for (int j=0;j<2;j++){ uint32_t o=args[j];
+        if (vm_oob(o+0x10,4)) continue;
+        uint32_t vt, code, toc; { uint32_t t;
+          memcpy(&t,vm_base+o+0xC,4); vt=__builtin_bswap32(t);
+          if (vt<0x600000 || vt>=0x50000000u) { /* vt could be a guest ptr */ }
+        }
+        if (!vm_oob(vt,8)) { uint32_t t; memcpy(&t,vm_base+vt,4); code=__builtin_bswap32(t);
+          memcpy(&t,vm_base+vt+4,4); toc=__builtin_bswap32(t);
+          fprintf(stderr,"      ARG[0x%08X] vtbl=0x%08X -> method code=0x%08X toc=0x%08X (worker body?)\n", o, vt, code, toc); }
+      } }
+    char gs[1200]; int gp = snprintf(gs, sizeof gs, "[GSTACK:%s] sp=0x%08X:", tag ? tag : "?", sp);
+    uint32_t last = 0;
+    for (int i = 0; i < 700 && gp < 1100; i++) {
+        uint32_t a = sp + i*4; if (vm_oob(a,4)) break;
+        uint32_t t; memcpy(&t, vm_base + a, 4); uint32_t w = __builtin_bswap32(t);
+        if (w < 0x10000 || w >= 0x600000) continue;
+        uint32_t bg = 0;
+        for (uint64_t k = 0; k < function_table_count; k++) { uint32_t aa = function_table[k].addr; if (aa <= w && aa > bg) bg = aa; }
+        if (bg && (w - bg) > 0 && (w - bg) < 0x4000 && w != last) {
+            gp += snprintf(gs+gp, sizeof(gs)-gp, " func_%08X+0x%X", bg, w - bg); last = w;
+        }
+    }
+    fprintf(stderr, "%s\n", gs);
 }
 
 /* Indirect call (bctrl/bctr): CTR holds the already-OPD-resolved code address. */
 extern "C" void ps3_indirect_call(ppu_context* ctx)
 {
     g_active_ctx = ctx;
+#ifdef _WIN32
+    { static int64_t tw=-2; if(tw==-2){const char*e=getenv("FLOW_TOCWATCH"); tw=e?(int64_t)strtoul(e,0,16):-1;}
+      if(tw>=0 && (uint32_t)ctx->gpr[2]==(uint32_t)tw){ static int _n=0; if(_n++<4){
+        char* mb=(char*)GetModuleHandleA(0); void* bt[24]; unsigned short fr=RtlCaptureStackBackTrace(0,24,bt,0);
+        char ln[800]; int p=snprintf(ln,sizeof ln,"[TOCWATCH] r2=0x%08X ctr=0x%08X bt:",(uint32_t)ctx->gpr[2],(uint32_t)ctx->ctr);
+        for(int i=0;i<fr;i++) p+=snprintf(ln+p,sizeof(ln)-p," %llX",(unsigned long long)((char*)bt[i]-mb));
+        fprintf(stderr,"%s\n",ln); } } }
+#endif
+    /* FLOW_RECVTRACE: log the guest caller-chain each time the indirect call
+     * targets the q=1 receive wrapper func_00075380 -- reveals the worker's
+     * receive LOOP (why it only receives once). */
+    { static int64_t rt=-2; if(rt==-2){rt=getenv("FLOW_RECVTRACE")?1:0;}
+      if(rt && (uint32_t)ctx->ctr==0x00075380u){ static int _n=0; if(_n++<8){
+        extern void ppu_dump_guest_stack(ppu_context*, const char*);
+        fprintf(stderr,"[RECVTRACE #%d] indirect-call -> func_00075380 (q=1 receive) r3=0x%08X r4=0x%08X\n",_n,(uint32_t)ctx->gpr[3],(uint32_t)ctx->gpr[4]);
+        ppu_dump_guest_stack(ctx,"recv-caller"); } } }
     uint32_t addr = (uint32_t)ctx->ctr;
     /* Null / return-to-OS sentinel: a bctr to address 0 means the guest
      * unwound to the initial frame (or a not-yet-populated function pointer).
@@ -231,7 +568,65 @@ extern "C" void ps3_indirect_call(ppu_context* ctx)
     if (addr == 0)
         return;
 
+    /* SPURS trace: log calls into libsre's cellSpurs export range so we can
+     * identify the instance-init function (called with &spurs = 0x40009D00) and
+     * confirm libsre receives the correct struct pointer. Env YDKJ_SPURSTRACE. */
+    if (addr >= 0x30031200u && addr < 0x30031900u) {
+        static int64_t st=-2; if (st==-2){ const char* e=getenv("YDKJ_SPURSTRACE"); st=e?1:0; }
+        if (st) fprintf(stderr, "[SPURSTRACE] call libsre 0x%08X  r3=0x%08X r4=0x%08X r5=0x%08X\n",
+            addr, (uint32_t)ctx->gpr[3], (uint32_t)ctx->gpr[4], (uint32_t)ctx->gpr[5]);
+    }
+
+    /* YDKJ_LIBTRACE: log the FIRST call into each libsre code-range function
+     * (0x30000000..0x3001D718 = libsre .text) so we can see how far the real
+     * lifted cellSpurs path gets -- in particular whether cellSpursInitialize
+     * completes and CreateTaskset (0x30014DC4) / CreateTask (0x30012520) are
+     * ever reached, or execution stalls in the SPU bring-up handshake. */
+    {
+        static int64_t lt=-2; if (lt==-2){ const char* e=getenv("YDKJ_LIBTRACE"); lt=e?1:0; }
+        if (lt && addr>=0x30000000u && addr<0x3001D718u) {
+            static uint32_t seen[1024]; static int nseen=0; int found=0;
+            for (int i=0;i<nseen;i++) if (seen[i]==addr){ found=1; break; }
+            if (!found && nseen<1024) {
+                seen[nseen++]=addr;
+                const char* tag = addr==0x30014DC4u?" <CreateTaskset>" : addr==0x30012520u?" <CreateTask>" : "";
+                fprintf(stderr, "[LIBTRACE] #%d libsre 0x%08X r3=0x%08X r4=0x%08X r5=0x%08X%s\n",
+                    nseen, addr, (uint32_t)ctx->gpr[3], (uint32_t)ctx->gpr[4], (uint32_t)ctx->gpr[5], tag);
+            }
+        }
+    }
+
+    /* YDKJ_DDTRACE: dump func_003DAA58's incoming object (orig) + call1's target
+     * (orig->vtable[0]->code). The crash is call2 = call1_result->vtable[4]() on a
+     * base-typed object; on real HW call1 should return null so call2 is skipped.
+     * Capture orig's type + call1's method so we can see why it returns non-null. */
+    if (addr == 0x003DAA58u && vm_base && getenv("YDKJ_DDTRACE")) {
+        uint32_t orig=(uint32_t)ctx->gpr[3];
+        uint32_t vt  = orig? __builtin_bswap32(*(volatile uint32_t*)(vm_base+orig)) : 0;
+        uint32_t m0  = vt?   __builtin_bswap32(*(volatile uint32_t*)(vm_base+vt))   : 0;
+        uint32_t code= m0?   __builtin_bswap32(*(volatile uint32_t*)(vm_base+m0))   : 0;
+        static int _n=0; if(_n++<8)
+            fprintf(stderr,"[dd] func_003DAA58 orig=0x%08X vtable=0x%08X method0_opd=0x%08X call1_code=func_%08X\n",
+                    orig, vt, m0, code);
+    }
     ppu_fn fn = ppu_lookup(addr);
+    if (!fn) {
+        /* OPD-swap clobber fixup: a malformed memcpy (game func_0036FA74) writes
+         * some handler/vtable OPDs as {TOC, func} (code & toc SWAPPED), so lifted
+         * code loads ctr = TOC base and r2 = the real function. If ctr is not a
+         * registered function but r2 IS, they are swapped -- call r2 with the TOC
+         * (the value that was in the code slot). Fixes the flip/vblank handlers,
+         * the teardown vtable, and func_002642A0's virtual calls in one shot. */
+        uint32_t toc_reg = (uint32_t)ctx->gpr[2];
+        ppu_fn fn2 = ppu_lookup(toc_reg);
+        if (fn2) {
+            static int _n = 0;
+            if (_n++ < 8) fprintf(stderr, "[ppu] OPD-swap fixup: ctr=0x%08X not a func, using r2=0x%08X\n", addr, toc_reg);
+            ctx->gpr[2] = addr;        /* callee TOC = the (TOC) value from the code slot */
+            addr = toc_reg; ctx->ctr = toc_reg;
+            fn = fn2;
+        }
+    }
     if (fn) {
         /* Recursion-depth guard: a malformed/cyclic jump table (or a tail-call
          * chain that never converges) can dispatch recursively without bound
@@ -244,30 +639,89 @@ extern "C" void ps3_indirect_call(ppu_context* ctx)
             return;
         }
         s_depth++;
+        /* FLOW_TOCFIX: the dispatched function's TOC (r2) is the OPD toc we were
+         * called with. Tail-call trampoline links (`b target`) are intra-module, so
+         * they must all run with THIS same r2. A link that does a cross-module call
+         * and then restores r2 from a stale [r1+0x28] frame slot (shared across the
+         * tail-call chain) can leave r2 corrupted for the next link -> the metaclass
+         * deserializer ran with a wrong TOC -> garbage globals -> abort. Re-pin r2
+         * to the dispatched toc before each link so the chain stays consistent. */
+        uint32_t _toc0 = (uint32_t)ctx->gpr[2];
+        static int _tf=-1; if(_tf<0)_tf=getenv("FLOW_TOCFIX")?1:0;
+        if (g_vcall_sp < 128) g_vcall_stk[g_vcall_sp] = addr;
+        g_vcall_sp++;
         fn(ctx);
-        /* Drain the tail-call trampoline chain. Lifted functions model a tail
-         * call (`b target`) by setting g_trampoline_fn and returning, expecting
-         * the *caller's* DRAIN_TRAMPOLINE to continue. An indirect call IS such
-         * a caller: if the dispatched function ends in a tail call, the
-         * continuation is lost unless we drain it here too -- ppu_run only
-         * drains the top frame, so without this the CRT's init tail-calls (and
-         * the function-pointer tables they populate) silently never run. */
         while (g_trampoline_fn) {
             void (*tf)(void*) = g_trampoline_fn;
             g_trampoline_fn = 0;
+            if (_tf) ctx->gpr[2] = _toc0;
             tf(ctx);
         }
+        if (g_vcall_sp > 0) g_vcall_sp--;
+        /* FLOW_RETWATCH=<hex>: catch the first vcall(s) whose RETURN value (r3)
+         * equals this, pinning the exact virtual method that produces the poison. */
+        { static int64_t rw=-2; if(rw==-2){const char*e=getenv("FLOW_RETWATCH"); rw=e?(int64_t)strtoul(e,0,16):-1;}
+          if(rw>=0 && (uint32_t)ctx->gpr[3]==(uint32_t)rw){ static int _n=0; if(_n++<8){
+            fprintf(stderr,"[RETWATCH] vcall -> func_%08X returned r3=0x%08X\n", addr, (uint32_t)rw);
+#ifdef _WIN32
+            void* bt[16]; unsigned short fr=RtlCaptureStackBackTrace(0,16,bt,0);
+            char ln[760]; int p=snprintf(ln,sizeof ln,"      RET-hostbt:");
+            for(int i=0;i<fr&&i<10;i++){ uintptr_t tgt=(uintptr_t)bt[i]; uint32_t bg=0; uintptr_t bh=0;
+              for(uint64_t k=0;k<function_table_count;k++){ uintptr_t h=(uintptr_t)function_table[k].func; if(h<=tgt&&h>bh){bh=h;bg=function_table[k].addr;} }
+              if(bg&&(tgt-bh)<0x1400) p+=snprintf(ln+p,sizeof(ln)-p," func_%08X+0x%llX",bg,(unsigned long long)(tgt-bh)); }
+            fprintf(stderr,"%s\n",ln);
+#endif
+          } } }
         s_depth--;
         return;
+    }
+    /* Garbage virtual-call guard: a call target that resolves to no registered
+     * function AND lands in the data/string-pool range (0x10000000..0x30000000 is
+     * mapped data/SPURS/heap, never valid PPU code -- game .text is <0x10000000,
+     * libsre is >=0x30000000) means the `this` object was uninitialised/stale and
+     * its vtable slot held string/data bytes. Calling it is meaningless; the
+     * correct C++ semantics for "method on an empty/invalid object" is a no-op
+     * returning null. Treat it as such (r3=0) so the caller's loop makes progress
+     * instead of spinning forever on the same bogus pointer. */
+    {
+        uint32_t tgt = (uint32_t)ctx->ctr;
+        /* A valid PPU function entry is 4-byte aligned and lies in game .text
+         * (0x10000..0xFFFFFFF) or the loaded-PRX region (0x30000000..0x3FFFFFFF).
+         * Anything else — the mapped data/heap range, a MISALIGNED address (never
+         * a real entry), a too-low or above-PRX address — means the vtable slot
+         * held non-code (NULL/string/stale). Calling it is meaningless; C++ "method
+         * on an absent/optional slot" is a no-op returning null. */
+        bool _invalid = (tgt >= 0x10000000u && tgt < 0x30000000u);
+        /* Opt-in (FLOW_NOOPVCALL): also no-op MISALIGNED / out-of-code-range targets.
+         * A valid entry is 4-aligned in game .text (0x10000..0xFFFFFFF) or PRX
+         * (0x30000000..0x3FFFFFFF). This lets the boot proceed PAST bad vcalls
+         * (diagnostic band-aid — skipped methods leave state incomplete). Default
+         * OFF so the boot takes a clean crash-with-backtrace instead. */
+        { static int _nv=-1; if(_nv<0){ const char* e=getenv("FLOW_NOOPVCALL"); _nv=e?1:0; }
+          if(_nv && ((tgt & 3u)!=0u || tgt < 0x10000u || tgt >= 0x40000000u)) _invalid = true; }
+        if (_invalid) {
+            static int _gn = 0;
+            if (_gn++ < 12) fprintf(stderr, "[ppu] garbage vcall -> 0x%08X this=0x%08X (uninit/stale object) -- no-op, r3=0\n", tgt, (uint32_t)ctx->gpr[3]);
+#ifdef _WIN32
+            if (getenv("FLOW_GVBT")) { static int _b=0; if(_b++<4){
+                char* mb=(char*)GetModuleHandleA(0); void* bt[26]; unsigned short fr=RtlCaptureStackBackTrace(0,26,bt,0);
+                char ln[820]; int p=snprintf(ln,sizeof ln,"      GVBT this=0x%08X r2=0x%08X lr=0x%08X rva:",(uint32_t)ctx->gpr[3],(uint32_t)ctx->gpr[2],(uint32_t)ctx->lr);
+                for(int i=0;i<fr;i++) p+=snprintf(ln+p,sizeof(ln)-p," %llX",(unsigned long long)((char*)bt[i]-mb));
+                fprintf(stderr,"%s\n",ln); } }
+#endif
+            ctx->gpr[3] = 0;
+            return;
+        }
     }
     /* Stuck-loop guard: a divergence (e.g. an object with a null function
      * pointer) can make the game spin on the same unresolved target forever.
      * Detect a long run of identical unresolved targets and bail so the run
      * stays fast and the log readable. */
     static uint32_t last = 0xFFFFFFFFu; static uint32_t streak = 0;
+    static uint32_t stuckmax = 0; if (!stuckmax) { const char* e=getenv("YDKJ_STUCKMAX"); stuckmax = e?(uint32_t)strtoul(e,0,0):2000u; }
     uint32_t cur = (uint32_t)ctx->ctr;
     if (cur == last) {
-        if (++streak == 2000) { fprintf(stderr, "[ppu] FATAL: stuck calling 0x%08X (%u times) -- aborting run\n", cur, streak); fflush(stderr); exit(3); }
+        if (++streak == stuckmax) { fprintf(stderr, "[ppu] FATAL: stuck calling 0x%08X (%u times) -- aborting run\n", cur, streak); fflush(stderr); exit(3); }
         return;   /* don't spam the log on a tight retry loop */
     }
     last = cur; streak = 0;
@@ -279,13 +733,132 @@ extern "C" void ps3_indirect_call(ppu_context* ctx)
           GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS|GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,(LPCSTR)ra,&m);
           fprintf(stderr, "      host_ra=%p rva=0x%llX (llvm-symbolizer --obj=ydkj_boot.exe)\n",
                 ra, (unsigned long long)((uintptr_t)ra-(uintptr_t)m)); }
-        fprintf(stderr, "      lr=0x%08X r2=0x%08X r3=0x%08X r11=0x%08X r12=0x%08X\n",
-                (uint32_t)ctx->lr, (uint32_t)ctx->gpr[2], (uint32_t)ctx->gpr[3],
+        { void* bt[32]; unsigned short fr=RtlCaptureStackBackTrace(0,32,bt,0);
+          char* mb=(char*)GetModuleHandleA(0); char line[900]; int p=snprintf(line,sizeof line,"      UNRES-bt rva:");
+          for(int i=0;i<fr;i++) p+=snprintf(line+p,sizeof(line)-p," %llX",(unsigned long long)((char*)bt[i]-mb));
+          fprintf(stderr,"%s\n",line);
+          /* Resolve each backtrace host address to the guest func_00XXXXXX that
+           * contains it: find the function_table entry whose host pointer is the
+           * largest one <= the frame address. No debug symbols needed. */
+          char gl[900]; int gp=snprintf(gl,sizeof gl,"      UNRES-guest:");
+          for(int i=0;i<fr && i<8;i++){
+              uintptr_t tgt=(uintptr_t)bt[i]; uint32_t bestGuest=0; uintptr_t bestHost=0;
+              for(uint64_t k=0;k<function_table_count;k++){
+                  uintptr_t h=(uintptr_t)function_table[k].func;
+                  if(h<=tgt && h>bestHost){ bestHost=h; bestGuest=function_table[k].addr; }
+              }
+              if(bestGuest) gp+=snprintf(gl+gp,sizeof(gl)-gp," func_%08X+0x%llX",bestGuest,(unsigned long long)(tgt-bestHost));
+              else gp+=snprintf(gl+gp,sizeof(gl)-gp," ?");
+          }
+          fprintf(stderr,"%s\n",gl); }
+        fprintf(stderr, "      cia=0x%08X lr=0x%08X r2=0x%08X r3=0x%08X r11=0x%08X r12=0x%08X\n",
+                (uint32_t)ctx->cia, (uint32_t)ctx->lr, (uint32_t)ctx->gpr[2], (uint32_t)ctx->gpr[3],
                 (uint32_t)ctx->gpr[11], (uint32_t)ctx->gpr[12]);
         for (int r = 0; r < 32; r += 8)
             fprintf(stderr, "      r%-2d: %08X %08X %08X %08X %08X %08X %08X %08X\n", r,
                 (uint32_t)ctx->gpr[r+0],(uint32_t)ctx->gpr[r+1],(uint32_t)ctx->gpr[r+2],(uint32_t)ctx->gpr[r+3],
                 (uint32_t)ctx->gpr[r+4],(uint32_t)ctx->gpr[r+5],(uint32_t)ctx->gpr[r+6],(uint32_t)ctx->gpr[r+7]);
+        /* Walk the C++ vtable->OPD chain from the `this` pointer (r3) so we can
+         * see where each link points (heap object vs game image vs garbage) and
+         * pinpoint how the garbage code field (e.g. 0xC708C708) got there. */
+        if (vm_base) {
+            auto g32 = [](uint32_t ea)->uint32_t {
+                return __builtin_bswap32(*(volatile uint32_t*)(vm_base + ea));
+            };
+            uint32_t obj = (uint32_t)ctx->gpr[3];
+            uint32_t vt  = g32(obj);
+            uint32_t opd = g32(vt);
+            fprintf(stderr, "      CHAIN obj=%08X  *(obj)=vtable=%08X  *(vtable)[0]=opd=%08X  *(opd)=code=%08X  *(opd+4)=toc=%08X\n",
+                    obj, vt, opd, g32(opd), g32(opd + 4));
+            fprintf(stderr, "      obj[0..7]: %08X %08X %08X %08X %08X %08X %08X %08X\n",
+                    g32(obj+0),g32(obj+4),g32(obj+8),g32(obj+12),g32(obj+16),g32(obj+20),g32(obj+24),g32(obj+28));
+            fprintf(stderr, "      vtable[0..7]: %08X %08X %08X %08X %08X %08X %08X %08X\n",
+                    g32(vt+0),g32(vt+4),g32(vt+8),g32(vt+12),g32(vt+16),g32(vt+20),g32(vt+24),g32(vt+28));
+            /* Root-cause probe for the mis-constructed MI object: the singleton
+             * @0x542E60 and the .bss pool @0x587AC8 (func_00182DD8's allocator).
+             * If the pool is 0 the sub-object allocs fail -> base vtable -> this
+             * crash. Also show whether obj matches the singleton. */
+            fprintf(stderr, "      PROBE singleton[0x542E60]=%08X  pool[0x587AC8]=%08X  poolstruct[0x587A00..]=%08X %08X %08X\n",
+                    g32(0x542E60), g32(0x587AC8), g32(0x587A00), g32(0x587AC0), g32(0x587AC4));
+            /* Guest-stack backtrace: the host RtlCaptureStackBackTrace mis-resolves
+             * lifted frames (small helpers alias earlier symbols). Walk the PPC
+             * back-chain (sp=[sp]) and resolve each saved LR ([frame+0x10]) against
+             * the guest function_table -- guest addresses are reliable. This pins
+             * the real caller that made the 0xC708C708 virtual call. */
+            {
+                uint32_t sp = (uint32_t)ctx->gpr[1];
+                /* Raw stack dump (16 words) so we can see the frame layout. */
+                { char rd[500]; int rp = snprintf(rd, sizeof rd, "      STACK@%08X:", sp);
+                  for (int i = 0; i < 16 && sp + i*4 < 0x10000000u; i++)
+                      rp += snprintf(rd+rp, sizeof(rd)-rp, " %08X", g32(sp + i*4));
+                  fprintf(stderr, "%s\n", rd); }
+                /* Scan the stack for saved return addresses: any word that lands
+                 * INSIDE a lifted function (addr > func start, i.e. a call site,
+                 * not a data/vtable pointer to a func start). Reliable w/o a valid
+                 * back-chain -- finds the real caller chain to the 0xC708C708 vcall. */
+                char gb[1400]; int gp = snprintf(gb, sizeof gb, "      GUEST-STACK(scan):");
+                uint32_t last = 0;
+                for (int i = 0; i < 700 && gp < 1300; i++) {
+                    uint32_t w = g32(sp + i*4);
+                    if (w < 0x10000 || w >= 0x600000) continue;
+                    uint32_t bg = 0;
+                    for (uint64_t k = 0; k < function_table_count; k++) {
+                        uint32_t a = function_table[k].addr;
+                        if (a <= w && a > bg) bg = a;
+                    }
+                    /* offset>0 (interior = return addr) and modest (<0x4000) */
+                    if (bg && (w - bg) > 0 && (w - bg) < 0x4000 && w != last) {
+                        gp += snprintf(gb+gp, sizeof(gb)-gp, " %08X:func_%08X+0x%X", sp+i*4, bg, w - bg);
+                        last = w;
+                    }
+                }
+                fprintf(stderr, "%s\n", gb);
+                /* Find which GPR held the OPD pointer: the crashing vcall did
+                 * r0=[rN]; ctr=r0, so some gpr[k] satisfies [gpr[k]]==ctr. That
+                 * pins the exact garbage descriptor address + lets us see the
+                 * structure it lives in (heap object? vtable slot? which one). */
+                uint32_t bad = (uint32_t)ctx->ctr;
+                for (int k = 0; k < 32; k++) {
+                    uint32_t rk = (uint32_t)ctx->gpr[k];
+                    if (rk < 0x8000 || rk >= 0x10000000u) continue;
+                    /* scan a window around the register for the garbage word:
+                     * catches r0=[rX+imm] loads (the vcall's OPD-ptr source). */
+                    for (int off = -0x40; off < 0x200; off += 4) {
+                        uint32_t a = rk + off;
+                        if (a < 0x8000 || a >= 0x10000000u) continue;
+                        if (g32(a) == bad) {
+                            fprintf(stderr, "      BADWORD @0x%08X = 0x%08X  (r%d=0x%08X %+d)\n",
+                                    a, bad, k, rk, off);
+                            char sd[520]; int sp2=snprintf(sd,sizeof sd,"      CTX@%08X-0x20:",a);
+                            for (int i=-8;i<16;i++) sp2+=snprintf(sd+sp2,sizeof(sd)-sp2," %08X",g32(a+i*4));
+                            fprintf(stderr,"%s\n",sd);
+                            off = 0x200;  /* one hit per register is enough */
+                        }
+                    }
+                }
+                /* One-shot full-RAM scan: find EVERY guest address holding the
+                 * garbage value -> pinpoints where the leaked (truncated host)
+                 * pointer is stored, so we can identify the struct + leaky HLE. */
+                { static int once = 0; if (!once) { once = 1;
+                    /* scan main RAM + the 0x40000000 object-heap region (where the
+                     * crash 'this'=0x400240A8 lives) + the 0x30000000 libsre region. */
+                    const uint32_t ranges[][2] = {
+                        {0x00010000u, 0x0FF00000u}, {0x30000000u, 0x30200000u},
+                        {0x40000000u, 0x40400000u}, {0x0F800000u, 0x10000000u} };
+                    char ram[1400]; int rp = snprintf(ram, sizeof ram, "      RAMSCAN 0x%08X at:", bad);
+                    int hits = 0;
+                    for (int R = 0; R < 4 && rp < 1300; R++)
+                        for (uint32_t a = ranges[R][0]; a < ranges[R][1] && rp < 1300; a += 4) {
+                            if (g32(a) == bad) {
+                                rp += snprintf(ram+rp, sizeof(ram)-rp, " %08X", a);
+                                if (++hits >= 60) { R = 4; break; }
+                            }
+                        }
+                    rp += snprintf(ram+rp, sizeof(ram)-rp, "  (total=%d)", hits);
+                    fprintf(stderr, "%s\n", ram);
+                } }
+            }
+        }
     }
 }
 
@@ -316,6 +889,30 @@ extern "C" void lv2_syscall(ppu_context* ctx)
         fprintf(stderr, "[sc] %llu r3=%08X r4=%08X r5=%08X r6=%08X\n",
                 (unsigned long long)num, (uint32_t)ctx->gpr[3], (uint32_t)ctx->gpr[4],
                 (uint32_t)ctx->gpr[5], (uint32_t)ctx->gpr[6]);
+    /* FLOW_WORKERSC: trace every lv2 syscall made by the loader/worker thread
+     * (tid=1) so we can see what it does AFTER receiving its q=1 event and why
+     * it never registers handlers / loads assets. */
+    { static int64_t ws=-2; if(ws==-2){ws=getenv("FLOW_WORKERSC")?1:0;}
+      if(ws && ctx->thread_id==1){ static int _n=0; if(_n++<60)
+        fprintf(stderr,"[WORKERSC tid1 #%d] syscall %llu r3=%08X r4=%08X r5=%08X r6=%08X\n",
+          _n,(unsigned long long)num,(uint32_t)ctx->gpr[3],(uint32_t)ctx->gpr[4],(uint32_t)ctx->gpr[5],(uint32_t)ctx->gpr[6]); } }
+    /* One-shot: resolve the guest function that makes the flag=100 spin syscall
+     * (num=141 r3=0x64), so we can inspect its lifted arg setup (is mode=garbage a
+     * lift bug or a real uninit-object field?). */
+    if (num==141 && (uint32_t)ctx->gpr[3]==0x64) { static int _s=0; if(_s++<3){
+        void* ra=__builtin_return_address(0); char* mb=(char*)GetModuleHandleA(0);
+        uintptr_t tgt=(uintptr_t)ra; uint32_t bg=0; uintptr_t bh=0;
+        for(uint64_t k=0;k<function_table_count;k++){ uintptr_t h=(uintptr_t)function_table[k].func; if(h<=tgt&&h>bh){bh=h;bg=function_table[k].addr;} }
+        fprintf(stderr,"[sc-caller] flag=100 syscall from func_%08X+0x%llX (r5/mode=0x%08X r7/timeout=0x%08X lr=0x%08X)\n",
+                bg,(unsigned long long)(tgt-bh),(uint32_t)ctx->gpr[5],(uint32_t)ctx->gpr[7],(uint32_t)ctx->lr); } }
+    /* Trace the port_send(port=1) sender (the cri kick): who sends it + the data
+     * (data=0 seen -> is the decode-job payload null? a real uninit field?). */
+    if (num==138 && (uint32_t)ctx->gpr[3]==1) { static int _s=0; if(_s++<4){
+        void* ra=__builtin_return_address(0); char* mb=(char*)GetModuleHandleA(0);
+        uintptr_t tgt=(uintptr_t)ra; uint32_t bg=0; uintptr_t bh=0;
+        for(uint64_t k=0;k<function_table_count;k++){ uintptr_t h=(uintptr_t)function_table[k].func; if(h<=tgt&&h>bh){bh=h;bg=function_table[k].addr;} }
+        fprintf(stderr,"[sc-caller] port_send(port=1) from func_%08X+0x%llX data=0x%08X/0x%08X/0x%08X\n",
+                bg,(unsigned long long)(tgt-bh),(uint32_t)ctx->gpr[4],(uint32_t)ctx->gpr[5],(uint32_t)ctx->gpr[6]); } }
     switch (num) {
     case 352: {   /* sys_memory_get_user_memory_size(sys_memory_info_t* info)
                    * info = { u32 total_user_memory; u32 available_user_memory } */
@@ -353,6 +950,23 @@ extern "C" void lv2_syscall(ppu_context* ctx)
             wlen = 0x4000u;
         }
         FILE* out = stdout;   /* keep all TTY on stdout, clean of [ppu] logs */
+        /* DIAGNOSTIC (FLOW_PSSGTRACE=1): when the title's tty output carries a
+         * PhyreEngine init-failure fragment, dump the HOST backtrace (RVAs vs
+         * the exe base) so we can map the error-reporter's call chain through
+         * build_boot/flow.map and locate the failing function. */
+        if (getenv("FLOW_PSSGTRACE") && vm_base && wlen < 256) {
+            char t[260]; uint32_t n = wlen < 255 ? wlen : 255;
+            for (uint32_t i = 0; i < n; i++) t[i] = (char)vm_read8(buf + i);
+            t[n] = 0;
+            if (strstr(t,"PSSG")||strstr(t,"Init")||strstr(t,"App")||strstr(t,"rror")||strstr(t,"ail")) {
+                void* bt[20]; unsigned short fr = RtlCaptureStackBackTrace(0, 20, bt, 0);
+                char* mb = (char*)GetModuleHandleA(0);
+                char line[512]; int p = snprintf(line, sizeof line, "[pssg-bt] \"%.30s\" rva:", t);
+                for (int i = 0; i < fr; i++)
+                    p += snprintf(line+p, sizeof(line)-p, " %llX", (unsigned long long)((char*)bt[i]-mb));
+                fprintf(stderr, "%s\n", line); fflush(stderr);
+            }
+        }
         for (uint32_t i = 0; i < wlen; i++) {
             if (ppu_vm_size && buf + i >= ppu_vm_size) break;
             fputc(vm_read8(buf + i), out);
@@ -367,8 +981,35 @@ extern "C" void lv2_syscall(ppu_context* ctx)
          * rwlock / event / timer / memory / vm / fs / spu). Initialised by
          * lv2_init_syscalls() at boot. Unregistered numbers fall through to the
          * return-0 stub below (which is what got the CRT this far). */
-        if (lv2_try_syscall(ctx))
-            return;
+        if (getenv("YDKJ_BLOCKTRACE")) {
+            static ULONGLONG s_acc[1024]={0}; static uint32_t s_cnt[1024]={0}; static ULONGLONG s_win=0;
+            uint32_t _a3=(uint32_t)ctx->gpr[3], _a4=(uint32_t)ctx->gpr[4], _a5=(uint32_t)ctx->gpr[5];
+            ULONGLONG _t0 = GetTickCount64();
+            int _ok = lv2_try_syscall(ctx);
+            ULONGLONG _dt = GetTickCount64() - _t0;
+            uint32_t _rv=(uint32_t)ctx->gpr[3];
+            if (num < 1024) { s_acc[num]+=_dt; s_cnt[num]++; }
+            if (_dt >= 150 || (num==130 && _dt >= 8)) {
+                static int _bn=0; if (_bn++ < 40) {
+                void* ra=__builtin_return_address(0);
+                uintptr_t tgt=(uintptr_t)ra; uint32_t bg=0; uintptr_t bh=0;
+                for(uint64_t k=0;k<function_table_count;k++){ uintptr_t h=(uintptr_t)function_table[k].func; if(h<=tgt&&h>bh){bh=h;bg=function_table[k].addr;} }
+                fprintf(stderr,"[BLOCK] syscall %llu blocked %llums  caller=func_%08X+0x%llX  queue=%08X evbuf=%08X timeout=%08X -> ret=%08X tid=%u\n",
+                    (unsigned long long)num,(unsigned long long)_dt,bg,(unsigned long long)(tgt-bh),
+                    _a3,_a4,_a5,_rv,(unsigned)ctx->thread_id);
+                }
+            }
+            if (s_win==0) s_win=_t0;
+            if (_t0 - s_win >= 2000) {
+                for (int n=0;n<1024;n++) if (s_acc[n]>=300)
+                    fprintf(stderr,"[BLOCKSUM] syscall %d: %llums total over %u calls (last 2s)\n",n,(unsigned long long)s_acc[n],s_cnt[n]);
+                for (int n=0;n<1024;n++){s_acc[n]=0;s_cnt[n]=0;} s_win=_t0;
+            }
+            if (_ok) return;
+        } else {
+            if (lv2_try_syscall(ctx))
+                return;
+        }
         static int logged = 0;
         if (logged < 30) {
             fprintf(stderr, "[ppu] lv2_syscall %llu (stub)\n", (unsigned long long)num);
@@ -496,6 +1137,22 @@ static void ppu_thread_entry_trampoline(ppu_context* ctx)
  * stack, and return r3. Used by the HLE runtime to deliver callbacks into
  * recompiled code (cellSysutil events, GCM vblank/flip handlers, ...) -- the
  * mechanism behind g_ps3_guest_caller (ps3emu/guest_call.h). */
+/* OPD fixups: some title OPDs (the GCM flip/vblank handlers at 0x530D70/78/80)
+ * have their code word clobbered in guest memory at runtime (read back as the TOC
+ * base 0x544370). A lib captures the real {code,toc} at registration and records
+ * it here so ppu_guest_call resolves the clobbered OPD to the real handler. */
+struct PpuOpdFixup { uint32_t opd, code, toc; };
+static PpuOpdFixup s_opd_fixups[16];
+static int s_opd_fixup_n = 0;
+extern "C" void ppu_register_opd_fixup(uint32_t opd, uint32_t code, uint32_t toc)
+{
+    if (!opd || !code) return;
+    for (int i = 0; i < s_opd_fixup_n; i++)
+        if (s_opd_fixups[i].opd == opd) { s_opd_fixups[i].code = code; s_opd_fixups[i].toc = toc; return; }
+    if (s_opd_fixup_n < 16) { s_opd_fixups[s_opd_fixup_n].opd = opd;
+        s_opd_fixups[s_opd_fixup_n].code = code; s_opd_fixups[s_opd_fixup_n].toc = toc; s_opd_fixup_n++; }
+}
+
 extern "C" uint64_t ppu_guest_call(uint32_t opd_addr,
                                    uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3)
 {
@@ -503,6 +1160,12 @@ extern "C" uint64_t ppu_guest_call(uint32_t opd_addr,
     uint32_t code = 0, toc = 0;
     ppu_opd_resolve(opd_addr, &code, &toc);
     ppu_fn fn = ppu_lookup(code);
+    if (!fn) {  /* OPD code clobbered? fall back to a captured fixup */
+        for (int i = 0; i < s_opd_fixup_n; i++)
+            if (s_opd_fixups[i].opd == opd_addr) {
+                code = s_opd_fixups[i].code; toc = s_opd_fixups[i].toc;
+                fn = ppu_lookup(code); break; }
+    }
     if (!fn) { fprintf(stderr, "[ppu] guest_call: OPD 0x%08X -> code 0x%08X not registered\n",
                        opd_addr, code); return 0; }
 
@@ -574,6 +1237,37 @@ extern "C" int ppu_run(uint32_t entry_opd, uint32_t stack_top)
             memset(vm_base + PPU_TLS_IMG + g_tls_filesz, 0, g_tls_memsz - g_tls_filesz);
         ctx.gpr[13] = PPU_TLS_TP;
         fprintf(stderr, "[ppu] TLS image 0x%08X (r13/TP=0x%08X)\n", PPU_TLS_IMG, PPU_TLS_TP);
+    }
+    /* Guest command line (argc/argv). The PS3 LV2 loader passes argv[0] = the boot
+     * path; ppu_run previously left r3/r4 zeroed, so the guest read a garbage argv[0]
+     * and echoed/parsed it ("Command Line: frequencyDividerOperation" = a stray
+     * pointer into the .rodata string table), corrupting init. Provide a valid argv. */
+    {
+        /* argv[0] MUST match the real disc path — the game's boot sequencer
+         * (func @~0x61e00) strncmp's argv[0] against "/dev_bdvd" and branches
+         * (disc vs hdd). RPCS3 oracle: real argv[0]=/dev_bdvd/PS3_GAME/USRDIR/EBOOT.BIN.
+         * The old /dev_hdd0/NPUA80001 (another game's id) failed the compare ->
+         * wrong boot branch -> init divergence/deadlock. $YDKJ_BOOTPATH overrides. */
+        const char* boot_path = getenv("YDKJ_BOOTPATH");
+        if (!boot_path || !*boot_path) boot_path = "/dev_bdvd/PS3_GAME/USRDIR/EBOOT.BIN";
+        uint32_t argv_base = 0x00B00000u;          /* scratch in the .data/heap gap */
+        uint32_t str_addr  = argv_base + 0x20u;     /* strings after the ptr slots */
+        uint32_t i = 0; for (; boot_path[i]; i++) vm_write8(str_addr + i, (uint8_t)boot_path[i]);
+        vm_write8(str_addr + i, 0);
+        /* The game's CRT (func_0005EDFC) reads argv as 64-bit BE pointers at
+         * [argv+4+i*8] (the LOW word of each 8-byte slot). Writing the ptr at +0
+         * left the CRT reading 0 at +4 -> null argv[0] -> boot-device check saw ""
+         * -> data.toc never loaded -> deadlock. Put the ptr in the LOW word (+4). */
+        vm_write32(argv_base + 0, 0);               /* argv[0] hi word          */
+        vm_write32(argv_base + 4, str_addr);        /* argv[0] lo word -> path   */
+        vm_write32(argv_base + 8, 0);               /* argv[1] hi (NULL)         */
+        vm_write32(argv_base + 12, 0);              /* argv[1] lo (NULL)         */
+        ctx.gpr[3] = 1;                             /* argc                     */
+        ctx.gpr[4] = argv_base;                     /* argv                     */
+        /* read back to confirm the write landed (demand-commit can drop writes) */
+        char rb[48]; for (uint32_t k=0;k<47;k++){ rb[k]=(char)vm_base[str_addr+k]; if(!rb[k])break; } rb[47]=0;
+        fprintf(stderr, "[ppu] argv: argc=1 argv[0]@0x%08X readback=\"%s\"  [argv_base]=0x%08X\n",
+                str_addr, rb, __builtin_bswap32(*(uint32_t*)(vm_base+argv_base)));
     }
     fprintf(stderr, "[ppu] run: code 0x%08X, toc 0x%08X, sp 0x%08X\n", code, toc, stack_top);
     g_active_ctx = &ctx;

--- a/runtime/ppu/ppu_sysprx.cpp
+++ b/runtime/ppu/ppu_sysprx.cpp
@@ -226,9 +226,25 @@ static void hle_cellGcmInitBody(ppu_context* ctx)
     ctx->gpr[3] = 0;   /* CELL_OK */
 }
 
+/* FIFO command-buffer-full callback: the title's inline gcmReserve calls
+ * context->callback(context, count) when the ring's `current` nears `end`.
+ * cellGcmSetupContext points that callback OPD at GCM_FIFO_CALLBACK_SENTINEL_EA;
+ * registering that EA here routes the indirect call into the ring recycle so the
+ * FIFO recycles on wrap instead of wedging on a null callback (which deref'd
+ * guest page 0 -> the 0xC708C708 poison vcall).  (via sagemono's fork) */
+#define GCM_FIFO_CALLBACK_SENTINEL_EA 0x03002F00u
+extern "C" void cellGcm_fifo_recycle(unsigned int ctx_ea);
+extern "C" void ppu_register_function(uint64_t addr, void (*fn)(ppu_context*));
+static void hle_gcm_callback(ppu_context* ctx)
+{
+    cellGcm_fifo_recycle((unsigned int)ctx->gpr[3]);   /* r3 = context EA */
+    ctx->gpr[3] = 0;                                   /* CELL_OK */
+}
+
 extern "C" void ppu_sysprx_register(void)
 {
     ps3_hle_register_ctx(0x15BAE46Bu, "_cellGcmInitBody", hle_cellGcmInitBody);
+    ppu_register_function(GCM_FIFO_CALLBACK_SENTINEL_EA, hle_gcm_callback);
     ps3_hle_register_ctx(ps3_compute_nid("sys_initialize_tls"),       "sys_initialize_tls",       sys_initialize_tls);
     ps3_hle_register_ctx(ps3_compute_nid("sys_time_get_system_time"), "sys_time_get_system_time", sys_time_get_system_time);
     ps3_hle_register_ctx(ps3_compute_nid("sys_process_is_stack"),     "sys_process_is_stack",     sys_process_is_stack);

--- a/runtime/ppu/ppu_sysprx.cpp
+++ b/runtime/ppu/ppu_sysprx.cpp
@@ -14,6 +14,7 @@
 #include "ps3emu/nid.h"     /* ps3_compute_nid */
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 extern "C" uint8_t* vm_base;
@@ -147,12 +148,30 @@ static void sys_ppu_thread_get_id(ppu_context* ctx)
 /* sys_mmapper_allocate_memory(u32 size, u64 flags, vm::ptr<u32> mem_id) ->
  * hand back a unique opaque id; the backing is the flat VM, so the later
  * search_and_map just needs a non-zero id to track. */
+static uint32_t s_mmapper_next_id = 0x1000;
 static void sys_mmapper_allocate_memory(ppu_context* ctx)
 {
-    static uint32_t s_next_id = 0x1000;
+    uint32_t size = (uint32_t)ctx->gpr[3];
     uint32_t mem_id_ptr = (uint32_t)ctx->gpr[5];
-    if (mem_id_ptr) vm_write32(mem_id_ptr, s_next_id);
-    s_next_id++;
+    if (getenv("FLOW_MEMTRACE"))
+        fprintf(stderr, "[mmapper] allocate_memory(size=0x%X flags=0x%llX id_ptr=0x%X) -> id 0x%X\n",
+                size, (unsigned long long)ctx->gpr[4], mem_id_ptr, s_mmapper_next_id);
+    if (mem_id_ptr) vm_write32(mem_id_ptr, s_mmapper_next_id);
+    s_mmapper_next_id++;
+    ctx->gpr[3] = 0;
+}
+/* sys_mmapper_allocate_memory_from_container(u32 size, u32 container, u64 flags,
+ * vm::ptr<u32> mem_id) -> id in *r6. flОw's CRT uses this for its heap/mutex pool;
+ * it was previously UNregistered (CRT saw failure -> "not enough memory"). */
+static void sys_mmapper_allocate_memory_from_container(ppu_context* ctx)
+{
+    uint32_t size = (uint32_t)ctx->gpr[3];
+    uint32_t mem_id_ptr = (uint32_t)ctx->gpr[6];
+    if (getenv("FLOW_MEMTRACE"))
+        fprintf(stderr, "[mmapper] alloc_from_container(size=0x%X cid=0x%X flags=0x%llX id_ptr=0x%X) -> id 0x%X\n",
+                size, (uint32_t)ctx->gpr[4], (unsigned long long)ctx->gpr[5], mem_id_ptr, s_mmapper_next_id);
+    if (mem_id_ptr) vm_write32(mem_id_ptr, s_mmapper_next_id);
+    s_mmapper_next_id++;
     ctx->gpr[3] = 0;
 }
 
@@ -237,6 +256,7 @@ extern "C" void ppu_sysprx_register(void)
     ps3_hle_register_ctx(ps3_compute_nid("sys_ppu_thread_create"),      "sys_ppu_thread_create",      hle_ppu_thread_create);
     ps3_hle_register_ctx(ps3_compute_nid("sys_ppu_thread_exit"),        "sys_ppu_thread_exit",        hle_ppu_thread_exit);
     ps3_hle_register_ctx(ps3_compute_nid("sys_mmapper_allocate_memory"), "sys_mmapper_allocate_memory", sys_mmapper_allocate_memory);
+    ps3_hle_register_ctx(ps3_compute_nid("sys_mmapper_allocate_memory_from_container"), "sys_mmapper_allocate_memory_from_container", sys_mmapper_allocate_memory_from_container);
     ps3_hle_register_ctx(ps3_compute_nid("sys_mmapper_map_memory"),     "sys_mmapper_map_memory",     crt_ok);
     ps3_hle_register_ctx(ps3_compute_nid("sys_mmapper_unmap_memory"),   "sys_mmapper_unmap_memory",   crt_ok);
     ps3_hle_register_ctx(ps3_compute_nid("sys_mmapper_free_memory"),    "sys_mmapper_free_memory",    crt_ok);

--- a/runtime/ppu/tests/boot_main.cpp
+++ b/runtime/ppu/tests/boot_main.cpp
@@ -167,14 +167,44 @@ static DWORD WINAPI vblank_ticker(LPVOID)
 {
     int rsx_ok = (rsx_d3d12_backend_init(1280, 720, "You Don't Know Jack (ps3recomp)") == 0);
     fprintf(stderr, "[rsx] backend init %s\n", rsx_ok ? "OK -- window open" : "FAILED");
+    /* The game's frame pacing (vblank/flip handlers -> display frame counter) must
+     * advance at ~60Hz regardless of how long present() blocks. On a hidden/occluded
+     * window DXGI Present throttles hard, which previously stalled these ticks and
+     * paced the game's main loop to ~0.5fps. Drive the ticks off REAL elapsed time
+     * and catch up in a bounded burst so present latency never slows the game. */
+    ULONGLONG next_tick = GetTickCount64();
     for (;;) {
-        Sleep(16);            /* ~60 Hz */
-        cellGcmTickVBlank();
-        cellGcmTickFlip();
+        Sleep(4);
+        ULONGLONG now = GetTickCount64();
+        int fired = 0;
+        while ((long long)(now - next_tick) >= 0 && fired < 240) {
+            cellGcmTickVBlank();
+            cellGcmTickFlip();
+            /* Drain the game's GCM FIFO every tick -- this writes the RSX sync-fence
+             * labels (e.g. @0x03000410) that the game's per-frame logic blocks on.
+             * Doing it here (not after present) keeps those fences advancing at 60Hz
+             * even when present() throttles on a hidden/occluded window. */
+            if (rsx_ok) cellGcm_rsx_process_fifo();
+            next_tick += 16;                 /* ~60 Hz */
+            fired++;
+        }
+        if (fired >= 240) next_tick = now;   /* fell too far behind -> resync */
         if (rsx_ok) {
             if (rsx_d3d12_backend_pump_messages() != 0) { rsx_ok = 0; }
-            cellGcm_rsx_process_fifo();      /* execute the game's GCM commands */
-            rsx_d3d12_backend_present();     /* present the frame */
+            if (getenv("YDKJ_PACETRACE")) {
+                static ULONGLONG s_win=0; static int s_pf=0, s_pres=0; static ULONGLONG s_presms=0;
+                s_pf += fired; s_pres++;
+                ULONGLONG t0=GetTickCount64(); rsx_d3d12_backend_present(); ULONGLONG t1=GetTickCount64();
+                s_presms += (t1-t0);
+                if (s_win==0) s_win=now;
+                if (now - s_win >= 1000) {
+                    fprintf(stderr,"[PACE] process_fifo=%d/s  present=%d/s  present_total=%llums/s (avg %llums)\n",
+                            s_pf, s_pres, s_presms, s_pres? s_presms/s_pres:0);
+                    s_pf=0; s_pres=0; s_presms=0; s_win=now;
+                }
+            } else {
+                rsx_d3d12_backend_present();     /* present (may block/throttle) */
+            }
         }
     }
     return 0;
@@ -215,12 +245,31 @@ static void dump_threads(const char* label, HMODULE self)
                     fprintf(stderr, "[WATCHDOG]   tid %5lu BOOT rip rva=0x%llX\n",
                             (unsigned long)te.th32ThreadID,
                             (unsigned long long)((char*)ctx.Rip - (char*)self));
-                    /* Scan the suspended thread's stack for boot-module return
-                     * addresses to reconstruct the call chain when there's no
-                     * OOB backtrace to lean on (some false positives expected). */
+                } else {
+                    char path[MAX_PATH] = "?";
+                    if (m) GetModuleFileNameA(m, path, sizeof path);
+                    const char* base = strrchr(path, '\\');
+                    fprintf(stderr, "[WATCHDOG]   tid %5lu in %s\n",
+                            (unsigned long)te.th32ThreadID, base ? base + 1 : path);
+                }
+                /* Scan the suspended thread's stack for boot-module return
+                 * addresses to reconstruct the lifted call chain — done for ALL
+                 * threads (even when RIP is parked in ntdll inside a CriticalSection
+                 * call), since that's exactly where the busy-spin's lwmutex churn
+                 * lands the main thread. Map RVAs -> func_ names via flow.map.
+                 * (some false positives expected — these are stack-scan hits.) */
+                {
                     uint64_t* sp = (uint64_t*)ctx.Rsp;
+                    /* Bound the scan to the committed stack region so we never read
+                     * past the guard page (VirtualQuery gives this region's end). */
+                    MEMORY_BASIC_INFORMATION mbi;
+                    uint64_t region_end = (uint64_t)sp + 0x8000;
+                    if (VirtualQuery((LPCVOID)sp, &mbi, sizeof mbi))
+                        region_end = (uint64_t)mbi.BaseAddress + mbi.RegionSize;
+                    int maxk = (int)((region_end - (uint64_t)sp) / 8);
+                    if (maxk > 0x20000 / 8) maxk = 0x20000 / 8;
                     int found = 0;
-                    for (int k = 0; k < 0x8000 / 8 && found < 16; k++) {
+                    for (int k = 0; k < maxk && found < 20; k++) {
                         uint64_t v = sp[k];
                         if (v < (uint64_t)self) continue;
                         HMODULE mm = NULL;
@@ -228,17 +277,12 @@ static void dump_threads(const char* label, HMODULE self)
                                            GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
                                            (LPCSTR)v, &mm);
                         if (mm == self) {
-                            fprintf(stderr, "[WATCHDOG]       ret rva=0x%llX\n",
+                            fprintf(stderr, "[WATCHDOG]       tid %5lu ret rva=0x%llX\n",
+                                    (unsigned long)te.th32ThreadID,
                                     (unsigned long long)(v - (uint64_t)self));
                             found++;
                         }
                     }
-                } else {
-                    char path[MAX_PATH] = "?";
-                    if (m) GetModuleFileNameA(m, path, sizeof path);
-                    const char* base = strrchr(path, '\\');
-                    fprintf(stderr, "[WATCHDOG]   tid %5lu in %s\n",
-                            (unsigned long)te.th32ThreadID, base ? base + 1 : path);
                 }
             }
             ResumeThread(th);
@@ -300,7 +344,20 @@ int main(int argc, char** argv)
     if (argc < 2) { printf("usage: %s <EBOOT.elf>\n", argv[0]); return 2; }
 
 #ifdef _WIN32
+#pragma comment(lib, "winmm.lib")
+    timeBeginPeriod(1);   /* 1ms timer resolution: the default ~15.6ms granularity
+                           * inflates every sub-15ms wait (the game's event polls,
+                           * usleeps) and throttled the whole title. */
     SetUnhandledExceptionFilter(ydkj_crash_filter);
+    AddVectoredExceptionHandler(0 /*last*/, [](EXCEPTION_POINTERS* ep)->LONG{
+        if (ep->ExceptionRecord->ExceptionCode == 0xC00000FDu /*STACK_OVERFLOW*/) {
+            fprintf(stderr,"\n[STACKOVERFLOW] infinite recursion detected; backtrace (RVAs):\n");
+            HMODULE mod=GetModuleHandleA(0); void* fr[62]; USHORT n=RtlCaptureStackBackTrace(0,62,fr,0);
+            for(USHORT i=0;i<n;i++) fprintf(stderr," %llX",(unsigned long long)((char*)fr[i]-(char*)mod));
+            fprintf(stderr,"\n"); fflush(stderr); ExitProcess(7);
+        }
+        return EXCEPTION_CONTINUE_SEARCH; });
+    { ULONG g=256*1024; SetThreadStackGuarantee(&g); }  /* reserve stack so the SO handler can run */
     signal(SIGABRT, ydkj_abort_handler);
     setvbuf(stdout, NULL, _IONBF, 0);   /* unbuffered: don't lose prints on kill */
 #endif
@@ -331,12 +388,17 @@ int main(int argc, char** argv)
     derive_vfs_root(argv[1]);
     printf("[boot] VFS root: %s\n", ppu_vfs_root);
 
+    fprintf(stderr,"[boot-dbg] before ppu_recomp_register\n"); fflush(stderr);
     ppu_recomp_register();   /* lifted function table -> address map */
+    fprintf(stderr,"[boot-dbg] after ppu_recomp_register; before ps3_load_prx_modules\n"); fflush(stderr);
     ps3_load_prx_modules();  /* real system PRX (libsre) -> guest RAM + exports */
+    fprintf(stderr,"[boot-dbg] after prx; before ppu_hle_init\n"); fflush(stderr);
     ppu_hle_init();          /* firmware import NID -> HLE handlers */
     ppu_sysprx_register();   /* boot-critical CRT (sys_initialize_tls, ...) */
     ppu_fs_register();       /* cellFs VFS over the real game directory */
+    fprintf(stderr,"[boot-dbg] before lv2_init_syscalls\n"); fflush(stderr);
     lv2_init_syscalls();     /* real lv2 syscall table (semaphore/memory/fs/...) */
+    fprintf(stderr,"[boot-dbg] after lv2_init_syscalls\n"); fflush(stderr);
 
     /* Install the guest-callback hook and start the synthetic RSX vblank driver
      * so the game's frame loop advances (it no-ops until the game registers its
@@ -348,6 +410,9 @@ int main(int argc, char** argv)
 #endif
 
     printf("\n[boot] dispatching entry OPD 0x%08X (stack top 0x%08X)\n\n", entry, STACK_TOP);
+#ifdef _WIN32
+    fprintf(stderr, "[boot] MAIN guest thread tid=%lu\n", (unsigned long)GetCurrentThreadId());
+#endif
     int rc = ppu_run(entry, STACK_TOP);
     printf("\n[boot] ppu_run returned %d (entry function unwound)\n", rc);
     return 0;

--- a/runtime/spu/spu_channels.c
+++ b/runtime/spu/spu_channels.c
@@ -15,6 +15,7 @@
 #include "spu_dma.h"
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <setjmp.h>
 #ifdef _WIN32
 #include <windows.h>
@@ -37,10 +38,58 @@ extern "C" {
 static SPU_TLS jmp_buf s_spu_halt_env;
 static SPU_TLS int     s_spu_halt_armed = 0;
 
+/* SPU->PPU outbound-mailbox delivery hook. The SPU writing WrOutMbox /
+ * WrOutIntrMbox must wake PPU code blocked on the SPURS event queue bound to
+ * the SPU thread group (e.g. cellSpursInitialize). lv2_register.c installs a
+ * handler that maps spu_group_id -> connected event queue and pushes an event.
+ * NULL until installed (plain SPU jobs with no PPU listener stay a no-op). */
+void (*g_spu_out_mbox_hook)(uint32_t group_id, uint32_t spu_id,
+                            int is_intr, uint32_t value) = 0;
+
 void spu_halt(spu_context* ctx)
 {
     (void)ctx;
     if (s_spu_halt_armed) { s_spu_halt_armed = 0; longjmp(s_spu_halt_env, 1); }
+}
+
+/* Diagnostic: dump the taskset-policy scheduler's working tables (LS 0x2700..)
+ * at func_00000E60 entry, to reverse why it computes "no runnable task". Env
+ * YDKJ_E60. Called from the lifted taskset policy. */
+void spu_dbg_e60(spu_context* ctx)
+{
+    static int s_e = -1; if (s_e < 0) s_e = getenv("YDKJ_E60") ? 1 : 0;
+    if (!s_e) return;
+    static int _d = 0; if (_d++ >= 6) return;
+    const uint8_t* L = ctx->ls;
+    #define RD(o) (((uint32_t)L[(o)]<<24)|((uint32_t)L[(o)+1]<<16)|((uint32_t)L[(o)+2]<<8)|L[(o)+3])
+    fprintf(stderr, "[E60] r20=%08X r24=%08X | run2700=%08X ready2710=%08X pend2720=%08X en2730=%08X sig2740=%08X wait2750=%08X x2770=%08X\n",
+            ctx->gpr[20]._u32[0], ctx->gpr[24]._u32[0],
+            RD(0x2700), RD(0x2710), RD(0x2720), RD(0x2730), RD(0x2740), RD(0x2750), RD(0x2770));
+    #undef RD
+    fflush(stderr);
+}
+
+/* SPU `stop` / stop-and-signal. A real SPU stop HALTS the core; the previous
+ * lifted emission only did `status=...; return;`, which unwound ONE frame and
+ * let the caller's service loop keep running -- so a SPURS policy doing
+ * stop-and-signal in a loop spun millions of times instead of yielding. Halt the
+ * host SPU thread (longjmp to spu_run_with_halt) so the job stops AT the stop,
+ * with ctx->status + the outbound mailbox value available for the dispatcher to
+ * service. Env YDKJ_STOP_NOHALT restores the old (looping) behavior for A/B. */
+void spu_stop(spu_context* ctx)
+{
+    /* A lifted `stop` sets status and RETURNS to its caller -- for a SPURS
+     * policy this is stop-and-signal: it returns up into the kernel/policy
+     * service loop, which continues (i.e. the SPU "resumes" past the stop). That
+     * resume-by-return behavior is correct; the previous spin was caused by the
+     * lack of (a) a PPU listener for the outbound mailbox and (b) mailbox
+     * backpressure -- both handled in the channel write path, not here. So by
+     * default DO NOT halt. Env YDKJ_STOP_HALT forces a hard halt (longjmp) for
+     * A/B experiments (it makes the kernel terminate, which the game restarts). */
+    static int s_halt = -1;
+    if (s_halt < 0) s_halt = getenv("YDKJ_STOP_HALT") ? 1 : 0;
+    ctx->status = SPU_STATUS_STOPPED_BY_STOP;
+    if (s_halt) spu_halt(ctx);
 }
 
 /* Run a lifted SPU entry with a halt landing pad. Returns 1 if the job halted
@@ -115,6 +164,60 @@ static int spu_mfc_atomic(spu_context* ctx, uint32_t cmd)
     uint8_t* ls  = &ctx->ls[lsa];
     uint8_t* mem = vm_base + ea;
 
+    { static int s_t = -1; if (s_t < 0) s_t = getenv("YDKJ_POLLTRACE") ? 1 : 0;
+      if (s_t) { static uint64_t s_n = 0; static uint32_t s_lastea = 0;
+        if ((++s_n % 2000000) == 0 || ea != s_lastea) {
+          if ((s_n % 2000000) == 0)
+            fprintf(stderr, "[atomcnt] %llu atomic ops; last cmd=0x%X ea=0x%08X\n",
+                    (unsigned long long)s_n, cmd, ea);
+          s_lastea = ea; } } }
+    { static int s_at = -1; if (s_at < 0) s_at = getenv("YDKJ_ATOMTRACE") ? 1 : 0;
+      if (s_at) { static int _a=0; if (_a++ < 40)
+        fprintf(stderr, "[atom] cmd=0x%02X ea=0x%08X (img=%d)\n", cmd, ea, ctx->image_id); } }
+    /* cri task (img22) atomic on the taskset: dump the loaded bitset line so we can
+     * see if the task reads MY taskset (0x4005E000) with my READY bit, or elsewhere. */
+    { static int s_ct=-1; if(s_ct<0) s_ct=getenv("YDKJ_ATOMTRACE")?1:0;
+      if(s_ct && ctx->image_id==22 && cmd==0xD0 && mfc_ea_range_committed(ea,16)) {
+        static int _c=0; if(_c++<24){
+          uint8_t* m=vm_base+ea;
+          #define BW(o) (((uint32_t)m[o]<<24)|((uint32_t)m[o+1]<<16)|((uint32_t)m[o+2]<<8)|m[o+3])
+          fprintf(stderr,"[cri-atom] GETLLAR ea=0x%08X line[0..0x30]: %08X %08X %08X %08X | %08X %08X %08X %08X | %08X %08X %08X %08X\n",
+            ea, BW(0),BW(4),BW(8),BW(0xC), BW(0x10),BW(0x14),BW(0x18),BW(0x1C), BW(0x20),BW(0x24),BW(0x28),BW(0x2C));
+          #undef BW
+        } } }
+    /* YDKJ_CRI_R4: dump the CellSpursTaskset bitsets when the policy atomically
+     * touches my taskset (0x0F000000), to watch the task-activation state machine
+     * (why task0 isn't selected+first-run). running@0 ready@0x10 pending@0x20
+     * enabled@0x30 signalled@0x40 waiting@0x50 (each 16B; word0 = MSB, task0=bit127). */
+    { static int s_td = -1; if (s_td < 0) s_td = (getenv("YDKJ_CRI_CHAIN") && getenv("YDKJ_ATOMTRACE")) ? 1 : 0;
+      if (s_td && ea >= 0x0F000000u && ea < 0x0F001900u) {
+        extern uint8_t* vm_base;
+        static int _t=0; if (vm_base && _t++ < 24) {
+            uint8_t* t = vm_base + 0x0F000000u;
+            #define TW(o) (((uint32_t)t[o]<<24)|((uint32_t)t[o+1]<<16)|((uint32_t)t[o+2]<<8)|t[o+3])
+            fprintf(stderr, "[tset] %s run=%08X rdy=%08X pnd=%08X ena=%08X sig=%08X wait=%08X | wid=%08X last=%02X\n",
+                    cmd==0xD0?"GET":cmd==0xB4?"PUT":"?", TW(0x00), TW(0x10), TW(0x20), TW(0x30), TW(0x40), TW(0x50), TW(0x74), t[0x73]);
+            #undef TW
+        }
+      } }
+
+    /* Guard atomic line ops against an uncommitted/garbage EA (e.g. a SPURS
+     * policy computing a lock-line address from an incomplete instance context).
+     * Same rationale as the DMA EA guard: a bad guest atomic must not segfault
+     * the host. GETLLAR returns a zeroed line (no reservation); PUTLLC fails. */
+    if (!mfc_ea_range_committed(ea, MFC_ATOMIC_LINE)) {
+        static int s_w = 0;
+        if (s_w++ < 16)
+            fprintf(stderr, "[spu-atomic] cmd=0x%X ea=0x%08X uncommitted -- skipped\n", cmd, ea);
+        if (cmd == MFC_GETLLAR_CMD) {
+            memset(ls, 0, MFC_ATOMIC_LINE);
+            ctx->resv_ea = ea; ctx->resv_valid = 0; ctx->atomic_stat = 0;
+        } else {
+            ctx->atomic_stat = 1;   /* PUTLLC failure (line "moved") */
+        }
+        return 1;
+    }
+
     switch (cmd) {
     case MFC_GETLLAR_CMD:
         resv_lock();
@@ -181,10 +284,22 @@ void spu_wrch(spu_context* ctx, uint32_t channel, u128 value)
     }
 
     switch (channel) {
-    case SPU_WrOutMbox:      spu_channel_write(&ctx->ch_out_mbox, v);       break;
-    case SPU_WrOutIntrMbox:  spu_channel_write(&ctx->ch_out_intr_mbox, v);  break;
+    case SPU_WrOutMbox:
+        spu_channel_write(&ctx->ch_out_mbox, v);
+        { static int s_t = -1; if (s_t < 0) s_t = getenv("YDKJ_MBOXTRACE") ? 1 : 0;
+          if (s_t) fprintf(stderr, "[spu-mbox] OUT  grp=0x%X spu=0x%X val=0x%08X\n",
+                           ctx->spu_group_id, ctx->spu_id, v); }
+        if (g_spu_out_mbox_hook) g_spu_out_mbox_hook(ctx->spu_group_id, ctx->spu_id, 0, v);
+        break;
+    case SPU_WrOutIntrMbox:
+        spu_channel_write(&ctx->ch_out_intr_mbox, v);
+        { static int s_t = -1; if (s_t < 0) s_t = getenv("YDKJ_MBOXTRACE") ? 1 : 0;
+          if (s_t) fprintf(stderr, "[spu-mbox] INTR grp=0x%X spu=0x%X val=0x%08X\n",
+                           ctx->spu_group_id, ctx->spu_id, v); }
+        if (g_spu_out_mbox_hook) g_spu_out_mbox_hook(ctx->spu_group_id, ctx->spu_id, 1, v);
+        break;
     case SPU_WrDec:          ctx->decrementer = v;                          break;
-    case SPU_WrEventMask:    ctx->event_mask = v;                           break;
+    case SPU_WrEventMask:    ctx->event_mask = v;                           break; /* WrEventMask */
     case SPU_WrEventAck:     ctx->event_status &= ~v;                       break;
     case SPU_WrSRR0:         ctx->srr0 = v;                                 break;
     default:
@@ -199,6 +314,18 @@ void spu_wrch(spu_context* ctx, uint32_t channel, u128 value)
 u128 spu_rdch(spu_context* ctx, uint32_t channel)
 {
     uint32_t v = 0;
+
+    { static int s_t = -1; if (s_t < 0) s_t = getenv("YDKJ_POLLTRACE") ? 1 : 0;
+      if (s_t) { static uint64_t s_c[10] = {0}; static uint64_t s_tot = 0;
+        int b = (channel==SPU_RdInMbox)?0:(channel==SPU_RdSigNotify1)?1:(channel==SPU_RdSigNotify2)?2:
+                (channel==SPU_RdDec)?3:(channel==SPU_RdEventStat)?4:(channel==SPU_RdEventMask)?5:
+                (channel==MFC_RdTagStat)?6:(channel==MFC_RdAtomicStat)?7:(channel==SPU_RdMachStat)?8:9;
+        s_c[b]++;
+        if ((++s_tot % 2000000) == 0)
+          fprintf(stderr, "[rdch] InMbox=%llu Sig1=%llu Sig2=%llu Dec=%llu EvStat=%llu EvMask=%llu TagStat=%llu AtomStat=%llu MachStat=%llu other=%llu\n",
+            (unsigned long long)s_c[0],(unsigned long long)s_c[1],(unsigned long long)s_c[2],(unsigned long long)s_c[3],
+            (unsigned long long)s_c[4],(unsigned long long)s_c[5],(unsigned long long)s_c[6],(unsigned long long)s_c[7],
+            (unsigned long long)s_c[8],(unsigned long long)s_c[9]); } }
 
     if (channel_is_mfc(channel)) {
         v = mfc_channel_read(mfc_for(ctx), ctx, channel);
@@ -226,6 +353,17 @@ u128 spu_rdch(spu_context* ctx, uint32_t channel)
  * ===========================================================================*/
 uint32_t spu_rchcnt(spu_context* ctx, uint32_t channel)
 {
+    { static int s_t = -1; if (s_t < 0) s_t = getenv("YDKJ_POLLTRACE") ? 1 : 0;
+      if (s_t) { static uint64_t s_cnt[8] = {0}; static uint64_t s_total = 0;
+        int b = (channel==SPU_RdInMbox)?0:(channel==SPU_RdEventStat)?1:(channel==SPU_RdSigNotify1)?2:
+                (channel==SPU_RdSigNotify2)?3:(channel==MFC_RdTagStat)?4:(channel==SPU_WrOutMbox)?5:
+                (channel==SPU_WrOutIntrMbox)?6:7;
+        s_cnt[b]++;
+        if ((++s_total % 2000000) == 0)
+          fprintf(stderr, "[pollcnt] InMbox=%llu EvStat=%llu Sig1=%llu Sig2=%llu TagStat=%llu OutMbox=%llu OutIntr=%llu other=%llu (ch last=%u)\n",
+                  (unsigned long long)s_cnt[0],(unsigned long long)s_cnt[1],(unsigned long long)s_cnt[2],
+                  (unsigned long long)s_cnt[3],(unsigned long long)s_cnt[4],(unsigned long long)s_cnt[5],
+                  (unsigned long long)s_cnt[6],(unsigned long long)s_cnt[7], channel); } }
     switch (channel) {
     case SPU_RdInMbox:       return ctx->ch_in_mbox.count;                 /* readable */
     case SPU_WrOutMbox:      return SPU_MBOX_DEPTH - ctx->ch_out_mbox.count; /* free slots */
@@ -282,13 +420,105 @@ static spu_fn spu_lookup(uint32_t addr, int image_id)
     return NULL;
 }
 
+/* HLE of the taskset Policy Module's task-syscall entry (LS 0xA70). A SPURS task
+ * (e.g. the cri_mpv task, image 22) reads syscallAddr from its SpursTasksetContext
+ * (LS 0x27C4) and branches to it to perform a task syscall (EXIT/YIELD/WAIT/POLL).
+ * The real kernel has the PM code resident at 0xA70; we don't, so we plant 0xA70 as
+ * syscallAddr (in the cri dispatch) and INTERCEPT a branch to it here to HLE the
+ * syscall. num = r3&0xF (0x10 bit = the "2" variant), args in r4. Adopted from the
+ * JonathanDC64/ps3recomp fork (aaea4158) which uses this to run SPURS tasks clean. */
+#define YDKJ_TASKSET_PM_SYSCALL_ADDR 0xA70u
+static void spu_spurs_taskset_syscall(spu_context* ctx)
+{
+    uint32_t raw = ctx->gpr[3]._u32[0];
+    uint32_t num = raw & 0x0F;
+    { static int _n = 0; if (_n++ < 24)
+        fprintf(stderr, "[spu] SPURS taskset syscall num=%u (raw=0x%X args=0x%08X) image=%d link/r0=0x%05X\n",
+                num, raw, ctx->gpr[4]._u32[0], ctx->image_id, ctx->gpr[0]._u32[0] & SPU_LS_MASK); }
+    /* NOTE (YDKJ cri_mpv): the cri task's BOOTSTRAP (func_00003040) calls the
+     * task-API syscall and EXPECTS IT TO RETURN, then branches to the real task
+     * entry (0x3050). Halting on num=0 here kills the task at bootstrap before it
+     * runs. So for image 22 we DON'T halt on num=0 -- we return so the bootstrap
+     * continues to the decode entry. (A genuine end-of-task EXIT would re-enter and
+     * spin; if that happens, gate a real halt after the task has done work.)
+     * For non-cri images keep the fork's EXIT=halt semantics. Env YDKJ_CRI_EXIT_HALT
+     * forces the old halt behaviour for comparison. */
+    if (num == 0 && (ctx->image_id != 22 || getenv("YDKJ_CRI_EXIT_HALT"))) {
+        ctx->status = SPU_STATUS_STOPPED_BY_STOP;
+        spu_halt(ctx);          /* longjmp out to spu_run_with_halt; post-run writes exit code */
+        return;
+    }
+    /* EXIT(0, cri bootstrap)/YIELD(1)/WAIT_SIGNAL(2)/POLL(3)/RECV_WKL_FLAG(4):
+     * report success and resume (return -> lifted caller continues at its link). */
+    ctx->gpr[3]._u32[0] = 0;
+}
+
 void spu_indirect_branch(spu_context* ctx)
 {
+    /* Real SPU bi/bisl mask the target to the 256 KB local store; the high bits
+     * of a computed pointer (e.g. a packed handle like 0x7a028803) are ignored.
+     * Without this, any indirect branch through such a value fails the lookup
+     * and falls into branch-to-0. All lifted funcs live below SPU_LS_SIZE, so
+     * masking is a no-op for already-valid targets. */
+    ctx->pc &= SPU_LS_MASK;
+    /* Taskset PM task-syscall entry (LS 0xA70): HLE it instead of branching into
+     * (absent) PM code. The cri task (image 22) reaches here via syscallAddr. */
+    if (ctx->pc == YDKJ_TASKSET_PM_SYSCALL_ADDR && ctx->image_id == 22) {
+        spu_spurs_taskset_syscall(ctx); return;
+    }
+    /* YDKJ_CRI_R4: the taskset policy entry (LS 0xA00, image 23) writes r4 into
+     * SpursTasksetContext.taskset @LS 0x27B8 (per RPCS3 cellSpursSpu.cpp). Our
+     * kernel->policy handoff doesn't convey the taskset EA, so the policy DMAs
+     * the taskset from garbage -> waiting!=0 -> wrong resume path -> savedContextLr=0.
+     * Inject r4 = taskset EA (0x0F000000) at the policy entry dispatch (this is the
+     * exact point before the entry reads r4, after the kernel's arg setup). */
+    if (ctx->image_id == 23 && !getenv("YDKJ_NO_CRI_R4")) {
+        static int s_r4 = -1; if (s_r4 < 0) s_r4 = getenv("YDKJ_CRI_CHAIN") ? 1 : 0;
+        if (s_r4) {
+            /* Force ctxt->taskset @LS 0x27B8 = taskset EA (u64 0x0F000000) on every
+             * image-23 branch, so the policy's atomic reads + context-EA computation
+             * use MY taskset (the r4 handoff sets it to garbage 0x0000FFFF via a path
+             * we can't intercept). Bytes 0x27B8..0x27BF = 00 00 00 00 0F 00 00 00. */
+            ctx->ls[0x27B8]=0x00; ctx->ls[0x27B9]=0x00; ctx->ls[0x27BA]=0x00; ctx->ls[0x27BB]=0x00;
+            ctx->ls[0x27BC]=0x0F; ctx->ls[0x27BD]=0x00; ctx->ls[0x27BE]=0x00; ctx->ls[0x27BF]=0x00;
+            if (ctx->pc == 0xA00u) { static int _n=0; if (_n++ < 4)
+                fprintf(stderr, "[cri-r4] policy entry pc=0xA00: forced ctxt->taskset LS[0x27B8]=0x0F000000\n"); }
+        }
+    }
+    { static int s_ib = -1; if (s_ib < 0) s_ib = getenv("YDKJ_IBTRACE") ? 1 : 0;
+      if (s_ib && ctx->image_id == 23) { static int _i = 0; if (_i++ < 60)
+        fprintf(stderr, "[ib23] target=0x%05X lr=0x%05X\n",
+                ctx->pc, ctx->gpr[0]._u32[0] & 0x3FFFF); } }
+    { static int s_t = -1; if (s_t < 0) s_t = getenv("YDKJ_POLLTRACE") ? 1 : 0;
+      if (s_t) { static uint64_t s_n = 0; static uint32_t s_last = 0; static uint64_t s_run = 0;
+        if (ctx->pc == s_last) s_run++; else { s_last = ctx->pc; s_run = 1; }
+        if ((++s_n % 2000000) == 0)
+          fprintf(stderr, "[ibranch] %llu indirect branches; current target=0x%05X run=%llu\n",
+                  (unsigned long long)s_n, ctx->pc, (unsigned long long)s_run); } }
+    /* Policy-entry trace: the SPURS policy at LS 0xA00 branches on
+     * r8 = word at LS[r6] (must be 32 for the path that sets the dispatch ptr
+     * LS[0x780]). Log r3..r6 + the word the kernel handed it, to see why the
+     * wrong branch is taken. Env YDKJ_POLTRACE. */
+    if (ctx->pc == 0xA00u) {
+        static int64_t pt=-2; if (pt==-2){ const char* e=getenv("YDKJ_POLTRACE"); pt=e?1:0; }
+        if (pt) { static int _p=0; if (_p++ < 8) {
+            /* re-lifted policy entry uses r80 (kernel-set context base): r44=LS[r80+0xC0] */
+            uint32_t r80=ctx->gpr[80]._u32[0] & SPU_LS_MASK;
+            const uint8_t* q = ctx->ls + ((r80+0xC0)&SPU_LS_MASK);
+            uint32_t ctxw = ((uint32_t)q[0]<<24)|((uint32_t)q[1]<<16)|((uint32_t)q[2]<<8)|q[3];
+            fprintf(stderr, "[POLTRACE] policy@0xA00 r3=%08X r4=%08X r80=%08X  LS[r80+0xC0]=%08X\n",
+                ctx->gpr[3]._u32[0], ctx->gpr[4]._u32[0], r80, ctxw);
+            fflush(stderr);
+        } }
+    }
     spu_fn fn = spu_lookup(ctx->pc, ctx->image_id);
     if (fn) {
         fn(ctx);
         return;
     }
+    { static int _bt0=0; if (_bt0++ < 12)
+        fprintf(stderr, "[SPU] BRANCH-TO-0 unresolved pc=0x%05X image=%d lr=0x%05X\n",
+                ctx->pc, ctx->image_id, ctx->gpr[0]._u32[0] & SPU_LS_MASK); }
     { static int _n=0; if (_n++ < 2) {
         fprintf(stderr, "[SPU] branch-to-0 lr=0x%05X r1=0x%05X\n",
                 ctx->gpr[0]._u32[0] & SPU_LS_MASK, ctx->gpr[1]._u32[0] & SPU_LS_MASK);
@@ -300,6 +530,30 @@ void spu_indirect_branch(spu_context* ctx)
             fprintf(stderr, " 0x%zX", (size_t)((char*)frames[i] - base));
         fprintf(stderr, "\n");
 #endif
+        /* State-diff oracle: dump full LS + all GPRs at the branch-to-0 so it can
+         * be compared byte-for-byte against the RPCS3 savestate LS of the same
+         * (cri_mpv) task. Path from YDKJ_SPU_LSDUMP, else ./recomp_spu_ls.bin. */
+        const char* dp = getenv("YDKJ_SPU_LSDUMP");
+        if (!dp || !*dp) dp = "recomp_spu_ls.bin";
+        FILE* lf = fopen(dp, "wb");
+        if (lf) { fwrite(ctx->ls, 1, SPU_LS_SIZE, lf); fclose(lf);
+                  fprintf(stderr, "[SPU] dumped 256KB LS -> %s\n", dp); }
+        fprintf(stderr, "[SPU] image_id=%d  GPR dump (r0..r127, hi64:lo64 of each quadword, preferred slot = _u32[0]):\n", ctx->image_id);
+        for (int g = 0; g < 128; g++) {
+            fprintf(stderr, " r%-3d=%08X %08X %08X %08X", g,
+                    ctx->gpr[g]._u32[0], ctx->gpr[g]._u32[1],
+                    ctx->gpr[g]._u32[2], ctx->gpr[g]._u32[3]);
+            if ((g & 1) == 1) fprintf(stderr, "\n");
+        }
+        fprintf(stderr, "\n");
+        /* echo the dispatch chain values the way func_00026DE0 computes them */
+        { uint32_t bec0 = ctx->ls[0xBEC0]<<24 | ctx->ls[0xBEC1]<<16 | ctx->ls[0xBEC2]<<8 | ctx->ls[0xBEC3];
+          fprintf(stderr, "[SPU] LS[0xBEC0].w0=0x%08X  LS[0x2d4e0:16]=%02X%02X%02X%02X %02X%02X%02X%02X %02X%02X%02X%02X %02X%02X%02X%02X\n",
+            bec0,
+            ctx->ls[0x2d4e0],ctx->ls[0x2d4e1],ctx->ls[0x2d4e2],ctx->ls[0x2d4e3],
+            ctx->ls[0x2d4e4],ctx->ls[0x2d4e5],ctx->ls[0x2d4e6],ctx->ls[0x2d4e7],
+            ctx->ls[0x2d4e8],ctx->ls[0x2d4e9],ctx->ls[0x2d4ea],ctx->ls[0x2d4eb],
+            ctx->ls[0x2d4ec],ctx->ls[0x2d4ed],ctx->ls[0x2d4ee],ctx->ls[0x2d4ef]); }
     } }
     ctx->status = SPU_STATUS_STOPPED_BY_HALT;
 }

--- a/runtime/spu/spu_dma.h
+++ b/runtime/spu/spu_dma.h
@@ -18,11 +18,49 @@
 #include "spu_context.h"
 #include <stdint.h>
 #include <string.h>
+#include <stdlib.h>
 #include <stdio.h>
+#include <stdio.h>
+#ifdef _WIN32
+#include <windows.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+extern uint8_t* vm_base;
+
+/* Guard against a guest DMA whose effective address lands in reserved-but-
+ * uncommitted guest memory (the 4 GB VM is MEM_RESERVE; only main mem / RSX /
+ * SPU / lv2-heap / stack pages are committed). A garbage EA — e.g. one the SPURS
+ * kernel computes from an incomplete context during bring-up — must be treated
+ * as a failed DMA, NOT crash the host emulator with an access violation. On
+ * Windows we query the page state; the whole [ea, ea+size) range must be
+ * committed and accessible. Returns 1 if the range is safe to memcpy. */
+static inline int mfc_ea_range_committed(uint64_t ea, uint32_t size)
+{
+    uint32_t e = (uint32_t)ea;
+    if (size == 0) return 0;
+    if ((uint64_t)e + (uint64_t)size > 0x100000000ull) return 0;   /* past 4 GB */
+#ifdef _WIN32
+    if (!vm_base) return 0;
+    uint8_t* p = vm_base + e;
+    MEMORY_BASIC_INFORMATION mbi;
+    if (VirtualQuery(p, &mbi, sizeof(mbi)) == 0) return 0;
+    if (mbi.State != MEM_COMMIT) return 0;
+    if (mbi.Protect & (PAGE_NOACCESS | PAGE_GUARD)) return 0;
+    /* If the range spans into the next region, verify the last byte's page too. */
+    uintptr_t region_end = (uintptr_t)mbi.BaseAddress + mbi.RegionSize;
+    if ((uintptr_t)p + size > region_end) {
+        MEMORY_BASIC_INFORMATION mbi2;
+        if (VirtualQuery(p + size - 1, &mbi2, sizeof(mbi2)) == 0) return 0;
+        if (mbi2.State != MEM_COMMIT) return 0;
+        if (mbi2.Protect & (PAGE_NOACCESS | PAGE_GUARD)) return 0;
+    }
+#endif
+    return 1;
+}
 
 /* MFC queue depth */
 #define MFC_QUEUE_DEPTH     16
@@ -126,6 +164,24 @@ static inline int mfc_do_transfer(spu_context* spu, uint32_t lsa, uint64_t ea,
     /* Mask LSA to local store range */
     lsa &= SPU_LS_MASK;
 
+    /* Reject transfers that would overrun the 256 KB local store buffer (a real
+     * SPU MFC requires the LS range to be valid; an out-of-range lsa+size here
+     * would corrupt host heap past spu->ls). */
+    if ((uint64_t)lsa + (uint64_t)size > (uint64_t)SPU_LS_SIZE)
+        return -1;
+
+    /* Reject transfers whose main-memory range is not committed guest memory,
+     * so a garbage EA (e.g. from an incomplete SPURS context) is a failed DMA
+     * rather than a host segfault. */
+    if (!mfc_ea_range_committed(ea, size)) {
+        static int s_warned = 0;
+        if (s_warned++ < 32)
+            fprintf(stderr, "[spu-dma] SKIP %s lsa=0x%05X ea=0x%08X size=%u "
+                    "(EA not committed -- bad/garbage DMA target)\n",
+                    mfc_is_get(cmd) ? "GET" : "PUT", lsa, (uint32_t)ea, size);
+        return -1;
+    }
+
     uint8_t* ls_ptr = &spu->ls[lsa];
     uint8_t* ea_ptr = vm_base + (uint32_t)ea; /* PS3 uses 32-bit effective addresses for SPU DMA */
 
@@ -134,12 +190,39 @@ static inline int mfc_do_transfer(spu_context* spu, uint32_t lsa, uint64_t ea,
         fprintf(stderr, "[spu-dma] %s lsa=0x%05X ea=0x%08X size=%u\n",
                 mfc_is_get(cmd) ? "GET" : "PUT", lsa, (uint32_t)ea, size); }
 #endif
+    { static int s_t = -1; if (s_t < 0) s_t = getenv("YDKJ_DMATRACE") ? 1 : 0;
+      if (s_t) { static int _n = 0; if (_n++ < 300)
+        fprintf(stderr, "[dmatrace] %s lsa=0x%05X ea=0x%08X size=%u img=%d\n",
+                mfc_is_get(cmd) ? "GET" : "PUT", lsa, (uint32_t)ea, size, spu->image_id); } }
+    /* Detect the cri task actually DECODING: a GET of the real video payload
+     * (large, from a non-context EA) as opposed to the 64-byte context handshake
+     * DMAs. Set a flag the dispatcher polls to know the task got real work. */
+    { extern int g_cri_video_dma;
+      if (spu->image_id == 22 && mfc_is_get(cmd) && size > 0x100)
+          g_cri_video_dma = 1; }
     if (mfc_is_get(cmd)) {
         /* GET: main memory -> local store */
         memcpy(ls_ptr, ea_ptr, size);
     } else if (mfc_is_put(cmd)) {
         /* PUT: local store -> main memory */
         memcpy(ea_ptr, ls_ptr, size);
+        /* POISON-DMA detector: does an SPU PUT write the singleton object region
+         * (0x40003000-0x40005000) or carry the 0xC708C708 poison? This host-side
+         * memcpy bypasses vm_write32/AWATCH, so it's the prime suspect for the
+         * garbage fn-ptr fields that cause the 0xC708C708 vcall crash. */
+        { uint32_t e = (uint32_t)ea;
+          int hitregion = (e < 0x40005000u && e + size > 0x40003000u);
+          int haspoison = 0;
+          for (uint32_t o = 0; o + 4 <= size; o += 4) {
+              uint32_t w; memcpy(&w, (const char*)ls_ptr + o, 4);
+              if (w == 0x08C708C7u) { haspoison = 1; break; } /* 0xC708C708 BE in LS bytes */
+          }
+          if (hitregion || haspoison) {
+              static int _n = 0;
+              if (_n++ < 12)
+                  fprintf(stderr, "[POISON-DMA] img%u PUT ea=0x%08X size=0x%X lsa=0x%X hitregion=%d haspoison=%d\n",
+                          spu->image_id, e, size, lsa, hitregion, haspoison);
+          } }
     }
 
     return 0;
@@ -219,6 +302,33 @@ static inline int mfc_submit(mfc_engine* mfc, spu_context* spu, uint32_t cmd)
     uint32_t tag  = spu->mfc_tag & 0x1F;
     int rc = 0;
 
+    /* cri build (YDKJ_CRI_CHAIN): when the kernel DMA-loads the TASKSET policy
+     * module (libsre guest 0x30023680) to LS 0xA00, switch this SPU's image to 23
+     * so subsequent indirect branches to 0xA00 resolve lift_tsp (taskset policy)
+     * instead of image-22's lift_pol (sys-service). The cri task (0x3000+) is
+     * registered under both 22 and 23, so it still resolves after the switch. */
+    if (lsa == 0xA00u && (uint32_t)ea == 0x30023680u) {
+        static int s_cc = -1; if (s_cc < 0) s_cc = getenv("YDKJ_CRI_CHAIN") ? 1 : 0;
+        if (s_cc) {
+            spu->image_id = 23;
+            fprintf(stderr, "[cri-chain] taskset policy DMA'd to LS 0xA00 -> SPU image -> 23\n");
+            /* YDKJ_CRI_R4: the taskset policy entry (tsp func_00000A00) writes r4
+             * into SpursTasksetContext.taskset @LS 0x27B8 (shufb gpr[4] -> +8), so
+             * r4 MUST be the CellSpursTaskset EA (per RPCS3 cellSpursSpu.cpp). The
+             * kernel->policy handoff doesn't convey it in our path, so the policy
+             * DMAs the taskset from garbage -> reads waiting!=0 -> wrong resume
+             * path -> savedContextLr=0. Inject r4 = taskset EA (0x0F000000) here.
+             * u64 pref-doubleword: bytes0-3=0, bytes4-7=0x0F000000 -> _u32[0]=0,
+             * _u32[1]=EA. Gated (default on with CRI_CHAIN unless YDKJ_NO_CRI_R4). */
+            if (!getenv("YDKJ_NO_CRI_R4")) {
+                spu->gpr[4]._u32[0] = 0x00000000u;
+                spu->gpr[4]._u32[1] = 0x0F000000u;   /* taskset EA (matches CRI_CHAIN TSEA) */
+                fprintf(stderr, "[cri-chain] injected r4 = taskset EA 0x0F000000 (-> ctxt->taskset @LS 0x27B8)\n");
+            }
+            fflush(stderr);
+        }
+    }
+
     /* Mark tag as in-progress */
     mfc->tag_completed &= ~(1u << tag);
 
@@ -230,11 +340,70 @@ static inline int mfc_submit(mfc_engine* mfc, spu_context* spu, uint32_t cmd)
         return 0;
     }
 
+    /* DMA trace for the cri task (image 22): log each transfer's LS/EA/size so we
+     * can see the work-fetch GET (func_000040F0) that precedes the branch-to-0 and
+     * whether its source EA holds valid work-queue data. Env YDKJ_DMATRACE. */
+    {
+        static int64_t dt=-2; if (dt==-2){ const char* e=getenv("YDKJ_DMATRACE"); dt=e?1:0; }
+        if (dt && (spu->image_id==22 || spu->image_id==23)) {
+            static int _n=0; if (_n++ < 160)
+                fprintf(stderr, "[DMA] img%d cmd=0x%02X lsa=0x%05X ea=0x%09llX size=0x%X tag=%u\n",
+                        spu->image_id, cmd, lsa, (unsigned long long)ea, size, tag);
+            /* YDKJ_CRI_R4 diag: when the policy issues the mis-computed context
+             * DMA (img23, lsa=0x2780, garbage high EA), dump the loaded
+             * SpursTasksetContext (LS 0x2700..0x27E0) so we can see which field
+             * fed the bad EA. taskset@0x27B8, kernelMgmt@0x27C0, syscall@0x27C4. */
+            if (spu->image_id==23 && lsa==0x2780u && ((ea>>32)&0xFFFF)) {
+                static int _d=0; if (_d++ < 3) {
+                    fprintf(stderr, "[cri-r4] BAD-DMA ea=0x%09llX; SpursTasksetContext LS[0x2700..0x27E0]:\n",
+                            (unsigned long long)ea);
+                    for (uint32_t o=0x2700; o<0x27E0; o+=16)
+                        fprintf(stderr, "   LS[0x%04X]: %02X%02X%02X%02X %02X%02X%02X%02X %02X%02X%02X%02X %02X%02X%02X%02X\n", o,
+                            spu->ls[o+0],spu->ls[o+1],spu->ls[o+2],spu->ls[o+3], spu->ls[o+4],spu->ls[o+5],spu->ls[o+6],spu->ls[o+7],
+                            spu->ls[o+8],spu->ls[o+9],spu->ls[o+10],spu->ls[o+11], spu->ls[o+12],spu->ls[o+13],spu->ls[o+14],spu->ls[o+15]);
+                }
+            }
+            /* kernel bootstrap DMA: dump LS[0x1C0] (=r17, the packed instance EA via
+             * the entry's cdd/cwd/shufb) to check if the EA got byte-mangled. */
+            if (cmd==0x40 && lsa==0x3FFE0) {
+                static int _k=0; if (_k++ < 3) {
+                    const uint8_t* p=&spu->ls[0x1C0];
+                    fprintf(stderr, "[DMA] LS[0x1C0] (r17, packed instance) = %02X%02X%02X%02X %02X%02X%02X%02X %02X%02X%02X%02X %02X%02X%02X%02X\n",
+                        p[0],p[1],p[2],p[3],p[4],p[5],p[6],p[7],p[8],p[9],p[10],p[11],p[12],p[13],p[14],p[15]);
+                    /* byte-order hypothesis: correct offset is 0xD00 (not 0xD0000).
+                     * Dump guest mem at instance+0xD00 (the SPU-correct EA) vs +0xD0000. */
+                    extern uint8_t* vm_base;
+                    uint32_t inst = (uint32_t)(ea - 0xD0000u);  /* recover instance base */
+                    for (uint32_t off2=0xD00; off2<=0xD0000; off2+= (0xD0000-0xD00)) {
+                        const uint8_t* q = vm_base + inst + off2;
+                        fprintf(stderr, "[DMA]   guest[inst+0x%05X = 0x%08X]: %02X%02X%02X%02X %02X%02X%02X%02X %02X%02X%02X%02X %02X%02X%02X%02X\n",
+                            off2, inst+off2, q[0],q[1],q[2],q[3],q[4],q[5],q[6],q[7],q[8],q[9],q[10],q[11],q[12],q[13],q[14],q[15]);
+                    }
+                }
+            }
+        }
+    }
+
     /* Execute the transfer */
     if (mfc_is_list(cmd)) {
         rc = mfc_do_list_transfer(spu, lsa, ea, size, cmd);
     } else {
         rc = mfc_do_transfer(spu, lsa, ea, size, cmd);
+    }
+
+    /* After a cri-task GET, dump the bytes it just read (the task context) so we
+     * can tell if eaContext holds valid SPURS work data or garbage. */
+    {
+        static int64_t dt2=-2; if (dt2==-2){ const char* e=getenv("YDKJ_DMATRACE"); dt2=e?1:0; }
+        if (dt2 && spu->image_id==22 && cmd==0x40 /*GET*/ && size<=0x80) {
+            static int _g=0; if (_g++ < 6) {
+                const uint8_t* p = spu->ls + (lsa & 0x3FFFF);
+                fprintf(stderr, "[DMA] GET data @LS0x%05X (from ea=0x%09llX):", lsa, (unsigned long long)ea);
+                for (uint32_t i=0;i<size && i<0x40;i+=4)
+                    fprintf(stderr, " %02X%02X%02X%02X", p[i],p[i+1],p[i+2],p[i+3]);
+                fprintf(stderr, "\n");
+            }
+        }
     }
 
     /* Mark tag as completed */

--- a/runtime/spu/spu_helpers.h
+++ b/runtime/spu/spu_helpers.h
@@ -33,9 +33,31 @@ static inline int spu_clz32(uint32_t x) {
 static inline int spu_clz32(uint32_t x) { return x ? __builtin_clz(x) : 32; }
 #endif
 
+/* SPU byte position -> our _u8 index.
+ * Our u128 is HOST-NATIVE little-endian (_u32[i]=SPU word i as a value via
+ * spu_ls_read128's big-endian load), so within each 4-byte word the _u8[]
+ * bytes are reversed vs SPU big-endian byte order. Any op defined in terms of
+ * SPU *byte positions* (quadword byte rotates/shifts, gen-controls, shuffle
+ * insertion) must map SPU byte P to our index W(P). Word-aligned operations
+ * are unaffected (W is identity modulo the within-word reversal). */
+#define SPU_W(P) (((P) & ~3) | (3 - ((P) & 3)))
+
 /* ---- constructors ---- */
 static inline u128 spu_splat_u32(uint32_t v) {
     u128 r; r._u32[0]=v; r._u32[1]=v; r._u32[2]=v; r._u32[3]=v; return r;
+}
+/* Link register value for brsl/bisl/bisled: the SPU writes the return address
+ * into the PREFERRED word (word 0) and ZEROS the other three slots (matches
+ * RPCS3 v128::from32r, SPUInterpreter.cpp BRSL). Splatting it (the old bug)
+ * corrupts any code that saves/reloads/operates on the full 128-bit link. */
+static inline u128 spu_link(uint32_t addr) {
+    u128 r; r._u32[0]=addr; r._u32[1]=0; r._u32[2]=0; r._u32[3]=0; return r;
+}
+/* Preferred-slot scalar: value in word 0, remaining slots ZERO. CBEA's scalar
+ * channel convention -- rchcnt returns the count this way (RPCS3 measured
+ * {1,0,0,0} where the old splat gave {1,1,1,1}). Same bug class as spu_link. */
+static inline u128 spu_pref_u32(uint32_t v) {
+    u128 r; r._u32[0]=v; r._u32[1]=0; r._u32[2]=0; r._u32[3]=0; return r;
 }
 static inline u128 spu_splat_u16(uint16_t v) {
     u128 r; for (int i=0;i<8;i++) r._u16[i]=v; return r;
@@ -112,16 +134,24 @@ static inline u128 spu_selb(u128 a, u128 b, u128 c) {
  *   sel & 0xC0 == 0x80 -> 0x00
  *   otherwise           -> concat{a,b}[sel & 0x1F] */
 static inline u128 spu_shufb(u128 a, u128 b, u128 c) {
+    /* shufb is defined on SPU byte positions. Our u128 is host-native LE, so SPU
+     * byte P lives at _u8[SPU_W(P)]; map every access (the concat source, the
+     * control, and the result) through SPU_W so a control supplied as an immediate
+     * (ila/il) or an LS-loaded constant -- already in true SPU byte order -- is
+     * interpreted correctly. The cbd/chd/cwd/cdd generators below produce true
+     * SPU-byte-order selectors to match. */
     uint8_t cat[32];
-    for (int i=0;i<16;i++) cat[i]=a._u8[i];
-    for (int i=0;i<16;i++) cat[16+i]=b._u8[i];
+    for (int j=0;j<16;j++) cat[j]    = a._u8[SPU_W(j)];   /* concat SPU byte j  = a SPU byte j */
+    for (int j=0;j<16;j++) cat[16+j] = b._u8[SPU_W(j)];   /* concat SPU byte 16+j = b SPU byte j */
     u128 r;
-    for (int i=0;i<16;i++) {
-        uint8_t s=c._u8[i];
-        if      ((s & 0xE0)==0xE0) r._u8[i]=0x80;
-        else if ((s & 0xC0)==0xC0) r._u8[i]=0xFF;
-        else if ((s & 0xC0)==0x80) r._u8[i]=0x00;
-        else                       r._u8[i]=cat[s & 0x1F];
+    for (int t=0;t<16;t++) {                              /* result SPU byte t */
+        uint8_t s = c._u8[SPU_W(t)];                      /* control SPU byte t */
+        uint8_t v;
+        if      ((s & 0xE0)==0xE0) v=0x80;
+        else if ((s & 0xC0)==0xC0) v=0xFF;
+        else if ((s & 0xC0)==0x80) v=0x00;
+        else                       v=cat[s & 0x1F];       /* concat SPU byte (s & 0x1F) */
+        r._u8[SPU_W(t)] = v;
     }
     return r;
 }
@@ -134,10 +164,21 @@ static inline u128 spu_rothi(u128 a, int sh) { u128 r; sh&=15; for(int i=0;i<8;i
 static inline u128 spu_rotmi(u128 a, int i7)  { u128 r; int sh=(0-i7)&0x3F; for(int i=0;i<4;i++) r._u32[i]=(sh>31)?0:(a._u32[i]>>sh); return r; }
 static inline u128 spu_rotmai(u128 a, int i7) { u128 r; int sh=(0-i7)&0x3F; for(int i=0;i<4;i++) r._s32[i]=(sh>31)?(a._s32[i]>>31):(a._s32[i]>>sh); return r; }
 static inline u128 spu_rotmhi(u128 a, int i7) { u128 r; int sh=(0-i7)&0x1F; for(int i=0;i<8;i++) r._u16[i]=(sh>15)?0:(uint16_t)(a._u16[i]>>sh); return r; }
-static inline u128 spu_shlqbyi(u128 a, int sh) { u128 r; sh&=0x1F; for(int i=0;i<16;i++){ int s=i+sh; r._u8[i]=(s<16)?a._u8[s]:0; } return r; }
-static inline u128 spu_rotqbyi(u128 a, int sh) { u128 r; sh&=0x0F; for(int i=0;i<16;i++) r._u8[i]=a._u8[(i+sh)&0x0F]; return r; }
-static inline u128 spu_shlqbii(u128 a, int sh) { sh&=7; if(!sh) return a; u128 r; r._u64[0]=(a._u64[0]<<sh)|(a._u64[1]>>(64-sh)); r._u64[1]=(a._u64[1]<<sh); return r; }
-static inline u128 spu_rotqbii(u128 a, int sh) { sh&=7; if(!sh) return a; u128 r; r._u64[0]=(a._u64[0]<<sh)|(a._u64[1]>>(64-sh)); r._u64[1]=(a._u64[1]<<sh)|(a._u64[0]>>(64-sh)); return r; }
+static inline u128 spu_shlqbyi(u128 a, int sh) { u128 r=spu_zero(); sh&=0x1F; for(int i=0;i<16;i++){ int s=i+sh; if(s<16) r._u8[SPU_W(i)]=a._u8[SPU_W(s)]; } return r; }
+static inline u128 spu_rotqbyi(u128 a, int sh) { u128 r; sh&=0x0F; for(int i=0;i<16;i++) r._u8[SPU_W(i)]=a._u8[SPU_W((i+sh)&0x0F)]; return r; }
+/* Bit-level quadword shifts/rotates operate on the WHOLE 128-bit big-endian
+ * value. Our _u64[0]/_u64[1] are word-SCRAMBLED (host-LE: _u64[0] = word0 |
+ * word1<<32, but SPU's MS half is word0<<32 | word1), so native shifts on them
+ * corrupt any bits crossing a 32-bit boundary. Assemble the logical hi/lo halves
+ * with _u32[0] as most-significant, shift, then disassemble. */
+static inline u128 spu_shlqbii(u128 a, int sh) { sh&=7; if(!sh) return a;
+    uint64_t hi=((uint64_t)a._u32[0]<<32)|a._u32[1], lo=((uint64_t)a._u32[2]<<32)|a._u32[3];
+    uint64_t nhi=(hi<<sh)|(lo>>(64-sh)), nlo=(lo<<sh);
+    u128 r; r._u32[0]=(uint32_t)(nhi>>32); r._u32[1]=(uint32_t)nhi; r._u32[2]=(uint32_t)(nlo>>32); r._u32[3]=(uint32_t)nlo; return r; }
+static inline u128 spu_rotqbii(u128 a, int sh) { sh&=7; if(!sh) return a;
+    uint64_t hi=((uint64_t)a._u32[0]<<32)|a._u32[1], lo=((uint64_t)a._u32[2]<<32)|a._u32[3];
+    uint64_t nhi=(hi<<sh)|(lo>>(64-sh)), nlo=(lo<<sh)|(hi>>(64-sh));
+    u128 r; r._u32[0]=(uint32_t)(nhi>>32); r._u32[1]=(uint32_t)nhi; r._u32[2]=(uint32_t)(nlo>>32); r._u32[3]=(uint32_t)nlo; return r; }
 
 /* ---- single-precision float (4 lanes) ---- */
 static inline u128 spu_fa(u128 a, u128 b) { u128 r; for(int i=0;i<4;i++) r._f32[i]=a._f32[i]+b._f32[i]; return r; }
@@ -160,17 +201,69 @@ static inline u128 spu_fnms(u128 a, u128 b, u128 c) { u128 r; for(int i=0;i<4;i+
 static inline u128 spu_fceq(u128 a, u128 b) { u128 r; for(int i=0;i<4;i++) r._u32[i]=(a._f32[i]==b._f32[i])?0xFFFFFFFFu:0; return r; }
 static inline u128 spu_fcgt(u128 a, u128 b) { u128 r; for(int i=0;i<4;i++) r._u32[i]=(a._f32[i]>b._f32[i])?0xFFFFFFFFu:0; return r; }
 
+/* ---- SPU double-precision (2 doubles/reg; dword i = words 2i(high),2i+1(low)).
+ * Reassemble via _u32 -- our u128 is host-LE, so a naive _f64[i] would SWAP the
+ * two words. Semantics from RPCS3 SPUInterpreter (DFASM / DFMA / FESD / FRDS). ---- */
+static inline double spu__dget(u128 r, int i) {
+    uint64_t u = ((uint64_t)r._u32[i*2] << 32) | r._u32[i*2+1];
+    double d; memcpy(&d, &u, sizeof d); return d;
+}
+static inline void spu__dset(u128* r, int i, double d) {
+    uint64_t u; memcpy(&u, &d, sizeof u);
+    r->_u32[i*2] = (uint32_t)(u >> 32); r->_u32[i*2+1] = (uint32_t)u;
+}
+static inline u128 spu_dfa(u128 a, u128 b) { u128 r; for(int i=0;i<2;i++) spu__dset(&r,i, spu__dget(a,i)+spu__dget(b,i)); return r; }
+static inline u128 spu_dfs(u128 a, u128 b) { u128 r; for(int i=0;i<2;i++) spu__dset(&r,i, spu__dget(a,i)-spu__dget(b,i)); return r; }
+static inline u128 spu_dfm(u128 a, u128 b) { u128 r; for(int i=0;i<2;i++) spu__dset(&r,i, spu__dget(a,i)*spu__dget(b,i)); return r; }
+/* double FMA family: c = rt (accumulator, 3-register). */
+static inline u128 spu_dfma(u128 a, u128 b, u128 t)  { u128 r; for(int i=0;i<2;i++) spu__dset(&r,i, spu__dget(a,i)*spu__dget(b,i)+spu__dget(t,i)); return r; }
+static inline u128 spu_dfms(u128 a, u128 b, u128 t)  { u128 r; for(int i=0;i<2;i++) spu__dset(&r,i, spu__dget(a,i)*spu__dget(b,i)-spu__dget(t,i)); return r; }
+static inline u128 spu_dfnms(u128 a, u128 b, u128 t) { u128 r; for(int i=0;i<2;i++) spu__dset(&r,i, spu__dget(t,i)-spu__dget(a,i)*spu__dget(b,i)); return r; }
+static inline u128 spu_dfnma(u128 a, u128 b, u128 t) { u128 r; for(int i=0;i<2;i++) spu__dset(&r,i, -(spu__dget(a,i)*spu__dget(b,i)+spu__dget(t,i))); return r; }
+/* double compares -> per-lane 64-bit mask (RPCS3 stubs these; sane impl here). */
+static inline u128 spu_dfceq(u128 a, u128 b)  { u128 r; for(int i=0;i<2;i++){ uint64_t m=(spu__dget(a,i)==spu__dget(b,i))?~0ull:0ull; r._u32[i*2]=(uint32_t)(m>>32); r._u32[i*2+1]=(uint32_t)m; } return r; }
+static inline u128 spu_dfcmeq(u128 a, u128 b) { u128 r; for(int i=0;i<2;i++){ double x=spu__dget(a,i),y=spu__dget(b,i); if(x<0)x=-x; if(y<0)y=-y; uint64_t m=(x==y)?~0ull:0ull; r._u32[i*2]=(uint32_t)(m>>32); r._u32[i*2+1]=(uint32_t)m; } return r; }
+/* fesd: extend single (word slots 1,3) -> double (dwords 0,1). frds: round
+ * double -> single in slots 1,3 and zero slots 0,2 (RPCS3 FESD/FRDS). */
+static inline u128 spu_fesd(u128 a) { u128 r; memset(&r,0,sizeof r); for(int i=0;i<2;i++) spu__dset(&r,i,(double)a._f32[i*2+1]); return r; }
+static inline u128 spu_frds(u128 a) { u128 r; memset(&r,0,sizeof r); for(int i=0;i<2;i++) r._f32[i*2+1]=(float)spu__dget(a,i); return r; }
+/* mpyhhu: high-16 x high-16 of each word, unsigned, full 32-bit product. */
+static inline u128 spu_mpyhhu(u128 a, u128 b){ u128 r; for(int i=0;i<4;i++) r._u32[i]=(uint32_t)a._u16[2*i+1]*(uint32_t)b._u16[2*i+1]; return r; }
+/* cgx: extended carry-generate, carry-in = low bit of old rt (RPCS3 CGX). */
+static inline u128 spu_cgx(u128 a, u128 b, u128 t){ u128 r; for(int i=0;i<4;i++) r._u32[i]=(uint32_t)(((uint64_t)(t._u32[i]&1u)+a._u32[i]+b._u32[i])>>32); return r; }
+
+/* ---- remaining SPU ISA ops (RPCS3 SPUInterpreter: EQV/ABSDB/AVGB/MPYHHA/
+ * MPYHHAU/DFCGT/DFCMGT/XORBI/DFTSV). Completes the lifter's opcode coverage. ---- */
+static inline u128 spu_eqv(u128 a, u128 b)   { u128 r; for(int i=0;i<4;i++) r._u32[i]=~(a._u32[i]^b._u32[i]); return r; }
+static inline u128 spu_xorbi(u128 a, int32_t imm){ u128 r; for(int i=0;i<16;i++) r._u8[i]=(uint8_t)(a._u8[i]^(uint8_t)imm); return r; }
+static inline u128 spu_absdb(u128 a, u128 b)  { u128 r; for(int i=0;i<16;i++){ uint8_t x=a._u8[i],y=b._u8[i]; r._u8[i]=(uint8_t)(x>y?x-y:y-x); } return r; }
+static inline u128 spu_avgb(u128 a, u128 b)   { u128 r; for(int i=0;i<16;i++) r._u8[i]=(uint8_t)(((uint32_t)a._u8[i]+(uint32_t)b._u8[i]+1u)>>1); return r; }
+/* mpyhha/mpyhhau: high-16 x high-16, ACCUMULATE into rt (3-register). */
+static inline u128 spu_mpyhha(u128 a, u128 b, u128 t)  { u128 r; for(int i=0;i<4;i++) r._s32[i]=t._s32[i]+(int32_t)a._s16[2*i+1]*(int32_t)b._s16[2*i+1]; return r; }
+static inline u128 spu_mpyhhau(u128 a, u128 b, u128 t) { u128 r; for(int i=0;i<4;i++) r._u32[i]=t._u32[i]+(uint32_t)a._u16[2*i+1]*(uint32_t)b._u16[2*i+1]; return r; }
+/* double compare greater (RPCS3 stubs these; sane impl) -> per-lane mask. */
+static inline u128 spu_dfcgt(u128 a, u128 b)  { u128 r; for(int i=0;i<2;i++){ uint64_t m=(spu__dget(a,i)>spu__dget(b,i))?~0ull:0ull; r._u32[i*2]=(uint32_t)(m>>32); r._u32[i*2+1]=(uint32_t)m; } return r; }
+static inline u128 spu_dfcmgt(u128 a, u128 b) { u128 r; for(int i=0;i<2;i++){ double x=spu__dget(a,i),y=spu__dget(b,i); if(x<0)x=-x; if(y<0)y=-y; uint64_t m=(x>y)?~0ull:0ull; r._u32[i*2]=(uint32_t)(m>>32); r._u32[i*2+1]=(uint32_t)m; } return r; }
+/* dftsv: double test special value -- RPCS3 stubs (fatal); 0 = no special. */
+static inline u128 spu_dftsv(u128 a, int32_t imm){ (void)a; (void)imm; u128 r; memset(&r,0,sizeof r); return r; }
+
 /* ---- Phase 2: register-variable shifts/rotates ---- */
 static inline u128 spu_shl(u128 a, u128 b)   { u128 r; for(int i=0;i<4;i++){ uint32_t sh=b._u32[i]&0x3F; r._u32[i]=(sh>31)?0:(a._u32[i]<<sh); } return r; }
 static inline u128 spu_shlh(u128 a, u128 b)  { u128 r; for(int i=0;i<8;i++){ uint32_t sh=b._u16[i]&0x1F; r._u16[i]=(sh>15)?0:(uint16_t)(a._u16[i]<<sh); } return r; }
 static inline u128 spu_rot(u128 a, u128 b)   { u128 r; for(int i=0;i<4;i++){ uint32_t sh=b._u32[i]&31; r._u32[i]= sh ? ((a._u32[i]<<sh)|(a._u32[i]>>(32-sh))) : a._u32[i]; } return r; }
 static inline u128 spu_roth(u128 a, u128 b)  { u128 r; for(int i=0;i<8;i++){ uint32_t sh=b._u16[i]&15; r._u16[i]= sh ? (uint16_t)((a._u16[i]<<sh)|(a._u16[i]>>(16-sh))) : a._u16[i]; } return r; }
-static inline u128 spu_shlqbi(u128 a, u128 b){ int sh=b._u32[0]&7; u128 r; if(!sh) return a; r._u64[0]=(a._u64[0]<<sh)|(a._u64[1]>>(64-sh)); r._u64[1]=(a._u64[1]<<sh); return r; }
-static inline u128 spu_rotqbi(u128 a, u128 b){ int sh=b._u32[0]&7; u128 r; if(!sh) return a; r._u64[0]=(a._u64[0]<<sh)|(a._u64[1]>>(64-sh)); r._u64[1]=(a._u64[1]<<sh)|(a._u64[0]>>(64-sh)); return r; }
-static inline u128 spu_shlqby(u128 a, u128 b){ int sh=b._u32[0]&0x1F; u128 r; if(sh>=16) return spu_zero(); for(int i=0;i<16;i++){ int s=i+sh; r._u8[i]=(s<16)?a._u8[s]:0; } return r; }
-static inline u128 spu_rotqby(u128 a, u128 b){ int sh=b._u32[0]&0x0F; u128 r; for(int i=0;i<16;i++) r._u8[i]=a._u8[(i+sh)&0x0F]; return r; }
-static inline u128 spu_shlqbybi(u128 a, u128 b){ int sh=(b._u32[0]>>3)&0x1F; u128 r; if(sh>=16) return spu_zero(); for(int i=0;i<16;i++){ int s=i+sh; r._u8[i]=(s<16)?a._u8[s]:0; } return r; }
-static inline u128 spu_rotqbybi(u128 a, u128 b){ int sh=(b._u32[0]>>3)&0x0F; u128 r; for(int i=0;i<16;i++) r._u8[i]=a._u8[(i+sh)&0x0F]; return r; }
+static inline u128 spu_shlqbi(u128 a, u128 b){ int sh=b._u32[0]&7; if(!sh) return a;
+    uint64_t hi=((uint64_t)a._u32[0]<<32)|a._u32[1], lo=((uint64_t)a._u32[2]<<32)|a._u32[3];
+    uint64_t nhi=(hi<<sh)|(lo>>(64-sh)), nlo=(lo<<sh);
+    u128 r; r._u32[0]=(uint32_t)(nhi>>32); r._u32[1]=(uint32_t)nhi; r._u32[2]=(uint32_t)(nlo>>32); r._u32[3]=(uint32_t)nlo; return r; }
+static inline u128 spu_rotqbi(u128 a, u128 b){ int sh=b._u32[0]&7; if(!sh) return a;
+    uint64_t hi=((uint64_t)a._u32[0]<<32)|a._u32[1], lo=((uint64_t)a._u32[2]<<32)|a._u32[3];
+    uint64_t nhi=(hi<<sh)|(lo>>(64-sh)), nlo=(lo<<sh)|(hi>>(64-sh));
+    u128 r; r._u32[0]=(uint32_t)(nhi>>32); r._u32[1]=(uint32_t)nhi; r._u32[2]=(uint32_t)(nlo>>32); r._u32[3]=(uint32_t)nlo; return r; }
+static inline u128 spu_shlqby(u128 a, u128 b){ int sh=b._u32[0]&0x1F; u128 r=spu_zero(); if(sh>=16) return r; for(int i=0;i<16;i++){ int s=i+sh; if(s<16) r._u8[SPU_W(i)]=a._u8[SPU_W(s)]; } return r; }
+static inline u128 spu_rotqby(u128 a, u128 b){ int sh=b._u32[0]&0x0F; u128 r; for(int i=0;i<16;i++) r._u8[SPU_W(i)]=a._u8[SPU_W((i+sh)&0x0F)]; return r; }
+static inline u128 spu_shlqbybi(u128 a, u128 b){ int sh=(b._u32[0]>>3)&0x1F; u128 r=spu_zero(); if(sh>=16) return r; for(int i=0;i<16;i++){ int s=i+sh; if(s<16) r._u8[SPU_W(i)]=a._u8[SPU_W(s)]; } return r; }
+static inline u128 spu_rotqbybi(u128 a, u128 b){ int sh=(b._u32[0]>>3)&0x0F; u128 r; for(int i=0;i<16;i++) r._u8[SPU_W(i)]=a._u8[SPU_W((i+sh)&0x0F)]; return r; }
 
 /* ---- Phase 2: rotmahi ---- */
 static inline u128 spu_rotmahi(u128 a, int i7) { u128 r; int sh=(0-i7)&0x1F; for(int i=0;i<8;i++) r._s16[i]=(sh>15)?(a._s16[i]>>15):(a._s16[i]>>sh); return r; }
@@ -190,10 +283,34 @@ static inline u128 spu_gb(u128 a) {
     u128 r = spu_zero(); r._u32[0]=v; return r;
 }
 static inline u128 spu_gbh(u128 a) {
-    uint32_t v=0; for(int i=0;i<8;i++) v |= ((uint32_t)(a._u16[i]&1) << (7-i));
+    /* gather LSB of each SPU halfword H into bit (7-H). SPU halfword H maps to
+     * our _u16[H^1] (the within-word halfword swap of the value layout). */
+    uint32_t v=0; for(int i=0;i<8;i++) v |= ((uint32_t)(a._u16[i^1]&1) << (7-i));
+    u128 r = spu_zero(); r._u32[0]=v; return r;
+}
+/* gather LSB of each SPU byte i into bit (15-i); exact inverse of spu_fsmb.
+ * SPU byte i lives at our _u8[SPU_W(i)] (byte-reversed within each word). */
+static inline u128 spu_gbb(u128 a) {
+    uint32_t v=0; for(int i=0;i<16;i++) v |= ((uint32_t)(a._u8[SPU_W(i)]&1) << (15-i));
     u128 r = spu_zero(); r._u32[0]=v; return r;
 }
 static inline u128 spu_cg(u128 a, u128 b)   { u128 r; for(int i=0;i<4;i++) r._u32[i]=(uint32_t)(((uint64_t)a._u32[i]+(uint64_t)b._u32[i])>>32); return r; }
+/* sumb: sum the 4 bytes of each word. Per CBEA, RT halfword 2i (the HIGH half of
+ * word i) = sum of RB's 4 bytes of word i; halfword 2i+1 (LOW half) = sum of RA's
+ * 4 bytes of word i. Computed on word VALUES so byte order is irrelevant. */
+static inline u128 spu_sumb(u128 a, u128 b) {
+    u128 r;
+    for(int i=0;i<4;i++) {
+        uint32_t wa=a._u32[i], wb=b._u32[i];
+        uint32_t sa=((wa>>24)&0xFF)+((wa>>16)&0xFF)+((wa>>8)&0xFF)+(wa&0xFF);
+        uint32_t sb=((wb>>24)&0xFF)+((wb>>16)&0xFF)+((wb>>8)&0xFF)+(wb&0xFF);
+        r._u32[i]=(sb<<16)|sa;
+    }
+    return r;
+}
+/* Borrow generate: carry-out of (b + ~a + 1) == (b >= a unsigned ? 1 : 0).
+ * The subtract-side sibling of cg; pairs with sf/sfx for extended subtraction. */
+static inline u128 spu_bg(u128 a, u128 b)   { u128 r; for(int i=0;i<4;i++) r._u32[i]=(uint32_t)(((uint64_t)b._u32[i]+(uint64_t)(~a._u32[i])+1u)>>32); return r; }
 static inline u128 spu_addx(u128 a, u128 b, u128 t) { u128 r; for(int i=0;i<4;i++) r._u32[i]=a._u32[i]+b._u32[i]+(t._u32[i]&1); return r; }
 /* LE host: high half of word i = _s16[2i+1], low half = _s16[2i]. */
 static inline u128 spu_mpyh(u128 a, u128 b) { u128 r; for(int i=0;i<4;i++) r._s32[i]=((int32_t)a._s16[2*i+1] * (int32_t)b._s16[2*i]) << 16; return r; }
@@ -203,8 +320,9 @@ static inline u128 spu_mpyui(u128 a, int32_t imm) { u128 r; for(int i=0;i<4;i++)
 static inline u128 spu_fcmeq(u128 a, u128 b){ u128 r; for(int i=0;i<4;i++){ float fa=fabsf(a._f32[i]),fb=fabsf(b._f32[i]); r._u32[i]=(fa==fb)?0xFFFFFFFFu:0; } return r; }
 static inline u128 spu_fcmgt(u128 a, u128 b){ u128 r; for(int i=0;i<4;i++){ float fa=fabsf(a._f32[i]),fb=fabsf(b._f32[i]); r._u32[i]=(fa>fb)?0xFFFFFFFFu:0; } return r; }
 static inline u128 spu_frsqest(u128 a){ u128 r; for(int i=0;i<4;i++) r._f32[i]= a._f32[i]>0.0f ? 1.0f/sqrtf(a._f32[i]) : 0.0f; return r; }
-/* frest: floating reciprocal estimate (~12-bit, refined by fi). 1/a per word. */
-static inline u128 spu_frest(u128 a){ u128 r; for(int i=0;i<4;i++) r._f32[i]= a._f32[i]!=0.0f ? 1.0f/a._f32[i] : 0.0f; return r; }
+/* frest: reciprocal estimate (refined by the following spu_fi Newton step).
+ * Full-precision 1/x is exact after fi and >= HW-estimate accuracy. */
+static inline u128 spu_frest(u128 a){ u128 r; for(int i=0;i<4;i++) r._f32[i]= 1.0f/a._f32[i]; return r; }
 
 /* ---- Phase 3: sign extension ----
  * LE host: low sub-lane = _u8[2i] / _s16[2i] / _s32[2i] (the byte/half/word
@@ -226,44 +344,63 @@ static inline u128 spu_fsm(u128 a) {
     for(int i=0;i<4;i++) r._u32[i] = ((v>>(3-i))&1) ? 0xFFFFFFFFu : 0;
     return r;
 }
+/* fsmh: per-halfword mask from 8 bits. SPU halfword H <- bit (7-H); store at
+ * our _u16[H^1] (within-word halfword swap of the value layout). Per-halfword
+ * both bytes are identical so byte order within a halfword is irrelevant, but
+ * the halfword ORDER within each word must be swapped. */
 static inline u128 spu_fsmh(u128 a) {
     u128 r; uint32_t v = a._u32[0] & 0xFF;
-    for(int i=0;i<8;i++) r._u16[i] = ((v>>(7-i))&1) ? 0xFFFFu : 0;
+    for(int i=0;i<8;i++) r._u16[i^1] = ((v>>(7-i))&1) ? 0xFFFFu : 0;
     return r;
 }
+/* fsmb/fsmbi: per-byte mask from 16 bits. SPU byte position P <- bit (15-P);
+ * store at our _u8[SPU_W(P)] (byte-reversed within each word). A bit set at SPU
+ * byte P must land at our _u8[SPU_W(P)] so that downstream word arithmetic (e.g.
+ * andbi(fsmbi(0x101),-128) building a +0x80 EA offset in the low byte of words
+ * 1,3) places the value in the correct byte lane. Raw _u8[P] would put 0x80 in
+ * the high byte (bit 31) instead -> wrong DMA EA. */
 static inline u128 spu_fsmb(u128 a) {
     u128 r; uint32_t v = a._u32[0] & 0xFFFF;
-    for(int i=0;i<16;i++) r._u8[i] = ((v>>(15-i))&1) ? 0xFFu : 0;
+    for(int i=0;i<16;i++) r._u8[SPU_W(i)] = ((v>>(15-i))&1) ? 0xFFu : 0;
     return r;
 }
 static inline u128 spu_fsmbi(int32_t imm) {
     u128 r; uint32_t v = imm & 0xFFFF;
-    for(int i=0;i<16;i++) r._u8[i] = ((v>>(15-i))&1) ? 0xFFu : 0;
+    for(int i=0;i<16;i++) r._u8[SPU_W(i)] = ((v>>(15-i))&1) ? 0xFFu : 0;
     return r;
 }
 
 /* ---- Phase 3: constant generators (insertion shuffle patterns) ---- */
+/* Generate-controls (cbd/chd/cwd/cdd) — insertion selectors for the (now
+ * SPU-byte-correct) shufb. Each builds a control in TRUE SPU byte order: the
+ * base selects b's SPU byte t at result SPU byte t (selector 0x10+t), and the
+ * insert positions select a's preferred scalar bytes -- SPU byte 3 for a byte
+ * (selector 0x03), SPU bytes 2,3 for a halfword (0x02,0x03), SPU bytes 0..3 for
+ * a word, 0..7 for a doubleword. Every store is mapped through SPU_W to land at
+ * the right host index. Verified to compose correctly with the fixed shufb for
+ * both cbd-generated and immediate/LS-constant controls. */
 static inline u128 spu_cbd_pos(int pos) {
-    u128 r; for(int i=0;i<16;i++) r._u8[i] = (uint8_t)(0x10|i);
-    r._u8[pos & 0xF] = 0x03;
+    u128 r; for(int t=0;t<16;t++) r._u8[SPU_W(t)] = (uint8_t)(0x10 + t);
+    r._u8[SPU_W(pos & 0xF)] = 0x03;                 /* a's preferred byte = SPU byte 3 */
     return r;
 }
 static inline u128 spu_chd_pos(int pos) {
-    u128 r; for(int i=0;i<16;i++) r._u8[i] = (uint8_t)(0x10|i);
-    int t = (pos & 0xF) & ~1;
-    r._u8[t] = 0x02; r._u8[t+1] = 0x03;
+    u128 r; for(int t=0;t<16;t++) r._u8[SPU_W(t)] = (uint8_t)(0x10 + t);
+    int p = (pos & 0xF) & ~1;                       /* SPU halfword byte positions p, p+1 */
+    r._u8[SPU_W(p)]   = 0x02;                        /* a SPU byte 2 (hi byte of preferred hw) */
+    r._u8[SPU_W(p+1)] = 0x03;                        /* a SPU byte 3 (lo byte) */
     return r;
 }
 static inline u128 spu_cwd_pos(int pos) {
-    u128 r; for(int i=0;i<16;i++) r._u8[i] = (uint8_t)(0x10|i);
-    int t = (pos & 0xF) & ~3;
-    r._u8[t]=0x00; r._u8[t+1]=0x01; r._u8[t+2]=0x02; r._u8[t+3]=0x03;
+    u128 r; for(int t=0;t<16;t++) r._u8[SPU_W(t)] = (uint8_t)(0x10 + t);
+    int p = (pos & 0xF) & ~3;
+    for(int k=0;k<4;k++) r._u8[SPU_W(p+k)] = (uint8_t)k;   /* a SPU bytes 0..3 (preferred word) */
     return r;
 }
 static inline u128 spu_cdd_pos(int pos) {
-    u128 r; for(int i=0;i<16;i++) r._u8[i] = (uint8_t)(0x10|i);
-    int t = (pos & 0xF) & ~7;
-    for(int j=0;j<8;j++) r._u8[t+j] = (uint8_t)j;
+    u128 r; for(int t=0;t<16;t++) r._u8[SPU_W(t)] = (uint8_t)(0x10 + t);
+    int p = (pos & 0xF) & ~7;
+    for(int k=0;k<8;k++) r._u8[SPU_W(p+k)] = (uint8_t)k;   /* a SPU bytes 0..7 (preferred dword) */
     return r;
 }
 static inline u128 spu_cbd(u128 a, int i7){ return spu_cbd_pos((int)a._u32[0]+i7); }
@@ -281,11 +418,17 @@ static inline u128 spu_rotma(u128 a, u128 b)  { u128 r; for(int i=0;i<4;i++){ ui
 static inline u128 spu_rothm(u128 a, u128 b)  { u128 r; for(int i=0;i<8;i++){ uint32_t sh=(0-b._u16[i])&0x1F; r._u16[i]=(sh>15)?0:(uint16_t)(a._u16[i]>>sh); } return r; }
 static inline u128 spu_rothma(u128 a, u128 b) { u128 r; for(int i=0;i<8;i++){ uint32_t sh=(0-b._u16[i])&0x1F; r._s16[i]=(sh>15)?(a._s16[i]>>15):(a._s16[i]>>sh); } return r; }
 static inline u128 spu_rothmi(u128 a, int i7) { u128 r; int sh=(0-i7)&0x1F; for(int i=0;i<8;i++) r._u16[i]=(sh>15)?0:(uint16_t)(a._u16[i]>>sh); return r; }
-static inline u128 spu_rotqmbi(u128 a, u128 b)   { int sh=(0-(int)b._u32[0])&7; if(!sh) return a; u128 r; r._u64[1]=(a._u64[1]>>sh)|(a._u64[0]<<(64-sh)); r._u64[0]=(a._u64[0]>>sh); return r; }
-static inline u128 spu_rotqmby(u128 a, u128 b)   { int sh=(0-(int)b._u32[0])&0x1F; u128 r; if(sh>=16) return spu_zero(); for(int i=0;i<16;i++){ int s=i-sh; r._u8[i]=(s>=0)?a._u8[s]:0; } return r; }
-static inline u128 spu_rotqmbybi(u128 a, u128 b) { int sh=(0-((int)b._u32[0]>>3))&0x1F; u128 r; if(sh>=16) return spu_zero(); for(int i=0;i<16;i++){ int s=i-sh; r._u8[i]=(s>=0)?a._u8[s]:0; } return r; }
-static inline u128 spu_rotqmbii(u128 a, int i7)  { int sh=(0-i7)&7; if(!sh) return a; u128 r; r._u64[1]=(a._u64[1]>>sh)|(a._u64[0]<<(64-sh)); r._u64[0]=(a._u64[0]>>sh); return r; }
-static inline u128 spu_rotqmbyi(u128 a, int i7)  { int sh=(0-i7)&0x1F; u128 r; if(sh>=16) return spu_zero(); for(int i=0;i<16;i++){ int s=i-sh; r._u8[i]=(s>=0)?a._u8[s]:0; } return r; }
+static inline u128 spu_rotqmbi(u128 a, u128 b)   { int sh=(0-(int)b._u32[0])&7; if(!sh) return a;
+    uint64_t hi=((uint64_t)a._u32[0]<<32)|a._u32[1], lo=((uint64_t)a._u32[2]<<32)|a._u32[3];
+    uint64_t nlo=(lo>>sh)|(hi<<(64-sh)), nhi=(hi>>sh);
+    u128 r; r._u32[0]=(uint32_t)(nhi>>32); r._u32[1]=(uint32_t)nhi; r._u32[2]=(uint32_t)(nlo>>32); r._u32[3]=(uint32_t)nlo; return r; }
+static inline u128 spu_rotqmby(u128 a, u128 b)   { int sh=(0-(int)b._u32[0])&0x1F; u128 r=spu_zero(); if(sh>=16) return r; for(int i=0;i<16;i++){ int s=i-sh; if(s>=0) r._u8[SPU_W(i)]=a._u8[SPU_W(s)]; } return r; }
+static inline u128 spu_rotqmbybi(u128 a, u128 b) { int sh=(0-((int)b._u32[0]>>3))&0x1F; u128 r=spu_zero(); if(sh>=16) return r; for(int i=0;i<16;i++){ int s=i-sh; if(s>=0) r._u8[SPU_W(i)]=a._u8[SPU_W(s)]; } return r; }
+static inline u128 spu_rotqmbii(u128 a, int i7)  { int sh=(0-i7)&7; if(!sh) return a;
+    uint64_t hi=((uint64_t)a._u32[0]<<32)|a._u32[1], lo=((uint64_t)a._u32[2]<<32)|a._u32[3];
+    uint64_t nlo=(lo>>sh)|(hi<<(64-sh)), nhi=(hi>>sh);
+    u128 r; r._u32[0]=(uint32_t)(nhi>>32); r._u32[1]=(uint32_t)nhi; r._u32[2]=(uint32_t)(nlo>>32); r._u32[3]=(uint32_t)nlo; return r; }
+static inline u128 spu_rotqmbyi(u128 a, int i7)  { int sh=(0-i7)&0x1F; u128 r=spu_zero(); if(sh>=16) return r; for(int i=0;i<16;i++){ int s=i-sh; if(s>=0) r._u8[SPU_W(i)]=a._u8[SPU_W(s)]; } return r; }
 
 /* ---- Phase 3: halfword/byte immediate logic ---- */
 static inline u128 spu_andhi(u128 a, int32_t imm) { u128 r; uint16_t v=(uint16_t)imm; for(int i=0;i<8;i++) r._u16[i]=a._u16[i]&v; return r; }
@@ -304,42 +447,6 @@ static inline u128 spu_bgx(u128 a, u128 b, u128 t) {
     return r;
 }
 
-/* bg: borrow generate (non-extended) = bgx with carry-in fixed to 1.
- * rt.u32[i] = 1 if (rb >= ra) i.e. no borrow in (rb - ra), else 0. */
-static inline u128 spu_bg(u128 a, u128 b) {
-    u128 r;
-    for(int i=0;i<4;i++) {
-        uint64_t s = (uint64_t)b._u32[i] + (uint64_t)(~a._u32[i]) + 1u;
-        r._u32[i] = (uint32_t)(s >> 32);
-    }
-    return r;
-}
-
-/* avgb: average bytes, rounded up. rt.u8[i] = (ra.u8[i] + rb.u8[i] + 1) >> 1. */
-static inline u128 spu_avgb(u128 a, u128 b) {
-    u128 r;
-    for(int i=0;i<16;i++) r._u8[i] = (uint8_t)(((unsigned)a._u8[i] + (unsigned)b._u8[i] + 1u) >> 1);
-    return r;
-}
-
-/* gbb: gather LSB of each of 16 bytes into the low 16 bits of the preferred
- * word (byte 0's bit -> bit 15), mirroring spu_gbh. */
-static inline u128 spu_gbb(u128 a) {
-    uint32_t v=0; for(int i=0;i<16;i++) v |= ((uint32_t)(a._u8[i]&1) << (15-i));
-    u128 r = spu_zero(); r._u32[0]=v; return r;
-}
-
-/* ---- double-precision (2 doubles per register, slots 0 and 1) ---- */
-static inline u128 spu_dfa(u128 a, u128 b) { u128 r; r._f64[0]=a._f64[0]+b._f64[0]; r._f64[1]=a._f64[1]+b._f64[1]; return r; }
-static inline u128 spu_dfs(u128 a, u128 b) { u128 r; r._f64[0]=a._f64[0]-b._f64[0]; r._f64[1]=a._f64[1]-b._f64[1]; return r; }
-static inline u128 spu_dfm(u128 a, u128 b) { u128 r; r._f64[0]=a._f64[0]*b._f64[0]; r._f64[1]=a._f64[1]*b._f64[1]; return r; }
-/* fesd: extend single->double, from even word slots (0,2) into doubles (0,1). */
-static inline u128 spu_fesd(u128 a) { u128 r; r._f64[0]=(double)a._f32[0]; r._f64[1]=(double)a._f32[2]; return r; }
-/* frds: round double->single, into even word slots (0,2); odd slots cleared. */
-static inline u128 spu_frds(u128 a) { u128 r=spu_zero(); r._f32[0]=(float)a._f64[0]; r._f32[2]=(float)a._f64[1]; return r; }
-/* fscrwr: FP status/control register write — no architectural state modeled. */
-static inline u128 spu_fscrwr(u128 a) { (void)a; return spu_zero(); }
-
 /* ---- Phase 3: mfspr stub ---- */
 static inline u128 spu_mfspr(u128 a) { (void)a; return spu_zero(); }
 
@@ -349,11 +456,6 @@ static inline u128 spu_ila(uint32_t i18) { return spu_splat_u32(i18 & 0x3FFFF); 
 static inline u128 spu_ilh(uint16_t imm) { return spu_splat_u16(imm); }
 static inline u128 spu_ilhu(uint16_t imm){ return spu_splat_u32((uint32_t)imm << 16); }
 static inline u128 spu_iohl(u128 a, uint16_t imm){ u128 r; for(int i=0;i<4;i++) r._u32[i]=a._u32[i]|(uint32_t)imm; return r; }
-
-/* Cleanly abort the current lifted SPU job (longjmp back to the dispatcher in
- * spu_run_lifted_job_*). Used for the `br .` infinite-halt idiom -- returning a
- * status flag is not enough because lifted code never checks it. */
-void spu_halt(spu_context* ctx);
 
 #ifdef __cplusplus
 }

--- a/runtime/spu/spu_lifted_job.h
+++ b/runtime/spu/spu_lifted_job.h
@@ -60,12 +60,42 @@ static inline int32_t spu_run_lifted_job_abi(spu_lifted_entry_fn entry,
             ctx.gpr[3]._u32[1] = args_ea;          /* eaContext (DMA'd first) */
             ctx.gpr[3]._u32[2] = r3_override[2];   /* queue/lock EA           */
             ctx.gpr[3]._u32[3] = r3_override[3];
+        } else if (image_id == 22) {
+            /* cri_mpv leaf (func_00003E68) gate is `rotmai(r3.word0, 112) == 64`
+             * = an ARITHMETIC RIGHT-SHIFT BY 16 then ceqi 64, i.e. it wants
+             * (r3.word0 >> 16) == 0x40  ->  r3.word0 = 0x0040xxxx (0x40 in bits
+             * 16-23, low 16 = DMA tag). If it matches it takes the REAL decode
+             * path (func_00003ED8, which DMAs the video job); else it halts
+             * (func_00003ED0). NOTE: r3.word0 = 0x40 (my earlier misread) shifts
+             * to 0 and FAILS the gate -> no decode, no DMA. Use 0x00400000. */
+            ctx.gpr[3]._u32[0] = 0x00400000u;   /* >>16 == 64 -> cri real decode path */
+            ctx.gpr[3]._u32[1] = args_ea;       /* eaContext -> r3.word1 */
         } else {
             ctx.gpr[3]._u32[0] = 0x00400000u;   /* 0x40 marker (>>16==64), DMA tag 0 */
             ctx.gpr[3]._u32[1] = args_ea;       /* eaContext -> r3.word1 */
         }
     } else {
         ctx.gpr[3]._u32[0] = args_ea;                           /* simple-job arg -> r3 */
+    }
+    /* The r3_override path already carries the game's 0x0040xxxx marker (which
+     * passes the (r3.word0>>16)==0x40 gate), so do NOT clobber it. The earlier
+     * forced r3.word0=0x40 here was a misread of the gate (see above) and made
+     * the cri task halt at func_00003ED0 instead of decoding -- removed. */
+    /* SPURS leaf ABI: the real PM (spursTasksetStartTask) sets r4 = {taskset->args (d0),
+     * taskset->spurs EA (d1)}, read from the SpursTasksetContext at LS 0x2700+0x60/0x68
+     * (planted by spurs_pm_build_context). Without it the leaf reads a garbage SPURS base
+     * and DMAs from a bad address / bails at init. Set for image 22 (cri) when the context
+     * carries a non-zero spurs ptr. */
+    if (spurs_task_abi && image_id == 22) {
+        #define LB(o) (((uint32_t)ctx.ls[(o)]<<24)|((uint32_t)ctx.ls[(o)+1]<<16)|((uint32_t)ctx.ls[(o)+2]<<8)|ctx.ls[(o)+3])
+        uint32_t spurs_lo = LB(0x2764);
+        if (spurs_lo) {
+            ctx.gpr[4]._u32[0] = LB(0x2768);   /* args hi (d0) */
+            ctx.gpr[4]._u32[1] = LB(0x276C);   /* args lo      */
+            ctx.gpr[4]._u32[2] = LB(0x2760);   /* spurs hi (d1)*/
+            ctx.gpr[4]._u32[3] = spurs_lo;     /* spurs lo = CellSpurs EA */
+        }
+        #undef LB
     }
     { extern int spu_run_with_halt(void (*)(spu_context*), spu_context*);
       spu_run_with_halt(entry, &ctx); }                         /* run with halt pad   */

--- a/runtime/spu/spu_workload.c
+++ b/runtime/spu/spu_workload.c
@@ -16,6 +16,12 @@
 #include <pthread.h>
 #endif
 
+/* Set by the MFC DMA engine (spu_dma.h) when the cri task (image 22) issues a
+ * real video-payload GET (>256B from a non-context EA) = it actually decoded,
+ * as opposed to the 64-byte context handshake DMAs. The dispatcher's
+ * YDKJ_CRI_RESUME poll-loop watches this to know real work arrived. */
+int g_cri_video_dma = 0;
+
 /* ---- fingerprint ------------------------------------------------------- */
 
 uint64_t spu_workload_fingerprint(const void* data, size_t n)
@@ -241,12 +247,125 @@ static void spu_async_run(spu_async_job* j)
     if (ls) {
         uint32_t entry = 0;
         if (spu_elf_load_to_ls(j->image, j->image_size, ls, &entry)) {
+            /* YDKJ_CRI_POLICY (cri build experiment): the cri SPU task
+             * (image 22) calls the SPURS task-API via a jump table at LS 0x2700
+             * and reads its task descriptor at LS 0x2FB0 — both POLICY-provided,
+             * not in the task ELF (so it branch-to-0's at func_00026DE0). Preload
+             * the policy module (libsre @0x30021480 -> LS 0xA00) and write the
+             * task descriptor {0xFFFFFFFF, 0x400, 0x2700, 0x3000} at 0x2FB0, then
+             * run the cri task, to see how much further it gets. Diagnostic only. */
+            if (j->image_id == 22 && getenv("YDKJ_CRI_TASKSET")) {
+                /* cri build: load the TASKSET POLICY module (libsre 0x23680 ->
+                 * LS 0xA00) alongside the cri task (already at 0x3000), then RUN
+                 * THE POLICY ENTRY (tsp_spu_func_00000A00) under image 23. The
+                 * policy builds the 0x2700 task-API table + dispatches the cri
+                 * task. Needs the SpursKernelContext at LS[0x1C0] (instance ptr)
+                 * + r80=0x100 context base, mirroring the kernel->policy handoff. */
+                extern uint8_t* vm_base;
+                extern void tsp_spu_func_00000A00(spu_context*);
+                if (vm_base) memcpy(ls + 0xA00, vm_base + 0x30023680, 0x2200);
+                /* SpursKernelContext.spurs (LS[0x1C0]) = the CellSpurs instance EA. */
+                uint32_t inst = 0x40009D00u;
+                uint8_t* p = ls + 0x1C0;
+                p[0]=0; p[1]=0; p[2]=0; p[3]=0;                 /* hi32 of u64 */
+                p[4]=(uint8_t)(inst>>24); p[5]=(uint8_t)(inst>>16);
+                p[6]=(uint8_t)(inst>>8);  p[7]=(uint8_t)inst;   /* lo32 */
+                fprintf(stderr, "[cri] YDKJ_CRI_TASKSET: loaded taskset policy@0xA00, LS[0x1C0]=inst, running policy entry (img23)\n");
+                fflush(stderr);
+                /* Run the taskset policy entry instead of the cri task entry. */
+                extern int32_t spu_run_lifted_job_abi(void(*)(spu_context*), uint8_t*, uint32_t, int, int, uint32_t*);
+                int32_t prc = spu_run_lifted_job_abi(tsp_spu_func_00000A00, ls,
+                                                     j->args_ea, 23, 1, j->have_r3 ? j->r3 : 0);
+                fprintf(stderr, "[cri] taskset policy RETURNED rc=%d\n", prc);
+                fflush(stderr);
+                free(ls); free(j); return;
+            }
+            /* YDKJ HLE cri-task path (image 22, cri_mpvps3spurs.elf): the real
+             * SPURS kernel/policy would build the task's SpursTasksetContext (LS
+             * 0x2700) before dispatch. In the HLE-cellSpurs path we dispatch the
+             * task ELF directly, so LS 0x2700 is empty and the task branch-to-0's:
+             * cri func_00026DE0 reads syscallAddr@0x27C4 (=0) and branches there.
+             * Plant a minimal context so the task-API call lands on the HLE syscall
+             * trampoline (LS 0xA70, intercepted in spu_channels.c) + the task
+             * descriptor @0x2FB0. Adopted from JonathanDC64/ps3recomp (aaea4158).
+             * Gate: default on for image 22 unless YDKJ_NO_CRI_CTX. */
+            if (j->image_id == 22 && !getenv("YDKJ_NO_CRI_CTX")) {
+                extern uint64_t spurs_pm_build_context(uint8_t*, uint32_t, uint32_t, uint32_t, uint32_t);
+                extern uint32_t g_ydkj_real_taskset_ea, g_ydkj_real_taskid;
+                #define LSBE32(o,v) do{uint32_t _v=(v);ls[(o)+0]=(uint8_t)(_v>>24);ls[(o)+1]=(uint8_t)(_v>>16);ls[(o)+2]=(uint8_t)(_v>>8);ls[(o)+3]=(uint8_t)_v;}while(0)
+                if (g_ydkj_real_taskset_ea && !getenv("YDKJ_MINIMAL_CTX")) {
+                    /* REAL taskset context: build the SpursTasksetContext at LS 0x2700
+                     * from the actual BE CellSpursTaskset (spurs ptr, args, TaskInfo)
+                     * so the cri leaf reads valid data instead of my planted guesses. */
+                    uint64_t elf = spurs_pm_build_context(ls, g_ydkj_real_taskset_ea, g_ydkj_real_taskid, 0, 0);
+                    /* still plant the cri-specific task descriptor @0x2FB0 that build_context
+                     * doesn't cover (cri func_00026DE0 reads it). */
+                    LSBE32(0x2FB0, 0xFFFFFFFFu); LSBE32(0x2FB4, 0x400);
+                    LSBE32(0x2FB8, 0x2700);      LSBE32(0x2FBC, 0x3000);
+                    fprintf(stderr, "[cri] REAL SpursTasksetContext built from taskset 0x%08X task %u (elf=0x%llX)\n",
+                            g_ydkj_real_taskset_ea, g_ydkj_real_taskid, (unsigned long long)elf);
+                } else {
+                    LSBE32(0x27C0, 0x100);     /* kernelMgmtAddr -> SPURS kernel ctx @LS 0x100 */
+                    LSBE32(0x27C4, 0xA70);     /* syscallAddr -> HLE PM syscall trampoline (0xA70) */
+                    LSBE32(0x2FB0, 0xFFFFFFFFu); LSBE32(0x2FB4, 0x400);
+                    LSBE32(0x2FB8, 0x2700);      LSBE32(0x2FBC, 0x3000);
+                    fprintf(stderr, "[cri] HLE cri-task ctx (minimal plant): syscallAddr@0x27C4=0xA70\n");
+                }
+                #undef LSBE32
+                fflush(stderr);
+            }
+            /* Dump the 64-byte decode context the cri task will DMA from eaContext
+             * (r3.word1 = args_ea). This is the job the game's cri_mpv PPU layer is
+             * supposed to populate (video-data EA, output buffer). If it's zero/garbage
+             * the PPU layer never wrote a real job -> the task decodes nothing. */
+            if (j->image_id == 22 && j->args_ea) {
+                extern uint8_t* vm_base;
+                const uint8_t* c = vm_base + (j->args_ea & 0x0FFFFFFFu);
+                fprintf(stderr, "[cri] eaContext=0x%08X 64B decode-context:", j->args_ea);
+                for (int i = 0; i < 64; i++) { if ((i&15)==0) fprintf(stderr,"\n     +%02X:", i); fprintf(stderr, " %02X", c[i]); }
+                fprintf(stderr, "\n"); fflush(stderr);
+            }
             /* Async dispatch is the SPURS-task path: the entry expects the SPURS
              * task kernel ABI in r3 ({0x40 marker, eaContext, queue EA, ...}),
              * captured at dispatch time (j->r3) so it doesn't race the PPU
              * overwriting the stack-allocated context. */
             int32_t rc = spu_run_lifted_job_abi(j->fn, ls, j->args_ea, j->image_id,
                                                 1, j->have_r3 ? j->r3 : 0);
+            /* YDKJ_CRI_RESUME: a real SPURS task is PERSISTENT -- on yield (num=0)
+             * the kernel re-enters it when work is signaled. Our HLE runs it once,
+             * so it polls the (concurrently PPU-updated) eaContext, finds no work,
+             * yields and exits before the PPU marks work-ready. Approximate the
+             * resume by re-running the task (fresh context re-read from eaContext)
+             * in a bounded loop until it actually DECODES (a >256B video GET sets
+             * g_cri_video_dma) or we time out. This does NOT fake data: the task
+             * only decodes if the PPU genuinely populated real work meanwhile. */
+            if (j->image_id == 22 && getenv("YDKJ_CRI_RESUME") && !g_cri_video_dma) {
+                for (int attempt = 0; attempt < 400 && !g_cri_video_dma; attempt++) {
+#ifdef _WIN32
+                    Sleep(3);
+#endif
+                    memset(ls, 0, SPU_LS_SIZE);
+                    uint32_t e2 = 0;
+                    if (!spu_elf_load_to_ls(j->image, j->image_size, ls, &e2)) break;
+                    rc = spu_run_lifted_job_abi(j->fn, ls, j->args_ea, j->image_id,
+                                                1, j->have_r3 ? j->r3 : 0);
+                    if (g_cri_video_dma) {
+                        fprintf(stderr, "[cri] RESUME: cri task DECODED real video (attempt %d)\n", attempt);
+                        break;
+                    }
+                }
+                if (!g_cri_video_dma)
+                    fprintf(stderr, "[cri] RESUME: no work-ready after 400 polls (PPU never marked work)\n");
+                fflush(stderr);
+            }
+            /* YDKJ_CRI_WAKE probe: on cri task (image 22) completion, wake any PPU
+             * completion-waiter (the SPU->PPU cellSpursEventFlag completion isn't
+             * propagated yet). Tests whether the game then advances to draw content. */
+            if (j->image_id == 22 && getenv("YDKJ_CRI_WAKE")) {
+                extern void ydkj_wake_all_event_flags(void);
+                ydkj_wake_all_event_flags();
+                fprintf(stderr, "[cri] YDKJ_CRI_WAKE: woke all event-flag waiters on cri completion\n");
+            }
             fprintf(stderr, "[spu_workload] async image=%d RETURNED rc=%d "
                     "(job ran to completion, did not loop)\n", j->image_id, rc);
         }

--- a/runtime/spu/tests/test_spu_helpers.c
+++ b/runtime/spu/tests/test_spu_helpers.c
@@ -30,8 +30,15 @@ static u128 make128(uint64_t hi, uint64_t lo) {
  * fsmbi, byte permutations). make128 above interprets values according to
  * host endianness, which is fine only for lane-symmetric vectors. */
 static u128 from_bytes(const uint8_t b[16]) {
+    /* Adapted to THIS runtime's u128 convention. Our u128 is host-native
+     * little-endian (_u32[i] = SPU word i as a value), so SPU byte i lives at
+     * _u8[SPU_W(i)], not _u8[i]. Upstream's u128 is a big-endian byte array
+     * (_u8[i] = SPU byte i), which is what these ISA vectors were written for.
+     * Routing the byte vector through SPU_W is the only change needed to make
+     * the byte-layout tests (shufb, cwd/cbd/chd/cdd, byte shifts) evaluate in
+     * our representation; every byte-position op already maps through SPU_W. */
     u128 r;
-    for (int i = 0; i < 16; i++) r._u8[i] = b[i];
+    for (int i = 0; i < 16; i++) r._u8[SPU_W(i)] = b[i];
     return r;
 }
 

--- a/runtime/syscalls/lv2_register.c
+++ b/runtime/syscalls/lv2_register.c
@@ -53,6 +53,32 @@ static int64_t sys_tty_write(ppu_context* ctx)
         /* Write guest string data to host stderr */
         fwrite(vm_base + buf_ea, 1, len, stderr);
         fflush(stderr);
+        /* DIAGNOSTIC (FLOW_PSSGTRACE=1): when the title logs a PhyreEngine
+         * init failure, dump the guest back-chain so we can locate the failing
+         * function (the message itself goes through here, not _sys_printf). */
+        if (getenv("FLOW_PSSGTRACE") && len < 4096) {
+            char tmp[256]; uint32_t n = len < 255 ? len : 255;
+            memcpy(tmp, vm_base + buf_ea, n); tmp[n] = 0;
+            /* The PhyreEngine failure message is written in fragments, so no
+             * single buffer holds "PSSG". Dump the back-chain for any fragment
+             * carrying init/error/Phyre keywords. */
+            if (strstr(tmp, "PSSG") || strstr(tmp, "Init") || strstr(tmp, "App") ||
+                strstr(tmp, "fail") || strstr(tmp, "Error") || strstr(tmp, "rror") ||
+                strstr(tmp, "PSpu") || strstr(tmp, "ation")) {
+                uint32_t sp = (uint32_t)ctx->gpr[1];
+                fprintf(stderr, "[pssg-bt] tty_write \"%.50s\" lr=0x%08X\n", tmp, (uint32_t)ctx->lr);
+                for (int i = 0; i < 28 && sp && sp < 0x10000000u; i++) {
+                    uint32_t nsp; memcpy(&nsp, vm_base + sp, 4);
+                    nsp = ((nsp>>24)&0xFF)|((nsp>>8)&0xFF00)|((nsp<<8)&0xFF0000)|((nsp<<24)&0xFF000000);
+                    if (nsp <= sp || nsp >= 0x10000000u) break;
+                    uint32_t lr; memcpy(&lr, vm_base + nsp + 0x10, 4);
+                    lr = ((lr>>24)&0xFF)|((lr>>8)&0xFF00)|((lr<<8)&0xFF0000)|((lr<<24)&0xFF000000);
+                    fprintf(stderr, "[pssg-bt]   #%d lr=0x%08X\n", i, lr);
+                    sp = nsp;
+                }
+                fflush(stderr);
+            }
+        }
     }
 
     /* Write back the number of bytes written */
@@ -162,6 +188,12 @@ typedef struct {
      * common pattern where the PPU writes job state into LS, the SPU runs
      * and writes results back to LS, then PPU reads them. */
     uint8_t*            local_store;
+    /* sys_spu_thread_connect_event(thread, eq, et): binds this SPU thread's
+     * outbound interrupt-mailbox events to a PPU event queue. When the SPU
+     * writes WrOutIntrMbox (or stop-and-signals), the runtime delivers an event
+     * to connected_queue so PPU code blocked in sys_event_queue_receive wakes. */
+    uint32_t            connected_queue;
+    uint32_t            connect_spup;
 } spu_thread_t;
 
 typedef struct {
@@ -310,12 +342,18 @@ static int64_t sys_spu_thread_group_create_handler(ppu_context* ctx)
  * idles; the full version polls the SPURS taskset (ctx = args_ea) and dispatches
  * the title's lifted SPU task images. */
 #define YDKJ_SPURS_KERNEL_ENTRY 0x5B555253u  /* 'SURS' marker entry */
+/* Project-side runner: runs the REAL lifted SPURS SPU kernel (sk_a, lifted in
+ * the title build, not the runtime lib) on this SPU thread. Set by the project
+ * at startup (src/ydkj_spurs_kernel.c). If unset, fall back to the idle loop. */
+int32_t (*g_ydkj_spurs_kernel_run)(uint32_t tid, uint32_t args_ea) = 0;
 static int32_t ydkj_hle_spurs_kernel(uint32_t tid, uint32_t args_ea,
                                      uint32_t args_size, void* user)
 {
     (void)args_size; (void)user;
     fprintf(stderr, "[HLE-SPURS] kernel SPU tid=0x%X ctx=0x%08X running\n", tid, args_ea);
     fflush(stderr);
+    if (g_ydkj_spurs_kernel_run)
+        return g_ydkj_spurs_kernel_run(tid, args_ea);   /* run the lifted kernel */
     /* Keep the group running so the SPURS handler sees a live SPU. */
     for (int i = 0; i < 1200; i++) {
 #ifdef _WIN32
@@ -393,6 +431,19 @@ static int64_t sys_spu_thread_initialize_handler(ppu_context* ctx)
     if (thread_num < 8)
         g->thread_indices[thread_num] = (uint32_t)(t - s_spu_threads);
 
+    /* EXPERIMENT (YDKJ_SPUREADY): the lifted libsre cellSpursInitialize busy-polls the
+     * SPU-thread descriptor field at img_ea+0x38 (e.g. 0x101671A8) for a non-zero
+     * "thread created/ready" status BEFORE it populates the SPURS instance / starts the
+     * group — but nothing in our HLE ever writes it (real lv2 does). Write the tid there
+     * to clear the poll so libsre can proceed past init. Diagnostic; value may need tuning. */
+    if (img_ea && getenv("YDKJ_SPUREADY")) {
+        uint32_t before = vm_read_be32(img_ea + 0x38);
+        vm_write_be32(img_ea + 0x38, t->tid);
+        fprintf(stderr, "[SPUREADY] wrote tid=0x%X to img+0x38=0x%08X (was 0x%08X)\n",
+                t->tid, img_ea + 0x38, before);
+        fflush(stderr);
+    }
+
     vm_write_be32(out_tid_ea, t->tid);
 
     fprintf(stderr, "[SPU] thread_init group=0x%X index=%u img=0x%08X args=0x%08X -> tid=0x%X entry=0x%08X\n",
@@ -438,6 +489,23 @@ static int64_t sys_spu_thread_group_start_handler(ppu_context* ctx)
     if (!g) { ctx->gpr[3] = (uint64_t)(int64_t)-1; return -1; }
     g->state = SPU_GROUP_STATE_RUNNING;
 
+    /* DIAG: dump the CellSpurs instance @0x40009D00 at group_start time, to see
+     * whether libsre has populated it BEFORE the SPU kernel threads spawn. */
+    { extern uint8_t* vm_base; static int s_d=0;
+      if (vm_base && s_d++ < 4) {
+        const uint8_t* in = vm_base + 0x40009D00;
+        fprintf(stderr, "[INSTDUMP] group_start id=0x%X CellSpurs@0x40009D00 (0x140 bytes):\n", id);
+        for (int row=0; row<10; row++){
+            fprintf(stderr, "  +0x%03X:", row*16);
+            for (int i=0;i<4;i++){ int o=row*16+i*4; uint32_t w=((uint32_t)in[o]<<24)|((uint32_t)in[o+1]<<16)|((uint32_t)in[o+2]<<8)|in[o+3]; fprintf(stderr," %08X",w);}
+            fprintf(stderr, "\n");
+        }
+        fflush(stderr);
+        /* Arm a page-guard on the instance page so we catch the libsre function
+         * that writes the CellSpurs struct (WWATCH misses memcpy/DMA writes). */
+        if (getenv("YDKJ_GUARD_INST")) { extern void ppu_guard_page(uint32_t); ppu_guard_page(0x40009D00); }
+      } }
+
     /* For each thread in the group, look up a registered PPU fallback by
      * the thread's SPU image entry point. Threads with a fallback run on
      * a host thread (real concurrency, like real SPUs). Threads without
@@ -467,7 +535,14 @@ static int64_t sys_spu_thread_group_start_handler(ppu_context* ctx)
             t->finish_event = CreateEventA(NULL, TRUE, FALSE, NULL);
         else
             ResetEvent(t->finish_event);
-        t->host_thread = CreateThread(NULL, 0, spu_fallback_thread_proc, t, 0, NULL);
+        /* Lifted SPU loops can become deep C tail-call recursion; give SPU host
+         * threads a large stack (reserved). Bumped to 512 MB to diagnose whether
+         * the cri/taskset-policy dispatch chain overflows (env YDKJ_BIGSTACK). */
+        SIZE_T _stk = getenv("YDKJ_BIGSTACK") ? (SIZE_T)512 * 1024 * 1024
+                                              : (SIZE_T)16 * 1024 * 1024;
+        t->host_thread = CreateThread(NULL, _stk,
+                                      spu_fallback_thread_proc, t,
+                                      STACK_SIZE_PARAM_IS_A_RESERVATION, NULL);
 #else
         pthread_mutex_init(&t->finish_event.mu, NULL);
         pthread_cond_init(&t->finish_event.cv, NULL);
@@ -581,6 +656,17 @@ static int64_t sys_spu_thread_group_join_handler(ppu_context* ctx)
 static int64_t sys_spu_thread_group_destroy_handler(ppu_context* ctx)
 {
     uint32_t id = (uint32_t)ctx->gpr[3];
+    /* EXPERIMENT (YDKJ_KEEPGROUP): libsre rolls back the SPURS kernel group during
+     * cellSpursInitialize (the handler asserts the SPU side is dead). Skip the
+     * destroy so the group + threads survive, to see whether libsre then proceeds
+     * (group_start) or just re-asserts. Logs the caller for diagnosis. */
+    if (getenv("YDKJ_KEEPGROUP") && id == 0x1000) {
+        fprintf(stderr, "[SPU] group_destroy id=0x%X SKIPPED (YDKJ_KEEPGROUP) caller_lr=0x%08X cia=0x%08X\n",
+                id, (uint32_t)ctx->lr, (uint32_t)ctx->cia);
+        fflush(stderr);
+        ctx->gpr[3] = 0;
+        return 0;
+    }
     spu_group_t* g = spu_find_group(id);
     if (g) {
         for (int i = 0; i < 8 && i < (int)g->num_threads; i++) {
@@ -700,6 +786,55 @@ static int64_t sys_spu_thread_group_disconnect_event_handler(ppu_context* ctx)
     fflush(stderr);
     ctx->gpr[3] = 0;
     return 0;
+}
+
+/* sys_spu_thread_connect_event(thread_id, eq_id, et) — bind an SPU thread's
+ * interrupt events to a PPU event queue. Previously a no-op stub, so the SPU's
+ * outbound interrupt mailbox had nowhere to deliver and PPU waiters on q=1/q=4
+ * (cellSpurs SpursHdlr / AsyncLoad) blocked forever. Record the binding here;
+ * the mailbox-delivery hook (below) uses it. */
+static int64_t sys_spu_thread_connect_event_handler(ppu_context* ctx)
+{
+    uint32_t tid = (uint32_t)ctx->gpr[3];
+    uint32_t eq  = (uint32_t)ctx->gpr[4];
+    uint32_t et  = (uint32_t)ctx->gpr[5];
+    spu_thread_t* t = spu_find_thread(tid);
+    if (t) { t->connected_queue = eq; t->connect_spup = et; }
+    fprintf(stderr, "[SPU] thread_connect_event tid=0x%X queue=0x%X et=0x%X%s\n",
+            tid, eq, et, t ? "" : " (thread not found)");
+    fflush(stderr);
+    ctx->gpr[3] = 0;
+    return 0;
+}
+
+/* SPU -> PPU outbound mailbox delivery. Installed into spu_channels.c's
+ * g_spu_out_mbox_hook; called when a (kernel/policy/task) SPU thread writes
+ * WrOutMbox/WrOutIntrMbox. Route the value to the event queue bound to the SPU
+ * thread (via connect_event) or its group, so a blocked PPU SpursHdlr/AsyncLoad
+ * receive wakes. The event carries the mbox value in data1 so the handler can
+ * dispatch on it. Only the interrupt mailbox (is_intr) raises a PPU event on
+ * real hardware; the plain mailbox is PPU-polled, but we deliver both as events
+ * here (harmless: a handler that doesn't expect data ignores it) gated so we
+ * don't flood. */
+extern int sys_event_queue_push_by_id(uint32_t, uint64_t, uint64_t, uint64_t, uint64_t);
+static void ydkj_spu_out_mbox_deliver(uint32_t group_id, uint32_t spu_id,
+                                      int is_intr, uint32_t value)
+{
+    /* Find the queue: prefer the per-thread connect_event binding; fall back to
+     * the group's connected queue. */
+    uint32_t q = 0;
+    spu_thread_t* t = spu_find_thread(spu_id);
+    if (t && t->connected_queue) q = t->connected_queue;
+    if (!q) { spu_group_t* g = spu_find_group(group_id); if (g) q = g->event_queue_id; }
+    if (!q) return;
+    /* SPURS SPU-event source convention: high word tags it as an SPU thread
+     * event; data1 = the mailbox value. */
+    sys_event_queue_push_by_id(q,
+        ((uint64_t)spu_id << 32) | (is_intr ? 0x2u : 0x1u),
+        (uint64_t)value, 0, 0);
+    { static int s_w = 0; if (s_w++ < 32)
+        fprintf(stderr, "[SPU->PPU] mbox deliver spu=0x%X intr=%d val=0x%08X -> q=%u\n",
+                spu_id, is_intr, value, q); }
 }
 
 /* SPU virtual local store. Real hardware: 256 KB per SPU. We allocate on
@@ -951,6 +1086,10 @@ void lv2_register_all_syscalls(lv2_syscall_table* tbl)
     /* TTY (debug console I/O — used by CRT startup) */
     lv2_syscall_register(tbl, SYS_TTY_READ,  sys_tty_read);
     lv2_syscall_register(tbl, SYS_TTY_WRITE, sys_tty_write);
+    /* Some SDK-era CRTs (Tokyo Jungle, Sonic/Gunstar hubs, 4 Elements HD) issue
+     * sys_tty_write under the alternate number 988 (0x3DC) instead of 403; an
+     * unimplemented return derails the CRT init table-walk into abort(). Alias it. */
+    lv2_syscall_register(tbl, 988, sys_tty_write);
 
     /* SPU syscalls — we don't execute SPU code but the PPU-side wrappers
      * need consistent IDs and out-params. See the stateful group tracker
@@ -970,7 +1109,9 @@ void lv2_register_all_syscalls(lv2_syscall_table* tbl)
     lv2_syscall_register(tbl, SYS_SPU_THREAD_INITIALIZE,      sys_spu_thread_initialize_handler);
     lv2_syscall_register(tbl, SYS_SPU_THREAD_SET_ARGUMENT,    sys_spu_thread_set_argument_handler);
     lv2_syscall_register(tbl, SYS_SPU_THREAD_GET_EXIT_STATUS, sys_spu_thread_get_exit_status_handler);
-    lv2_syscall_register(tbl, SYS_SPU_THREAD_CONNECT_EVENT,   sys_spu_thread_stub);
+    lv2_syscall_register(tbl, SYS_SPU_THREAD_CONNECT_EVENT,   sys_spu_thread_connect_event_handler);
+    { extern void (*g_spu_out_mbox_hook)(uint32_t,uint32_t,int,uint32_t);
+      g_spu_out_mbox_hook = ydkj_spu_out_mbox_deliver; }
     lv2_syscall_register(tbl, SYS_SPU_THREAD_DISCONNECT_EVENT,sys_spu_thread_stub);
     lv2_syscall_register(tbl, SYS_SPU_THREAD_GROUP_CONNECT_EVENT, sys_spu_thread_group_connect_event_handler);
     lv2_syscall_register(tbl, SYS_SPU_THREAD_GROUP_DISCONNECT_EVENT, sys_spu_thread_group_disconnect_event_handler);

--- a/runtime/syscalls/sys_cond.c
+++ b/runtime/syscalls/sys_cond.c
@@ -5,6 +5,9 @@
 #include "sys_cond.h"
 #include "../memory/vm.h"
 #include <string.h>
+#include <stdlib.h>
+/* RtlCaptureStackBackTrace + GetModuleHandleA come from <windows.h> (pulled in
+ * by sys_cond.h for CRITICAL_SECTION) -- do not redeclare them. */
 
 /* ---------------------------------------------------------------------------
  * Globals
@@ -147,7 +150,21 @@ int64_t sys_cond_wait(ppu_context* ctx)
 {
     uint32_t cond_id    = LV2_ARG_U32(ctx, 0);
     uint64_t timeout_us = LV2_ARG_U64(ctx, 1);
-    fprintf(stderr, "[WAIT] cond_wait(cond=%u timeout=%llu)\n", cond_id, (unsigned long long)timeout_us);
+    fprintf(stderr, "[WAIT] cond_wait(cond=%u timeout=%llu) tid=%llu lr=0x%08X\n", cond_id, (unsigned long long)timeout_us,
+            (unsigned long long)ctx->thread_id, (uint32_t)ctx->lr);
+#ifdef _WIN32
+    if (cond_id == 7) {
+        static int _n = 0;
+        if (_n++ < 1) {
+            void* bt[24]; unsigned short fr = RtlCaptureStackBackTrace(0, 24, bt, 0);
+            char* mb = (char*)GetModuleHandleA(0);
+            char line[640]; int p = snprintf(line, sizeof line, "[cond7-bt] fr=%u rva:", (unsigned)fr);
+            for (int i = 0; i < fr; i++)
+                p += snprintf(line+p, sizeof(line)-p, " %llX", (unsigned long long)((char*)bt[i]-mb));
+            fprintf(stderr, "%s\n", line); fflush(stderr);
+        }
+    }
+#endif
 
     if (cond_id == 0 || cond_id > SYS_COND_MAX)
         return (int64_t)(int32_t)CELL_ESRCH;
@@ -176,6 +193,11 @@ int64_t sys_cond_wait(ppu_context* ctx)
 #ifdef _WIN32
     DWORD ms = (timeout_us == 0) ? INFINITE : (DWORD)(timeout_us / 1000);
     if (ms == 0 && timeout_us > 0) ms = 1;
+    /* FLOW_CONDKICK (SPU-bring-up diagnostic): cond=7 is waited on but never
+     * signaled (its signaler is blocked on the dead SPU pipeline). Cap infinite
+     * waits and return CELL_OK so the engine can advance past spurious waits. */
+    static int s_kick = -1; if (s_kick < 0) s_kick = getenv("FLOW_CONDKICK") ? 1 : 0;
+    if (s_kick && ms == INFINITE) ms = 1500;
 
     BOOL ok = SleepConditionVariableCS(&c->cv, &m->cs, ms);
 
@@ -184,6 +206,7 @@ int64_t sys_cond_wait(ppu_context* ctx)
     m->lock_count = saved_count;
 
     if (!ok && GetLastError() == ERROR_TIMEOUT) {
+        if (s_kick) return CELL_OK;   /* pretend signaled so the guest re-checks/proceeds */
         return (int64_t)(int32_t)CELL_ETIMEDOUT;
     }
 #else
@@ -226,6 +249,8 @@ int64_t sys_cond_wait(ppu_context* ctx)
 int64_t sys_cond_signal(ppu_context* ctx)
 {
     uint32_t cond_id = LV2_ARG_U32(ctx, 0);
+    { static int n=0; if(n++<80) fprintf(stderr,"[SIGNAL] cond_signal(cond=%u) tid=%llu lr=0x%08X\n", cond_id,
+            (unsigned long long)ctx->thread_id, (uint32_t)ctx->lr); }
 
     if (cond_id == 0 || cond_id > SYS_COND_MAX)
         return (int64_t)(int32_t)CELL_ESRCH;
@@ -251,6 +276,7 @@ int64_t sys_cond_signal(ppu_context* ctx)
 int64_t sys_cond_signal_all(ppu_context* ctx)
 {
     uint32_t cond_id = LV2_ARG_U32(ctx, 0);
+    { static int n=0; if(n++<40) fprintf(stderr,"[SIGNAL] cond_signal_all(cond=%u)\n", cond_id); }
 
     if (cond_id == 0 || cond_id > SYS_COND_MAX)
         return (int64_t)(int32_t)CELL_ESRCH;

--- a/runtime/syscalls/sys_event.c
+++ b/runtime/syscalls/sys_event.c
@@ -199,7 +199,9 @@ int64_t sys_event_queue_receive(ppu_context* ctx)
     uint32_t queue_id    = LV2_ARG_U32(ctx, 0);
     uint32_t event_addr  = LV2_ARG_PTR(ctx, 1);
     uint64_t timeout_us  = LV2_ARG_U64(ctx, 2);
-    fprintf(stderr, "[WAIT] event_queue_receive(q=%u timeout=%llu)\n", queue_id, (unsigned long long)timeout_us);
+    fprintf(stderr, "[WAIT] event_queue_receive(q=%u timeout=%llu) tid=%llu cia=0x%08X lr=0x%08X\n",
+            queue_id, (unsigned long long)timeout_us,
+            (unsigned long long)ctx->thread_id, (uint32_t)ctx->cia, (uint32_t)ctx->lr);
 
     if (queue_id == 0 || queue_id > SYS_EVENT_QUEUE_MAX)
         return (int64_t)(int32_t)CELL_ESRCH;
@@ -228,6 +230,68 @@ int64_t sys_event_queue_receive(ppu_context* ctx)
         }
     }
 
+    /* YDKJ_SPURS_READY (diagnostic): break the SPURS bring-up deadlock from the
+     * PPU side. cellSpursInitialize blocks forever (timeout=0) on the SPURS event
+     * queues (q=1/q=4) awaiting the kernel/policy "ready" event, while the policy
+     * (now running real code) waits for a workload the PPU only adds AFTER init
+     * returns. Synthesize a ready event so init returns -> see whether the PPU
+     * then reaches CreateTaskset and the running policy dispatches the cri task.
+     * Returns a zero-ish SPU-thread-group event; refine the format if init rejects it. */
+    if (getenv("YDKJ_SPURS_READY") && (queue_id == 1 || queue_id == 4)
+            && timeout_us == 0 && q->count == 0) {
+        static int s_fire[8] = {0};
+        if (s_fire[queue_id] < 64) {
+            s_fire[queue_id]++;
+            if (event_addr != 0) {
+                uint64_t* out = (uint64_t*)vm_to_host(event_addr);
+                /* Match the observed real port_send(port=4) shape: data1=0, data2=1,
+                 * data3=0. source is the port name; use a SPURS-ish tag. Env
+                 * YDKJ_RDY_D2 overrides data2 for quick format experiments. */
+                const char* d2s = getenv("YDKJ_RDY_D2");
+                uint64_t d2 = d2s ? (uint64_t)strtoull(d2s, 0, 0) : 1ULL;
+                out[0] = bswap64(0x0000000000000000ULL); /* source/name */
+                out[1] = 0; out[2] = bswap64(d2); out[3] = 0;
+            }
+            fprintf(stderr, "[ydkj] SPURS_READY: synthesized ready event on q=%u (#%d)\n",
+                    queue_id, s_fire[queue_id]);
+            return CELL_OK;
+        }
+    }
+
+    /* YDKJ_FAKECOMPLETE (diagnostic): the SPURS task-completion events the SPU
+     * would post to q=2/q=3 never arrive (SPU video task not running), so the
+     * main thread times out after 30s and the title tears down. Synthesize a
+     * completion so the wait returns -> see whether the game then advances to
+     * asset load + menu draw (content). Returns immediately with a zero event. */
+    if (getenv("YDKJ_FAKECOMPLETE") && (queue_id == 2 || queue_id == 3) && q->count == 0) {
+        if (event_addr != 0) {
+            uint64_t* out = (uint64_t*)vm_to_host(event_addr);
+            out[0] = 0; out[1] = 0; out[2] = 0; out[3] = 0;
+        }
+        return CELL_OK;
+    }
+    /* YDKJ_HLE_DRAW (diagnostic): also unblock the AsyncLoad q=1 wait (timeout=0,
+     * blocks forever) so the loader thread proceeds. Tests whether the game's
+     * render/draw code is reachable once the completion waits are satisfied. */
+    if (getenv("YDKJ_HLE_DRAW") && queue_id == 1 && timeout_us == 0 && q->count == 0) {
+        static int s_n1 = 0;
+        if (s_n1 < 256) { s_n1++;
+            if (event_addr != 0) {
+                uint64_t* out = (uint64_t*)vm_to_host(event_addr);
+                out[0] = 0; out[1] = 0; out[2] = 0; out[3] = 0;
+            }
+            return CELL_OK;
+        }
+    }
+
+    /* Diagnostic: dump the guest call chain of a thread about to block on q=1
+     * (the loader/worker) -- identifies WHICH function's receive-loop it's in,
+     * so we can see why it only receives once. Fires a few times. */
+    if (queue_id == 1 && timeout_us == 0) {
+        extern void ppu_dump_guest_stack(ppu_context*, const char*);
+        static int _gs = 0; if (_gs++ < 5) ppu_dump_guest_stack(ctx, "q1-worker");
+    }
+
 #ifdef _WIN32
     EnterCriticalSection(&q->lock);
 
@@ -235,9 +299,20 @@ int64_t sys_event_queue_receive(ppu_context* ctx)
         while (q->count == 0 && q->active) {
             SleepConditionVariableCS(&q->not_empty, &q->lock, INFINITE);
         }
+    } else if (timeout_us < 1000) {
+        /* Sub-millisecond timeout = the title's non-blocking event poll (it polls
+         * queues 2 & 3 every frame with a 30us timeout). Windows' ~15.6ms timer
+         * granularity inflates even a 1ms SleepConditionVariableCS to ~15ms, so a
+         * naive floor-to-1ms throttled the game's per-frame poll loop ~500x
+         * (each frame ate ~30ms in two polls). Honor the intent: check once and
+         * return ETIMEDOUT immediately if empty -- same result the game already
+         * handles, just without the bogus 15ms stall. */
+        if (q->count == 0 || !q->active) {
+            LeaveCriticalSection(&q->lock);
+            return (int64_t)(int32_t)CELL_ETIMEDOUT;
+        }
     } else {
         DWORD ms = (DWORD)(timeout_us / 1000);
-        if (ms == 0) ms = 1;
         while (q->count == 0 && q->active) {
             if (!SleepConditionVariableCS(&q->not_empty, &q->lock, ms)) {
                 if (GetLastError() == ERROR_TIMEOUT) {
@@ -302,6 +377,16 @@ int64_t sys_event_queue_receive(ppu_context* ctx)
         out[1] = bswap64(evt.data1);
         out[2] = bswap64(evt.data2);
         out[3] = bswap64(evt.data3);
+    }
+    /* Diagnostic: prove the blocked receiver was WOKEN and is returning an event
+     * (vs. staying blocked forever). Distinguishes a wake bug from game logic. */
+    if (queue_id == 1) {
+        static int _r = 0;
+        if (_r++ < 12)
+            fprintf(stderr, "[evt] q=1 receive RETURNED to tid=%llu: src=0x%llX d1=0x%llX d2=0x%llX d3=0x%llX (qcount now %u)\n",
+                    (unsigned long long)ctx->thread_id, (unsigned long long)evt.source,
+                    (unsigned long long)evt.data1, (unsigned long long)evt.data2,
+                    (unsigned long long)evt.data3, q->count);
     }
 
     return CELL_OK;
@@ -577,11 +662,17 @@ int64_t sys_event_port_send(ppu_context* ctx)
         return (int64_t)(int32_t)CELL_ESRCH;
 
     sys_event_port_info* p = &g_sys_event_ports[port_id - 1];
-    if (!p->active)
+    if (!p->active) {
+        fprintf(stderr, "[evt] port_send(port=%u): port NOT ACTIVE\n", port_id);
         return (int64_t)(int32_t)CELL_ESRCH;
+    }
 
-    if (p->connected_queue == 0)
+    if (p->connected_queue == 0) {
+        fprintf(stderr, "[evt] port_send(port=%u): NOT CONNECTED to any queue\n", port_id);
         return (int64_t)(int32_t)CELL_ENOTCONN;
+    }
+    fprintf(stderr, "[evt] port_send(port=%u) -> queue id=%d (source=0x%llX)\n",
+            port_id, p->connected_queue, (unsigned long long)p->name);
 
     int32_t qidx = p->connected_queue;
     if (qidx <= 0 || qidx > SYS_EVENT_QUEUE_MAX)
@@ -658,6 +749,10 @@ int64_t sys_event_flag_create(ppu_context* ctx)
     if (id_out_addr != 0) {
         write_be32(id_out_addr, flag_id);
     }
+    { char nm[9]; memcpy(nm, f->name, 8); nm[8]=0;
+      for(int i=0;i<8;i++) if(nm[i] && (nm[i]<32||nm[i]>126)) nm[i]='.';
+      fprintf(stderr, "[evt] flag_create id=%u name=\"%s\" init=0x%llX type=%u\n",
+              flag_id, nm, (unsigned long long)init_pattern, f->type); }
 
     evt_table_unlock();
     return CELL_OK;
@@ -716,6 +811,7 @@ int64_t sys_event_flag_wait(ppu_context* ctx)
     uint64_t bitpat     = LV2_ARG_U64(ctx, 1);
     uint32_t mode       = LV2_ARG_U32(ctx, 2);
     uint32_t result_addr = LV2_ARG_PTR(ctx, 3);
+    { static int n=0; if(n++<30) fprintf(stderr,"[WAIT] event_flag_wait(flag=%u pat=0x%llX mode=%u)\n", flag_id,(unsigned long long)bitpat,mode); }
     uint64_t timeout_us = LV2_ARG_U64(ctx, 4);
     { static int _w=0; if (_w++ < 40) fprintf(stderr, "[WAIT] event_flag_wait(flag=%u bits=0x%llX timeout=%llu)\n", flag_id, (unsigned long long)bitpat, (unsigned long long)timeout_us); }
     /* SPU-completion shim (targeted): the main thread spins in func_003319D0 until
@@ -737,15 +833,54 @@ int64_t sys_event_flag_wait(ppu_context* ctx)
         return CELL_OK;
     }
 
-    if (flag_id == 0 || flag_id > SYS_EVENT_FLAG_MAX)
+    if (flag_id == 0 || flag_id > SYS_EVENT_FLAG_MAX) {
+        { static int _e=0; if(_e++<8) fprintf(stderr,"[evt] flag_wait flag=%u OUT-OF-RANGE (max=%d) -> ESRCH\n", flag_id, SYS_EVENT_FLAG_MAX); }
         return (int64_t)(int32_t)CELL_ESRCH;
+    }
 
+    /* YDKJ_F100_OK (diagnostic, env-gated): the game busy-spins ~145k times on
+     * event_flag_wait(flag=100 bits=0x2) with a GARBAGE mode (0x38CAE4) on a
+     * NEVER-CREATED flag -> ESRCH each time. Test whether returning CELL_OK
+     * (as if the flag were set) breaks the spin and lets the game progress into
+     * real render code. Diagnostic only; identifies whether the spin is the gate. */
+    { static int s_f = -1; if (s_f < 0) s_f = getenv("YDKJ_F100_OK") ? 1 : 0;
+      if (s_f && !g_sys_event_flags[flag_id-1].active) {
+        static int _n=0; if(_n++<4) fprintf(stderr,"[evt] YDKJ_F100_OK: flag=%u -> return CELL_OK (break spin)\n", flag_id);
+        if (result_addr != 0) { write_be32(result_addr, (uint32_t)(bitpat>>32)); write_be32(result_addr+4, (uint32_t)bitpat); }
+        return CELL_OK;
+      } }
     sys_event_flag_info* f = &g_sys_event_flags[flag_id - 1];
-    if (!f->active)
+    if (!f->active) {
+        { static int _e=0; if(_e++<8) {
+            uint32_t r29=(uint32_t)ctx->gpr[29], r30=(uint32_t)ctx->gpr[30], r31=(uint32_t)ctx->gpr[31], r3g=(uint32_t)ctx->gpr[3];
+            fprintf(stderr,"[evt] flag_wait flag=%u NOT ACTIVE -> ESRCH; r3=0x%08X r29=0x%08X r30=0x%08X r31=0x%08X\n", flag_id, r3g, r29, r30, r31);
+            /* dump the loop's likely counter object (r29-relative, like the flag=1000 shim's *(r29)/*(r29+0x24)) */
+            if (r29 && r29 < 0x10000000u) { uint8_t* p=(uint8_t*)vm_to_host(r29);
+              fprintf(stderr,"     [r29+0x00..0x30]:"); for(int i=0;i<0x34;i+=4) fprintf(stderr," %02X%02X%02X%02X",p[i],p[i+1],p[i+2],p[i+3]); fprintf(stderr,"\n"); }
+        } }
         return (int64_t)(int32_t)CELL_ESRCH;
+    }
+    { static int _a=0; if(_a++<8) fprintf(stderr,"[evt] flag_wait flag=%u ACTIVE, pattern=0x%llX awaiting bits=0x%llX -> BLOCK\n", flag_id,(unsigned long long)f->pattern,(unsigned long long)bitpat); }
 
     if (bitpat == 0)
         return (int64_t)(int32_t)CELL_EINVAL;
+
+    /* YDKJ_FORCE_EVF (diagnostic): the game's init blocks polling event_flag
+     * (flag=100 bits=0x2) for a subsystem/SPU completion that our HLE never fires,
+     * so boot stalls on a black screen. Force-satisfy the wait (set the awaited
+     * bits) to see if the game advances into its real render/content code. Blunt;
+     * identifies the gate. */
+    { static int s_fe = -1; if (s_fe < 0) s_fe = getenv("YDKJ_FORCE_EVF") ? 1 : 0;
+      if (s_fe && f->active && !flag_check(f->pattern, bitpat, mode)) {
+        static int _n = 0; if (_n++ < 20)
+            fprintf(stderr, "[evt] YDKJ_FORCE_EVF: force-satisfy flag=%u bits=0x%llX mode=%u\n",
+                    flag_id, (unsigned long long)bitpat, mode);
+#ifdef _WIN32
+        EnterCriticalSection(&f->lock); f->pattern |= bitpat; LeaveCriticalSection(&f->lock);
+#else
+        pthread_mutex_lock(&f->lock); f->pattern |= bitpat; pthread_mutex_unlock(&f->lock);
+#endif
+      } }
 
 #ifdef _WIN32
     EnterCriticalSection(&f->lock);
@@ -895,6 +1030,9 @@ int64_t sys_event_flag_set(ppu_context* ctx)
     uint32_t flag_id = LV2_ARG_U32(ctx, 0);
     uint64_t bitpat  = LV2_ARG_U64(ctx, 1);
 
+    { static int _n=0; if(_n++<200) fprintf(stderr,"[evt] flag_set(flag=%u bits=0x%llX)\n",
+        flag_id,(unsigned long long)bitpat); }
+
     if (flag_id == 0 || flag_id > SYS_EVENT_FLAG_MAX)
         return (int64_t)(int32_t)CELL_ESRCH;
 
@@ -915,6 +1053,30 @@ int64_t sys_event_flag_set(ppu_context* ctx)
 #endif
 
     return CELL_OK;
+}
+
+/* YDKJ diag (YDKJ_CRI_WAKE): the cri_mpv SPU task completes but the SPU->PPU
+ * completion (cellSpursEventFlagSet) isn't propagated, so the game blocks in
+ * event_flag_wait forever (black screen). As a probe, set all bits on every
+ * active event flag with a waiter -> wake any completion-waiter, to see if the
+ * game then advances to draw content. Blunt; identifies the gate, not a real fix. */
+void ydkj_wake_all_event_flags(void)
+{
+    for (int i = 0; i < SYS_EVENT_FLAG_MAX; i++) {
+        sys_event_flag_info* f = &g_sys_event_flags[i];
+        if (!f->active) continue;
+#ifdef _WIN32
+        EnterCriticalSection(&f->lock);
+        f->pattern |= 0xFFFFFFFFFFFFFFFFull;
+        WakeAllConditionVariable(&f->cv);
+        LeaveCriticalSection(&f->lock);
+#else
+        pthread_mutex_lock(&f->lock);
+        f->pattern |= 0xFFFFFFFFFFFFFFFFull;
+        pthread_cond_broadcast(&f->cv);
+        pthread_mutex_unlock(&f->lock);
+#endif
+    }
 }
 
 int64_t sys_event_flag_clear(ppu_context* ctx)

--- a/runtime/syscalls/sys_fs.c
+++ b/runtime/syscalls/sys_fs.c
@@ -75,9 +75,21 @@ static void fs_normalize_sep(char* p) {
 
 void sys_fs_translate_path(const char* ps3_path, char* host_path, int host_path_size)
 {
-    /* Strip leading slash for concatenation */
+    /* Lazily adopt PS3_VFS_ROOT if the root is still the default ".", so this
+     * sys_fs layer points at the same place as the cellFs layer (ppu_vfs_root). */
+    if (g_sys_fs_root[0] == '.' && g_sys_fs_root[1] == '\0') {
+        const char* env = getenv("PS3_VFS_ROOT");
+        if (env && *env) { strncpy(g_sys_fs_root, env, sizeof(g_sys_fs_root) - 1); g_sys_fs_root[sizeof(g_sys_fs_root)-1] = 0; }
+    }
+
+    /* /app_home/ is the game's install dir (== the USRDIR root); the title opens
+     * it in several spellings ("/app_home/...", "app_home/...", "e:/app_home/...").
+     * Map anything from "app_home/" onward to <root>/... directly rather than
+     * appending a literal "app_home" directory that doesn't exist on disk. */
     const char* rel = ps3_path;
-    if (rel[0] == '/') rel++;
+    const char* ah = strstr(ps3_path, "app_home/");
+    if (ah) rel = ah + 9;                 /* everything after "app_home/" */
+    else if (rel[0] == '/') rel++;         /* otherwise just strip leading slash */
 
     snprintf(host_path, (size_t)host_path_size, "%s/%s", g_sys_fs_root, rel);
     fs_normalize_sep(host_path);
@@ -122,6 +134,29 @@ int64_t sys_fs_open(ppu_context* ctx)
     const char* ps3_path = (const char*)vm_to_host(path_addr);
     char host_path[1024];
     sys_fs_translate_path(ps3_path, host_path, sizeof(host_path));
+
+    { extern char* getenv(const char*); if (getenv("FLOW_TITLEOPEN") && ps3_path && strstr(ps3_path, "Titles")) {
+        size_t _l = strlen(ps3_path);
+        fprintf(stderr, "[TITLEOPEN] path='%s' (len=%zu, ends_slash=%d) guest_lr=0x%08X\n",
+                ps3_path, _l, (_l && ps3_path[_l-1]=='/')?1:0, (uint32_t)ctx->lr); fflush(stderr);
+#ifdef _WIN32
+        { char* mb=(char*)GetModuleHandleA(0); void* bt[30]; unsigned short fr=RtlCaptureStackBackTrace(0,30,bt,0);
+          char ln[820]; int p=snprintf(ln,sizeof ln,"[TITLEOPEN-bt] rva:");
+          for(unsigned short i=0;i<fr;i++) p+=snprintf(ln+p,sizeof(ln)-p," %llX",(unsigned long long)((char*)bt[i]-mb));
+          fprintf(stderr,"%s\n",ln); fflush(stderr); }
+#endif
+    } }
+    /* DIAGNOSTIC (FLOW_TITLEFIX): the game builds the title path with an EMPTY filename
+     * (a stale-lift string-construction bug) -> opens the dir. Redirect a bare
+     * ".../Data/Titles/" open to the language file so we can confirm the render path. */
+    { extern char* getenv(const char*); if (getenv("FLOW_TITLEFIX")) {
+        size_t hl = strlen(host_path);
+        if (hl >= 8 && (strcmp(host_path + hl - 8, "Titles\\") == 0 || strcmp(host_path + hl - 8, "Titles/") == 0
+                        || strcmp(host_path + hl - 7, "Titles\\") == 0 || strcmp(host_path + hl - 7, "Titles/") == 0)) {
+            if (hl + 20 < sizeof(host_path)) { strcat(host_path, "Titles_English.xml");
+                fprintf(stderr, "[TITLEFIX] redirected empty-filename title open -> %s\n", host_path); fflush(stderr); }
+        }
+    } }
 
     /* Find free fd slot */
     int slot = -1;

--- a/runtime/syscalls/sys_mutex.c
+++ b/runtime/syscalls/sys_mutex.c
@@ -179,6 +179,7 @@ int64_t sys_mutex_lock(ppu_context* ctx)
 {
     uint32_t mutex_id    = LV2_ARG_U32(ctx, 0);
     uint64_t timeout_us  = LV2_ARG_U64(ctx, 1);
+    { static int n=0; if(n++<30) fprintf(stderr,"[WAIT] mutex_lock(mutex=%u timeout=%llu)\n", mutex_id,(unsigned long long)timeout_us); }
 
     if (mutex_id == 0 || mutex_id > SYS_MUTEX_MAX)
         return (int64_t)(int32_t)CELL_ESRCH;

--- a/runtime/syscalls/sys_ppu_thread.c
+++ b/runtime/syscalls/sys_ppu_thread.c
@@ -300,6 +300,7 @@ int64_t sys_ppu_thread_join(ppu_context* ctx)
 {
     uint64_t tid          = LV2_ARG_U64(ctx, 0);
     uint32_t status_addr  = LV2_ARG_PTR(ctx, 1);
+    { static int n=0; if(n++<30) fprintf(stderr,"[WAIT] ppu_thread_join(tid=%llu)\n", (unsigned long long)tid); }
 
     table_lock();
     ppu_thread_info* t = find_thread(tid);
@@ -429,8 +430,24 @@ int64_t sys_ppu_thread_get_priority(ppu_context* ctx)
     table_lock();
     ppu_thread_info* t = find_thread(tid);
     if (!t) {
+        /* The main thread (and any thread we didn't spawn via sys_ppu_thread_create)
+         * isn't in our table. Returning ESRCH here is fatal for engines that query
+         * their own priority at startup (PhyreEngine PApplication::PlatformInit ->
+         * "Error initializing PSSG"). Report a sane default priority + success. */
         table_unlock();
-        return (int64_t)(int32_t)CELL_ESRCH;
+        if (prio_addr != 0) {
+            int32_t prio = 1000;
+            int32_t* out = (int32_t*)vm_to_host(prio_addr);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__ || defined(_WIN32)
+            uint32_t u = (uint32_t)prio;
+            u = ((u >> 24) & 0xFF) | ((u >> 8) & 0xFF00) |
+                ((u <<  8) & 0xFF0000) | ((u << 24) & 0xFF000000u);
+            *out = (int32_t)u;
+#else
+            *out = prio;
+#endif
+        }
+        return CELL_OK;
     }
 
     if (prio_addr != 0) {

--- a/runtime/syscalls/sys_rwlock.c
+++ b/runtime/syscalls/sys_rwlock.c
@@ -171,8 +171,13 @@ int64_t sys_rwlock_wlock(ppu_context* ctx)
         return (int64_t)(int32_t)CELL_ESRCH;
 
 #ifdef _WIN32
+    /* A thread that already holds the write lock re-acquiring it would deadlock
+     * the (non-recursive) SRWLock. Real lv2 returns CELL_EDEADLK. */
+    if (r->writer && r->writer_tid == ctx->thread_id)
+        return (int64_t)(int32_t)CELL_EDEADLK;
     AcquireSRWLockExclusive(&r->srw);
     InterlockedExchange(&r->writer, 1);
+    r->writer_tid = ctx->thread_id;
 #else
     pthread_rwlock_wrlock(&r->rwl);
 #endif
@@ -192,9 +197,12 @@ int64_t sys_rwlock_trywlock(ppu_context* ctx)
         return (int64_t)(int32_t)CELL_ESRCH;
 
 #ifdef _WIN32
+    if (r->writer && r->writer_tid == ctx->thread_id)
+        return (int64_t)(int32_t)CELL_EDEADLK;
     if (!TryAcquireSRWLockExclusive(&r->srw))
         return (int64_t)(int32_t)CELL_EBUSY;
     InterlockedExchange(&r->writer, 1);
+    r->writer_tid = ctx->thread_id;
 #else
     int rc = pthread_rwlock_trywrlock(&r->rwl);
     if (rc != 0)
@@ -216,6 +224,11 @@ int64_t sys_rwlock_wunlock(ppu_context* ctx)
         return (int64_t)(int32_t)CELL_ESRCH;
 
 #ifdef _WIN32
+    /* Only the owning thread may write-unlock (releasing an SRWLock not held in
+     * exclusive mode by this thread is UB). Real lv2 returns CELL_EPERM. */
+    if (!r->writer || r->writer_tid != ctx->thread_id)
+        return (int64_t)(int32_t)CELL_EPERM;
+    r->writer_tid = 0;
     InterlockedExchange(&r->writer, 0);
     ReleaseSRWLockExclusive(&r->srw);
 #else

--- a/runtime/syscalls/sys_rwlock.h
+++ b/runtime/syscalls/sys_rwlock.h
@@ -35,6 +35,7 @@ typedef struct sys_rwlock_info {
     /* Track exclusive ownership for proper unlock dispatch */
     volatile LONG  readers;
     volatile LONG  writer;
+    uint64_t       writer_tid;   /* owning thread of the write lock (EDEADLK/EPERM) */
 #else
     pthread_rwlock_t rwl;
 #endif

--- a/runtime/syscalls/sys_timer.c
+++ b/runtime/syscalls/sys_timer.c
@@ -25,6 +25,36 @@ static void ensure_qpc_init(void)
 }
 #endif
 
+/* ---------------------------------------------------------------------------
+ * PPU timebase (mftb/mftbu) -- THE guest clock.
+ *
+ * One global monotonic counter scaled to the PS3 timebase (79.8 MHz),
+ * anchored at first use. The old lifter emission was a per-call-site
+ * static that advanced 16667 ticks PER READ -- not a clock at all: every
+ * guest timing loop (media pacers, throttles, profilers) computed garbage
+ * from it, and each call site had a PRIVATE counter that only moved when
+ * polled. Overflow-safe split multiply (rem < qpf, so
+ * rem * 79.8e6 < ~8e14 << 2^63).
+ * -----------------------------------------------------------------------*/
+uint64_t ppu_timebase_now(void)
+{
+#ifdef _WIN32
+    static LONGLONG t0 = 0;
+    ensure_qpc_init();
+    LARGE_INTEGER now;
+    QueryPerformanceCounter(&now);
+    if (!t0) t0 = now.QuadPart;   /* benign race: same anchor either way */
+    uint64_t d = (uint64_t)(now.QuadPart - t0);
+    uint64_t q = (uint64_t)s_qpc_freq.QuadPart;
+    return (d / q) * PS3_TIMEBASE_FREQ + (d % q) * PS3_TIMEBASE_FREQ / q;
+#else
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * PS3_TIMEBASE_FREQ +
+           (uint64_t)ts.tv_nsec * PS3_TIMEBASE_FREQ / 1000000000ull;
+#endif
+}
+
 static void write_be32(uint32_t addr, uint32_t val)
 {
     uint32_t* p = (uint32_t*)vm_to_host(addr);

--- a/runtime/syscalls/sys_timer.h
+++ b/runtime/syscalls/sys_timer.h
@@ -28,6 +28,10 @@ extern "C" {
 /* PS3 timebase frequency */
 #define PS3_TIMEBASE_FREQ  79800000ULL
 
+/* The guest mftb/mftbu clock: one global monotonic counter, host time scaled
+ * to the PS3 timebase. Called from every lifted mftb site (ppu_lifter.py). */
+uint64_t ppu_timebase_now(void);
+
 #define SYS_TIMER_MAX  64
 
 typedef struct sys_timer_info {

--- a/tests/sync_stress/CMakeLists.txt
+++ b/tests/sync_stress/CMakeLists.txt
@@ -1,0 +1,61 @@
+# ps3recomp - tests/sync_stress
+#
+# Deterministic lv2 sync-primitive stress suite.
+# Standalone project: its OWN build dir, never yakuza\build.
+#
+# Build (chain in ONE command -- Launch-VsDevShell is blocked in this harness;
+# shell state does not persist between tool calls):
+#
+#   cmd /c "call ""C:\Program Files\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build\vcvars64.bat"" >nul && cmake -S tests\sync_stress -B tests\sync_stress\build -G Ninja && ninja -C tests\sync_stress\build"
+#
+# Run:
+#   .\tests\sync_stress\build\sync_stress.exe [seed]
+#
+cmake_minimum_required(VERSION 3.20)
+project(sync_stress LANGUAGES C)
+
+set(CMAKE_C_STANDARD 17)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+# ---------------------------------------------------------------------------
+# Location of the ps3recomp runtime sources under test. Overridable so a
+# seeded-bug self-test can point PS3RECOMP_TREE_ROOT at a temp MIRROR of the
+# runtime/+include/ tree (e.g. with sys_cond.c mutated) without touching the
+# real one. The mirror must keep the same relative layout (runtime/syscalls,
+# runtime/ppu, runtime/memory, include/ps3emu) because the runtime headers
+# use relative includes like "../ppu/ppu_context.h".
+#   cmake -DPS3RECOMP_TREE_ROOT=C:\path\to\temp\tree ...
+#   (RUNTIME_SYNC_DIR alone can also be overridden if only the four .c/.h
+#   sync files were copied into an otherwise-normal tree layout.)
+# ---------------------------------------------------------------------------
+get_filename_component(PS3RECOMP_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../.." ABSOLUTE)
+
+if(NOT DEFINED PS3RECOMP_TREE_ROOT)
+    set(PS3RECOMP_TREE_ROOT "${PS3RECOMP_ROOT}")
+endif()
+
+if(NOT DEFINED RUNTIME_SYNC_DIR)
+    set(RUNTIME_SYNC_DIR "${PS3RECOMP_TREE_ROOT}/runtime/syscalls")
+endif()
+
+add_executable(sync_stress
+    main.c
+    "${RUNTIME_SYNC_DIR}/sys_mutex.c"
+    "${RUNTIME_SYNC_DIR}/sys_cond.c"
+    "${RUNTIME_SYNC_DIR}/sys_semaphore.c"
+    "${RUNTIME_SYNC_DIR}/sys_event.c"
+)
+
+target_include_directories(sync_stress PRIVATE
+    "${RUNTIME_SYNC_DIR}"
+    "${PS3RECOMP_TREE_ROOT}/runtime"
+    "${PS3RECOMP_TREE_ROOT}/include"
+)
+
+if(MSVC)
+    target_compile_options(sync_stress PRIVATE /W3 /wd4100 /wd4244 /wd4267)
+    target_compile_definitions(sync_stress PRIVATE _CRT_SECURE_NO_WARNINGS)
+else()
+    target_compile_options(sync_stress PRIVATE -Wall -Wextra -Wno-unused-parameter)
+    target_link_libraries(sync_stress PRIVATE pthread)
+endif()

--- a/tests/sync_stress/main.c
+++ b/tests/sync_stress/main.c
@@ -1,0 +1,1118 @@
+/*
+ * ps3recomp - tests/sync_stress/main.c
+ *
+ * Deterministic lv2 sync-primitive stress suite.
+ * Exercises runtime/syscalls/sys_mutex.c, sys_cond.c, sys_semaphore.c,
+ * sys_event.c directly (as C functions taking a ppu_context*), on Win32
+ * threads, with NO dependency on the yakuza runner or the recompiled game.
+ *
+ * Usage: sync_stress.exe [seed]   (default seed 0)
+ *
+ * Exit code 0 = all tests passed. Nonzero = at least one test FAILed (see
+ * stderr for the FAIL dump: which test, which thread/object, and counters).
+ */
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <process.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <time.h>
+
+#include "sys_mutex.h"
+#include "sys_cond.h"
+#include "sys_semaphore.h"
+#include "sys_event.h"
+#include "ppu/ppu_context.h"
+
+/* ---------------------------------------------------------------------------
+ * Minimal guest-memory + thread-id shims the runtime sync sources need.
+ * (Mirrors the pattern already used by runtime/spu/tests/test_dma_main.c:
+ * a plain host buffer stands in for guest memory; vm_to_host() in vm.h does
+ * `vm_base + addr`, so any host buffer works as long as addresses used here
+ * stay inside it.)
+ * -----------------------------------------------------------------------*/
+#define GUEST_MEM_SIZE (4u * 1024u * 1024u)
+static uint8_t g_guest_mem[GUEST_MEM_SIZE];
+uint8_t* vm_base = g_guest_mem;
+
+/* Simple bump allocator for "guest addresses" (attr structs, out-params). */
+static LONG volatile g_guest_bump = 4096; /* keep addr 0 reserved/invalid */
+static uint32_t guest_alloc(uint32_t size)
+{
+    LONG size_al = (LONG)((size + 15u) & ~15u);
+    LONG addr = InterlockedExchangeAdd(&g_guest_bump, size_al);
+    if ((uint32_t)(addr + size_al) >= GUEST_MEM_SIZE) {
+        fprintf(stderr, "FATAL: guest_mem exhausted\n");
+        exit(97);
+    }
+    return (uint32_t)addr;
+}
+
+/* Per-host-thread guest thread id (the runtime keys mutex ownership / cond
+ * ownership checks off ppu_context.thread_id, and sys_cond.c / sys_semaphore.c
+ * / sys_event.c's diagnostic levers key off yz_thread_current_id()). */
+static __declspec(thread) uint32_t t_tid = 0;
+uint32_t yz_thread_current_id(void) { return t_tid; }
+
+static LONG volatile g_next_tid = 1;
+static uint32_t alloc_tid(void) { return (uint32_t)InterlockedIncrement(&g_next_tid); }
+
+/* ---------------------------------------------------------------------------
+ * Link-time stubs for sys_event.c's title-diagnostic side paths.
+ *
+ * sys_event.c's sys_event_queue_receive() carries a few instrumentation
+ * branches that call into the SPU workload dispatcher and a PPU guest-stack
+ * dumper. This suite links only the four lv2 sync .c files (deliberately,
+ * to stay a fast standalone unit test with no PPU/SPU runtime dependency),
+ * so those symbols are otherwise undefined at link time. None of the three
+ * branches can fire here: the SPU-dispatch path is gated on an environment
+ * variable this suite never sets, and the guest-stack dump path takes a
+ * live ppu_context produced only by the real recompiled-game loader (this
+ * suite builds its own minimal ppu_context, see ctx_init_for_thread()) and
+ * self-limits to a handful of calls. These bodies exist purely to satisfy
+ * the linker and are never expected to execute.
+ * -----------------------------------------------------------------------*/
+size_t spu_elf_image_size(const uint8_t* image, size_t max_avail)
+{
+    (void)image; (void)max_avail;
+    return 0;
+}
+
+int spu_workload_dispatch_async(const uint8_t* image, uint32_t image_size, uint32_t args_ea)
+{
+    (void)image; (void)image_size; (void)args_ea;
+    return 0;
+}
+
+void ppu_dump_guest_stack(ppu_context* ctx, const char* tag)
+{
+    (void)ctx; (void)tag;
+}
+
+/* Build a ppu_context for the calling host thread, tagged with a guest tid. */
+static void ctx_init_for_thread(ppu_context* ctx, uint32_t tid)
+{
+    ppu_context_init(ctx);
+    ctx->thread_id = tid;
+}
+
+/* ---------------------------------------------------------------------------
+ * be32 helpers for reading/writing "guest" out-params in the test harness
+ * (the runtime writes IDs/values big-endian via its own write_be32; we read
+ * them back the same way here without reaching into runtime internals).
+ * -----------------------------------------------------------------------*/
+static uint32_t read_be32(uint32_t addr)
+{
+    uint8_t* p = g_guest_mem + addr;
+    return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) | ((uint32_t)p[2] << 8) | p[3];
+}
+
+static void write_be32_host(uint32_t addr, uint32_t val)
+{
+    uint8_t* p = g_guest_mem + addr;
+    p[0] = (uint8_t)(val >> 24);
+    p[1] = (uint8_t)(val >> 16);
+    p[2] = (uint8_t)(val >> 8);
+    p[3] = (uint8_t)val;
+}
+
+/* ---------------------------------------------------------------------------
+ * Small syscall-call wrappers: set gpr[3..], invoke the handler, return its
+ * signed 32-bit result the way the guest would see it in gpr[3].
+ * -----------------------------------------------------------------------*/
+static int32_t call1(int64_t (*fn)(ppu_context*), ppu_context* ctx, uint64_t a0)
+{
+    ctx->gpr[3] = a0;
+    return (int32_t)fn(ctx);
+}
+static int32_t call2(int64_t (*fn)(ppu_context*), ppu_context* ctx, uint64_t a0, uint64_t a1)
+{
+    ctx->gpr[3] = a0; ctx->gpr[4] = a1;
+    return (int32_t)fn(ctx);
+}
+static int32_t call3(int64_t (*fn)(ppu_context*), ppu_context* ctx, uint64_t a0, uint64_t a1, uint64_t a2)
+{
+    ctx->gpr[3] = a0; ctx->gpr[4] = a1; ctx->gpr[5] = a2;
+    return (int32_t)fn(ctx);
+}
+static int32_t call4(int64_t (*fn)(ppu_context*), ppu_context* ctx, uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3)
+{
+    ctx->gpr[3] = a0; ctx->gpr[4] = a1; ctx->gpr[5] = a2; ctx->gpr[6] = a3;
+    return (int32_t)fn(ctx);
+}
+
+/* ---------------------------------------------------------------------------
+ * Deterministic PRNG (xorshift32) seeded from argv -- NOT rand(), so runs are
+ * reproducible across platforms/CRTs given the same seed.
+ * -----------------------------------------------------------------------*/
+static uint32_t g_seed;
+static uint32_t xorshift32(uint32_t* s)
+{
+    uint32_t x = *s;
+    x ^= x << 13; x ^= x >> 17; x ^= x << 5;
+    *s = x;
+    return x;
+}
+
+/* ---------------------------------------------------------------------------
+ * Guest attribute-struct builders (offsets per sys_mutex.h / sys_semaphore.h
+ * / sys_event.h comments and the create() handlers' own field reads).
+ * -----------------------------------------------------------------------*/
+static uint32_t make_mutex_attr(uint32_t protocol, int recursive)
+{
+    uint32_t addr = guest_alloc(32); /* sizeof(sys_mutex_attribute_t) rounded */
+    write_be32_host(addr + 0, protocol);
+    write_be32_host(addr + 4, recursive ? SYS_SYNC_RECURSIVE : SYS_SYNC_NOT_RECURSIVE);
+    return addr;
+}
+
+static uint32_t make_sema_attr(uint32_t protocol)
+{
+    uint32_t addr = guest_alloc(16);
+    write_be32_host(addr + 0, protocol);
+    return addr;
+}
+
+static uint32_t make_equeue_attr(uint32_t protocol, uint32_t qtype)
+{
+    uint32_t addr = guest_alloc(16);
+    write_be32_host(addr + 0, protocol);
+    write_be32_host(addr + 4, qtype);
+    return addr;
+}
+
+/* ---------------------------------------------------------------------------
+ * Failure bookkeeping
+ * -----------------------------------------------------------------------*/
+static LONG volatile g_fail_count = 0;
+static void fail(const char* test, const char* fmt, ...)
+{
+    InterlockedIncrement(&g_fail_count);
+    fprintf(stderr, "[FAIL] %s: ", test);
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    va_end(ap);
+    fprintf(stderr, "\n");
+    fflush(stderr);
+}
+
+static ULONGLONG now_ms(void) { return GetTickCount64(); }
+
+/* =========================================================================
+ * TEST 1 -- No lost wakeup
+ *
+ * N producers signal a cond (under the associated mutex, as lv2 requires:
+ * producers lock, mutate a shared "produced" counter, signal, unlock).
+ * M consumers each wait on the SAME cond/mutex pair for "produced > consumed"
+ * and, on wake, consume one item (bump `consumed`) -- a classic monitor
+ * pattern. Total items = iterations. A consumer that cannot make progress
+ * for > 2s is a lost-wakeup FAIL (the recorded case this whole test exists
+ * to catch: sys_cond_signal's rendezvous window, see sys_cond.c comments).
+ * ========================================================================= */
+#define T1_PRODUCERS   4
+#define T1_CONSUMERS   4
+#define T1_ITERS       10000  /* total items produced across all producers */
+#define T1_STALL_MS    2000
+
+typedef struct {
+    uint32_t mutex_id;
+    uint32_t cond_id;
+    LONG volatile produced;
+    LONG volatile consumed;
+    LONG volatile done_producing; /* set once all producers finish */
+    /* Global last-progress timestamp, updated ONLY when `consumed` actually
+     * advances (NOT on every wait attempt/timeout -- a consumer polling
+     * every 500ms on a dropped wakeup must still be flagged once outstanding
+     * work sits unconsumed for T1_STALL_MS, not reset every poll cycle). */
+    LONG volatile last_progress_ms;
+} t1_shared;
+
+typedef struct {
+    t1_shared* sh;
+    int my_index; /* consumer slot, -1 for producers */
+    int iters_for_me;
+} t1_arg;
+
+static unsigned __stdcall t1_producer(void* p)
+{
+    t1_arg* arg = (t1_arg*)p;
+    t1_shared* sh = arg->sh;
+    uint32_t tid = alloc_tid();
+    t_tid = tid;
+    ppu_context ctx; ctx_init_for_thread(&ctx, tid);
+
+    for (int i = 0; i < arg->iters_for_me; i++) {
+        int32_t rc = call2((int64_t(*)(ppu_context*))sys_mutex_lock, &ctx, sh->mutex_id, 0);
+        if (rc != CELL_OK) { fail("test1", "producer lock rc=0x%08X", (unsigned)rc); return 1; }
+
+        InterlockedIncrement(&sh->produced);
+
+        rc = call1((int64_t(*)(ppu_context*))sys_cond_signal, &ctx, sh->cond_id);
+        if (rc != CELL_OK) { fail("test1", "producer signal rc=0x%08X", (unsigned)rc); return 1; }
+
+        rc = call1((int64_t(*)(ppu_context*))sys_mutex_unlock, &ctx, sh->mutex_id);
+        if (rc != CELL_OK) { fail("test1", "producer unlock rc=0x%08X", (unsigned)rc); return 1; }
+    }
+    return 0;
+}
+
+static unsigned __stdcall t1_consumer(void* p)
+{
+    t1_arg* arg = (t1_arg*)p;
+    t1_shared* sh = arg->sh;
+    int idx = arg->my_index;
+    uint32_t tid = alloc_tid();
+    t_tid = tid;
+    ppu_context ctx; ctx_init_for_thread(&ctx, tid);
+
+    for (;;) {
+        int32_t rc = call2((int64_t(*)(ppu_context*))sys_mutex_lock, &ctx, sh->mutex_id, 0);
+        if (rc != CELL_OK) { fail("test1", "consumer lock rc=0x%08X", (unsigned)rc); return 1; }
+
+        while (sh->produced <= sh->consumed) {
+            if (sh->done_producing && sh->produced <= sh->consumed) {
+                /* No more work will ever arrive. Exit cleanly. */
+                call1((int64_t(*)(ppu_context*))sys_mutex_unlock, &ctx, sh->mutex_id);
+                return 0;
+            }
+            /* INFINITE wait deliberately: sys_cond_wait's own timed-wait path
+             * re-polls `pending` on every internal timer tick until its
+             * timeout elapses (see sys_cond.c), so a BOUNDED wait here would
+             * still (eventually, spuriously) notice a `pending` bump made
+             * without a real OS wake -- which is exactly what happened in an
+             * earlier draft: a seeded "drop WakeConditionVariable but still
+             * increment pending" bug only added latency (bounded by the
+             * wait's own timeout), it never actually hung, so a timed wait
+             * here could not distinguish "slow" from "truly lost forever".
+             * An infinite wait genuinely blocks forever on a true lost
+             * wakeup, which the external watchdog thread in
+             * test1_no_lost_wakeup (below) is responsible for detecting via
+             * `last_progress_ms` from OUTSIDE this thread and hard-failing
+             * the process -- this mirrors how a real lost wakeup actually
+             * manifests in the game (a thread parked forever), not a slow
+             * poll loop. */
+            rc = call2((int64_t(*)(ppu_context*))sys_cond_wait, &ctx, sh->cond_id, (uint64_t)0 /* infinite */);
+            if (rc != CELL_OK) {
+                fail("test1", "consumer wait rc=0x%08X", (unsigned)rc);
+                call1((int64_t(*)(ppu_context*))sys_mutex_unlock, &ctx, sh->mutex_id);
+                return 1;
+            }
+        }
+
+        InterlockedIncrement(&sh->consumed);
+        InterlockedExchange(&sh->last_progress_ms, (LONG)now_ms());
+
+        int32_t urc = call1((int64_t(*)(ppu_context*))sys_mutex_unlock, &ctx, sh->mutex_id);
+        if (urc != CELL_OK) { fail("test1", "consumer unlock rc=0x%08X", (unsigned)urc); return 1; }
+    }
+}
+
+/* External stall watchdog: a lost wakeup parks a consumer FOREVER in an
+ * infinite sys_cond_wait (see t1_consumer's comment on why the wait must be
+ * infinite for this test to be meaningful). This thread is the only piece
+ * that can observe and report that stall promptly -- it polls the shared
+ * `last_progress_ms` from OUTSIDE any consumer, and if outstanding work
+ * (produced > consumed) sits with zero progress for T1_STALL_MS, it prints
+ * the FAIL+dump the spec asks for and hard-exits the process immediately
+ * (a stuck consumer thread can't be safely cancelled out of a CRITICAL_
+ * SECTION/CV wait, so "detect and report, then terminate" is the only sound
+ * way to bound this test's runtime on a genuine lost wakeup). */
+static unsigned __stdcall t1_watchdog(void* p)
+{
+    t1_shared* sh = (t1_shared*)p;
+    for (;;) {
+        Sleep(100);
+        if (sh->done_producing && sh->produced <= sh->consumed) return 0; /* test finished cleanly */
+        if (sh->produced > sh->consumed) {
+            ULONGLONG stalled_for = now_ms() - (ULONGLONG)sh->last_progress_ms;
+            if (stalled_for > T1_STALL_MS) {
+                fprintf(stderr, "[FAIL] test1_no_lost_wakeup: STUCK: no consumption progress for "
+                        ">%dms with produced=%ld consumed=%ld (possible lost wakeup)\n",
+                        T1_STALL_MS, sh->produced, sh->consumed);
+                fflush(stderr);
+                InterlockedIncrement(&g_fail_count);
+                fflush(stdout);
+                _exit(1); /* a parked consumer can't be joined; report and terminate now */
+            }
+        }
+    }
+}
+
+/* ---------------------------------------------------------------------------
+ * Rendezvous sub-check: guarantees the waiter is ALREADY PARKED inside the
+ * host condvar wait before the signal fires.
+ *
+ * The bulk producer/consumer stress scenario below is a legitimate, valuable
+ * test on its own, but it turned out to be a WEAK oracle for a dropped
+ * WakeConditionVariable specifically: sys_cond_wait's rendezvous design
+ * (sys_cond.c) checks `while (c->pending == 0)` BEFORE ever calling
+ * SleepConditionVariableCS, and `pending++` is untouched by that class of
+ * bug -- so a waiter that re-enters sys_cond_wait AFTER the signal already
+ * bumped `pending` sails through without ever needing an OS wake. With 4
+ * producers/4 consumers churning the same mutex, most items are drained via
+ * that fast path, so a genuinely-parked waiter (the case an OS-level dropped
+ * wake actually breaks) was rare -- confirmed via an independent code-
+ * reading review of sys_cond_wait/sys_cond_signal before adding this check
+ * (see the T10 completion report for the full mechanism). This sub-check
+ * closes that gap directly: one dedicated consumer thread that is given a
+ * generous head start to actually block inside sys_cond_wait, THEN one
+ * signal fires. If the wake is dropped, the consumer hangs forever and the
+ * watchdog below reports it -- no fast-path escape is possible because
+ * nothing touches `pending` before the deliberate delay elapses. */
+#define T1B_PARK_DELAY_MS  300
+#define T1B_STALL_MS       2000
+
+typedef struct {
+    uint32_t mutex_id;
+    uint32_t cond_id;
+    LONG volatile woke;         /* 1 once the consumer's wait returns */
+    LONG volatile parked_at_ms; /* set just before the consumer waits */
+} t1b_shared;
+
+static unsigned __stdcall t1b_consumer(void* p)
+{
+    t1b_shared* sh = (t1b_shared*)p;
+    uint32_t tid = alloc_tid(); t_tid = tid;
+    ppu_context ctx; ctx_init_for_thread(&ctx, tid);
+
+    int32_t rc = call2((int64_t(*)(ppu_context*))sys_mutex_lock, &ctx, sh->mutex_id, 0);
+    if (rc != CELL_OK) { fail("test1b", "lock rc=0x%08X", (unsigned)rc); return 1; }
+
+    InterlockedExchange(&sh->parked_at_ms, (LONG)now_ms());
+    rc = call2((int64_t(*)(ppu_context*))sys_cond_wait, &ctx, sh->cond_id, (uint64_t)0 /* infinite */);
+    if (rc != CELL_OK) { fail("test1b", "wait rc=0x%08X", (unsigned)rc); return 1; }
+
+    InterlockedExchange(&sh->woke, 1);
+    call1((int64_t(*)(ppu_context*))sys_mutex_unlock, &ctx, sh->mutex_id);
+    return 0;
+}
+
+static unsigned __stdcall t1b_watchdog(void* p)
+{
+    t1b_shared* sh = (t1b_shared*)p;
+    for (;;) {
+        Sleep(50);
+        if (sh->woke) return 0;
+        if (sh->parked_at_ms != 0) {
+            ULONGLONG since_park = now_ms() - (ULONGLONG)sh->parked_at_ms;
+            if (since_park > (ULONGLONG)(T1B_PARK_DELAY_MS + T1B_STALL_MS)) {
+                fprintf(stderr, "[FAIL] test1b_rendezvous_park: consumer parked >%dms ago and "
+                        "never woke (signal delivered to an already-sleeping waiter was lost)\n",
+                        T1B_PARK_DELAY_MS + T1B_STALL_MS);
+                fflush(stderr);
+                InterlockedIncrement(&g_fail_count);
+                fflush(stdout);
+                _exit(1);
+            }
+        }
+    }
+}
+
+static int test1b_rendezvous_park(void)
+{
+    const char* name = "test1b_rendezvous_park";
+    LONG before = g_fail_count;
+    ppu_context ctx; ctx_init_for_thread(&ctx, alloc_tid());
+
+    uint32_t mattr = make_mutex_attr(SYS_SYNC_FIFO, 0);
+    uint32_t mid_addr = guest_alloc(4);
+    int32_t rc = call2((int64_t(*)(ppu_context*))sys_mutex_create, &ctx, mid_addr, mattr);
+    if (rc != CELL_OK) { fail(name, "mutex_create rc=0x%08X", (unsigned)rc); return 1; }
+    uint32_t mid = read_be32(mid_addr);
+
+    uint32_t cid_addr = guest_alloc(4);
+    rc = call3((int64_t(*)(ppu_context*))sys_cond_create, &ctx, cid_addr, mid, 0);
+    if (rc != CELL_OK) { fail(name, "cond_create rc=0x%08X", (unsigned)rc); return 1; }
+    uint32_t cid = read_be32(cid_addr);
+
+    t1b_shared sh; memset(&sh, 0, sizeof(sh));
+    sh.mutex_id = mid;
+    sh.cond_id = cid;
+
+    HANDLE consumer = (HANDLE)_beginthreadex(NULL, 0, t1b_consumer, &sh, 0, NULL);
+    HANDLE watchdog = (HANDLE)_beginthreadex(NULL, 0, t1b_watchdog, &sh, 0, NULL);
+
+    /* Generous head start so the consumer is provably already parked inside
+     * SleepConditionVariableCS (holds no lock while parked, so this sleep on
+     * the signalling side does not deadlock anything) before we signal. */
+    Sleep(T1B_PARK_DELAY_MS);
+
+    rc = call2((int64_t(*)(ppu_context*))sys_mutex_lock, &ctx, mid, 0);
+    if (rc != CELL_OK) { fail(name, "signaler lock rc=0x%08X", (unsigned)rc); }
+    rc = call1((int64_t(*)(ppu_context*))sys_cond_signal, &ctx, cid);
+    if (rc != CELL_OK) { fail(name, "signal rc=0x%08X", (unsigned)rc); }
+    call1((int64_t(*)(ppu_context*))sys_mutex_unlock, &ctx, mid);
+
+    DWORD wr = WaitForSingleObject(consumer, T1B_STALL_MS + 3000);
+    if (wr == WAIT_TIMEOUT) {
+        fail(name, "consumer never woke after signal to an already-parked waiter (hard hang)");
+    }
+    WaitForSingleObject(watchdog, 500);
+    CloseHandle(consumer);
+    CloseHandle(watchdog);
+
+    if (!sh.woke) fail(name, "consumer did not report waking");
+
+    int ok = (g_fail_count == before);
+    printf("[%s] woke=%ld -> %s\n", name, sh.woke, ok ? "PASS" : "FAIL");
+    return ok ? 0 : 1;
+}
+
+static int test1_no_lost_wakeup(void)
+{
+    const char* name = "test1_no_lost_wakeup";
+    printf("[%s] %d producers x %d consumers, %d items...\n", name, T1_PRODUCERS, T1_CONSUMERS, T1_ITERS);
+    LONG before = g_fail_count;
+
+    ppu_context boot_ctx; ctx_init_for_thread(&boot_ctx, alloc_tid());
+
+    uint32_t mutex_attr = make_mutex_attr(SYS_SYNC_FIFO, 0);
+    uint32_t mutex_id_addr = guest_alloc(4);
+    int32_t rc = call2((int64_t(*)(ppu_context*))sys_mutex_create, &boot_ctx, mutex_id_addr, mutex_attr);
+    if (rc != CELL_OK) { fail(name, "mutex_create rc=0x%08X", (unsigned)rc); return 1; }
+    uint32_t mutex_id = read_be32(mutex_id_addr);
+
+    uint32_t cond_id_addr = guest_alloc(4);
+    rc = call3((int64_t(*)(ppu_context*))sys_cond_create, &boot_ctx, cond_id_addr, mutex_id, 0);
+    if (rc != CELL_OK) { fail(name, "cond_create rc=0x%08X", (unsigned)rc); return 1; }
+    uint32_t cond_id = read_be32(cond_id_addr);
+
+    t1_shared sh;
+    memset(&sh, 0, sizeof(sh));
+    sh.mutex_id = mutex_id;
+    sh.cond_id = cond_id;
+    sh.last_progress_ms = (LONG)now_ms();
+
+    HANDLE producers[T1_PRODUCERS];
+    HANDLE consumers[T1_CONSUMERS];
+    t1_arg pargs[T1_PRODUCERS];
+    t1_arg cargs[T1_CONSUMERS];
+
+    int base = T1_ITERS / T1_PRODUCERS;
+    int rem = T1_ITERS % T1_PRODUCERS;
+    for (int i = 0; i < T1_PRODUCERS; i++) {
+        pargs[i].sh = &sh;
+        pargs[i].my_index = -1;
+        pargs[i].iters_for_me = base + (i < rem ? 1 : 0);
+        producers[i] = (HANDLE)_beginthreadex(NULL, 0, t1_producer, &pargs[i], 0, NULL);
+    }
+    for (int i = 0; i < T1_CONSUMERS; i++) {
+        cargs[i].sh = &sh;
+        cargs[i].my_index = i;
+        consumers[i] = (HANDLE)_beginthreadex(NULL, 0, t1_consumer, &cargs[i], 0, NULL);
+    }
+    HANDLE watchdog = (HANDLE)_beginthreadex(NULL, 0, t1_watchdog, &sh, 0, NULL);
+
+    WaitForMultipleObjects(T1_PRODUCERS, producers, TRUE, INFINITE);
+    InterlockedExchange(&sh.done_producing, 1);
+    /* Wake every consumer once: with an infinite per-consumer wait, only
+     * signal_all (unmutated by the seeded-bug self-test) reliably drains the
+     * "no more work" tail; sys_cond_signal alone (mutated in the self-test)
+     * would leave any consumer that raced past the produced>consumed check
+     * parked forever, which is exactly what the watchdog above exists to
+     * catch mid-run. */
+    ppu_context wctx; ctx_init_for_thread(&wctx, alloc_tid());
+    call1((int64_t(*)(ppu_context*))sys_cond_signal_all, &wctx, cond_id);
+
+    DWORD wr = WaitForMultipleObjects(T1_CONSUMERS, consumers, TRUE, 10000);
+    if (wr == WAIT_TIMEOUT) {
+        fail(name, "one or more consumers never returned (hard hang)");
+    }
+    InterlockedExchange(&sh.done_producing, 1); /* tell the watchdog we're wrapping up */
+    WaitForSingleObject(watchdog, 2000);
+    CloseHandle(watchdog);
+
+    for (int i = 0; i < T1_PRODUCERS; i++) CloseHandle(producers[i]);
+    for (int i = 0; i < T1_CONSUMERS; i++) CloseHandle(consumers[i]);
+
+    if (sh.produced != T1_ITERS) {
+        fail(name, "produced=%ld expected=%d", sh.produced, T1_ITERS);
+    }
+    if (sh.consumed != T1_ITERS) {
+        fail(name, "consumed=%ld expected=%d (lost item(s))", sh.consumed, T1_ITERS);
+    }
+
+    int ok = (g_fail_count == before);
+    printf("[%s] produced=%ld consumed=%ld -> %s\n", name, sh.produced, sh.consumed, ok ? "PASS" : "FAIL");
+    return ok ? 0 : 1;
+}
+
+/* =========================================================================
+ * TEST 2 -- Timed-wait semantics
+ *
+ * cond timed waits must return ETIMEDOUT on expiry and 0 (CELL_OK) on a
+ * real signal, and must NEVER hang past their timeout (bounded by the host
+ * wait itself, but we also assert the wall-clock elapsed matches order of
+ * magnitude). Semaphore timed waits get the same treatment.
+ * ========================================================================= */
+static unsigned __stdcall t2_signal_after_delay(void* p);
+
+static int test2_timed_wait_semantics(void)
+{
+    const char* name = "test2_timed_wait_semantics";
+    LONG before = g_fail_count;
+    ppu_context ctx; ctx_init_for_thread(&ctx, alloc_tid());
+
+    /* --- cond: expiry case --- */
+    uint32_t mattr = make_mutex_attr(SYS_SYNC_FIFO, 0);
+    uint32_t mid_addr = guest_alloc(4);
+    int32_t rc = call2((int64_t(*)(ppu_context*))sys_mutex_create, &ctx, mid_addr, mattr);
+    if (rc != CELL_OK) { fail(name, "mutex_create rc=0x%08X", (unsigned)rc); return 1; }
+    uint32_t mid = read_be32(mid_addr);
+
+    uint32_t cid_addr = guest_alloc(4);
+    rc = call3((int64_t(*)(ppu_context*))sys_cond_create, &ctx, cid_addr, mid, 0);
+    if (rc != CELL_OK) { fail(name, "cond_create rc=0x%08X", (unsigned)rc); return 1; }
+    uint32_t cid = read_be32(cid_addr);
+
+    for (int trial = 0; trial < 50; trial++) {
+        rc = call2((int64_t(*)(ppu_context*))sys_mutex_lock, &ctx, mid, 0);
+        if (rc != CELL_OK) { fail(name, "lock rc=0x%08X", (unsigned)rc); return 1; }
+
+        ULONGLONG t0 = now_ms();
+        rc = call2((int64_t(*)(ppu_context*))sys_cond_wait, &ctx, cid, (uint64_t)50000 /* 50ms, no signaler */);
+        ULONGLONG elapsed = now_ms() - t0;
+
+        if (rc != (int32_t)CELL_ETIMEDOUT) {
+            fail(name, "cond timed-wait trial %d: expected ETIMEDOUT got 0x%08X", trial, (unsigned)rc);
+        }
+        if (elapsed > 5000) {
+            fail(name, "cond timed-wait trial %d: took %llums (expected ~50ms, never-hang bound blown)",
+                 trial, (unsigned long long)elapsed);
+        }
+
+        rc = call1((int64_t(*)(ppu_context*))sys_mutex_unlock, &ctx, mid);
+        if (rc != CELL_OK) { fail(name, "unlock rc=0x%08X", (unsigned)rc); return 1; }
+    }
+
+    /* --- cond: real signal beats the timeout, rc must be CELL_OK --- */
+    typedef struct { uint32_t mid, cid; } signaler_arg;
+    signaler_arg sarg = { mid, cid };
+    /* Signaler thread: sleep a bit, then signal (real lv2 sys_cond_signal
+     * does not require the caller to hold the mutex -- see sys_cond.c). */
+    HANDLE sig_th = (HANDLE)_beginthreadex(NULL, 0, t2_signal_after_delay, &sarg, 0, NULL);
+
+    rc = call2((int64_t(*)(ppu_context*))sys_mutex_lock, &ctx, mid, 0);
+    if (rc != CELL_OK) { fail(name, "signalled-case lock rc=0x%08X", (unsigned)rc); }
+    ULONGLONG t0 = now_ms();
+    rc = call2((int64_t(*)(ppu_context*))sys_cond_wait, &ctx, cid, (uint64_t)5000000 /* 5s */);
+    ULONGLONG elapsed = now_ms() - t0;
+    if (rc != CELL_OK) {
+        fail(name, "signalled-case: expected CELL_OK got 0x%08X after %llums", (unsigned)rc, (unsigned long long)elapsed);
+    }
+    call1((int64_t(*)(ppu_context*))sys_mutex_unlock, &ctx, mid);
+    WaitForSingleObject(sig_th, INFINITE);
+    CloseHandle(sig_th);
+
+    /* --- semaphore: expiry case --- */
+    uint32_t sattr = make_sema_attr(SYS_SYNC_FIFO);
+    uint32_t sid_addr = guest_alloc(4);
+    rc = call4((int64_t(*)(ppu_context*))sys_semaphore_create, &ctx, sid_addr, sattr, 0, 4);
+    if (rc != CELL_OK) { fail(name, "sema_create rc=0x%08X", (unsigned)rc); return 1; }
+    uint32_t sid = read_be32(sid_addr);
+
+    for (int trial = 0; trial < 50; trial++) {
+        ULONGLONG s0 = now_ms();
+        rc = call2((int64_t(*)(ppu_context*))sys_semaphore_wait, &ctx, sid, (uint64_t)30000 /* 30ms */);
+        ULONGLONG selapsed = now_ms() - s0;
+        if (rc != (int32_t)CELL_ETIMEDOUT) {
+            fail(name, "sema timed-wait trial %d: expected ETIMEDOUT got 0x%08X", trial, (unsigned)rc);
+        }
+        if (selapsed > 5000) {
+            fail(name, "sema timed-wait trial %d: took %llums (never-hang bound blown)",
+                 trial, (unsigned long long)selapsed);
+        }
+    }
+
+    /* --- semaphore: post before wait must return CELL_OK immediately --- */
+    rc = call2((int64_t(*)(ppu_context*))sys_semaphore_post, &ctx, sid, 1);
+    if (rc != CELL_OK) { fail(name, "sema_post rc=0x%08X", (unsigned)rc); }
+    rc = call2((int64_t(*)(ppu_context*))sys_semaphore_wait, &ctx, sid, (uint64_t)1000000);
+    if (rc != CELL_OK) { fail(name, "sema wait-after-post rc=0x%08X", (unsigned)rc); }
+
+    int ok = (g_fail_count == before);
+    printf("[%s] -> %s\n", name, ok ? "PASS" : "FAIL");
+    return ok ? 0 : 1;
+}
+
+static unsigned __stdcall t2_signal_after_delay(void* p)
+{
+    typedef struct { uint32_t mid, cid; } signaler_arg;
+    signaler_arg* a = (signaler_arg*)p;
+    Sleep(100);
+    uint32_t tid = alloc_tid();
+    t_tid = tid;
+    ppu_context ctx; ctx_init_for_thread(&ctx, tid);
+    call1((int64_t(*)(ppu_context*))sys_cond_signal, &ctx, a->cid);
+    return 0;
+}
+
+/* =========================================================================
+ * TEST 3 -- Semaphore counting invariant under post/wait storms
+ *
+ * P posters each post `count` in bursts; C waiters each wait/decrement.
+ * At all times 0 <= value <= max_value must hold (checked via
+ * sys_semaphore_get_value from a monitor thread) and, at the end (all
+ * threads joined, posts==waits in total units), value must return to its
+ * starting point exactly -- no lost or phantom counts.
+ * ========================================================================= */
+#define T3_POSTERS   4
+#define T3_WAITERS   4
+#define T3_MAXVAL    64
+#define T3_ITERS     10000 /* total post units == total wait units */
+
+typedef struct {
+    uint32_t sem_id;
+    LONG volatile posted_units;
+    LONG volatile waited_units;
+    LONG volatile invariant_violations;
+    LONG volatile stop;
+} t3_shared;
+
+static unsigned __stdcall t3_poster(void* p)
+{
+    typedef struct { t3_shared* sh; int units_for_me; uint32_t seed; } t3_parg;
+    t3_parg* arg = (t3_parg*)p;
+    t3_shared* sh = arg->sh;
+    uint32_t tid = alloc_tid(); t_tid = tid;
+    ppu_context ctx; ctx_init_for_thread(&ctx, tid);
+    uint32_t rng = arg->seed;
+
+    int remaining = arg->units_for_me;
+    while (remaining > 0) {
+        int burst = 1 + (int)(xorshift32(&rng) % 3);
+        if (burst > remaining) burst = remaining;
+        int32_t rc;
+        for (;;) {
+            rc = call2((int64_t(*)(ppu_context*))sys_semaphore_post, &ctx, sh->sem_id, burst);
+            if (rc == CELL_OK) break;
+            if (rc == (int32_t)CELL_EBUSY) { Sleep(0); continue; } /* would exceed max, retry smaller */
+            fail("test3", "poster: unexpected post rc=0x%08X", (unsigned)rc);
+            return 1;
+        }
+        InterlockedAdd(&sh->posted_units, burst);
+        remaining -= burst;
+    }
+    return 0;
+}
+
+static unsigned __stdcall t3_waiter(void* p)
+{
+    typedef struct { t3_shared* sh; int units_for_me; } t3_warg;
+    t3_warg* arg = (t3_warg*)p;
+    t3_shared* sh = arg->sh;
+    uint32_t tid = alloc_tid(); t_tid = tid;
+    ppu_context ctx; ctx_init_for_thread(&ctx, tid);
+
+    for (int i = 0; i < arg->units_for_me; i++) {
+        int32_t rc = call2((int64_t(*)(ppu_context*))sys_semaphore_wait, &ctx, sh->sem_id, (uint64_t)2000000 /* 2s bound */);
+        if (rc != CELL_OK) {
+            fail("test3", "waiter wait rc=0x%08X (possible stuck waiter)", (unsigned)rc);
+            return 1;
+        }
+        InterlockedIncrement(&sh->waited_units);
+    }
+    return 0;
+}
+
+static unsigned __stdcall t3_monitor(void* p)
+{
+    t3_shared* sh = (t3_shared*)p;
+    uint32_t tid = alloc_tid(); t_tid = tid;
+    ppu_context ctx; ctx_init_for_thread(&ctx, tid);
+    uint32_t out_addr = guest_alloc(4);
+
+    while (!sh->stop) {
+        int32_t rc = call2((int64_t(*)(ppu_context*))sys_semaphore_get_value, &ctx, sh->sem_id, out_addr);
+        if (rc == CELL_OK) {
+            int32_t val = (int32_t)read_be32(out_addr);
+            if (val < 0 || val > T3_MAXVAL) {
+                InterlockedIncrement(&sh->invariant_violations);
+                fail("test3", "invariant violated: value=%d not in [0,%d]", val, T3_MAXVAL);
+            }
+        }
+        Sleep(0);
+    }
+    return 0;
+}
+
+static int test3_semaphore_counting(void)
+{
+    const char* name = "test3_semaphore_counting";
+    LONG before = g_fail_count;
+    ppu_context ctx; ctx_init_for_thread(&ctx, alloc_tid());
+
+    uint32_t sattr = make_sema_attr(SYS_SYNC_FIFO);
+    uint32_t sid_addr = guest_alloc(4);
+    int32_t rc = call4((int64_t(*)(ppu_context*))sys_semaphore_create, &ctx, sid_addr, sattr, 0, T3_MAXVAL);
+    if (rc != CELL_OK) { fail(name, "sema_create rc=0x%08X", (unsigned)rc); return 1; }
+    uint32_t sid = read_be32(sid_addr);
+
+    t3_shared sh; memset(&sh, 0, sizeof(sh)); sh.sem_id = sid;
+
+    HANDLE mon = (HANDLE)_beginthreadex(NULL, 0, t3_monitor, &sh, 0, NULL);
+
+    typedef struct { t3_shared* sh; int units_for_me; uint32_t seed; } t3_parg;
+    typedef struct { t3_shared* sh; int units_for_me; } t3_warg;
+    HANDLE posters[T3_POSTERS];
+    HANDLE waiters[T3_WAITERS];
+    t3_parg pargs[T3_POSTERS];
+    t3_warg wargs[T3_WAITERS];
+
+    int pbase = T3_ITERS / T3_POSTERS, prem = T3_ITERS % T3_POSTERS;
+    for (int i = 0; i < T3_POSTERS; i++) {
+        pargs[i].sh = &sh;
+        pargs[i].units_for_me = pbase + (i < prem ? 1 : 0);
+        pargs[i].seed = g_seed ^ (0x9E3779B9u * (uint32_t)(i + 1));
+        posters[i] = (HANDLE)_beginthreadex(NULL, 0, t3_poster, &pargs[i], 0, NULL);
+    }
+    int wbase = T3_ITERS / T3_WAITERS, wrem = T3_ITERS % T3_WAITERS;
+    for (int i = 0; i < T3_WAITERS; i++) {
+        wargs[i].sh = &sh;
+        wargs[i].units_for_me = wbase + (i < wrem ? 1 : 0);
+        waiters[i] = (HANDLE)_beginthreadex(NULL, 0, t3_waiter, &wargs[i], 0, NULL);
+    }
+
+    WaitForMultipleObjects(T3_POSTERS, posters, TRUE, INFINITE);
+    DWORD wr = WaitForMultipleObjects(T3_WAITERS, waiters, TRUE, 30000);
+    if (wr == WAIT_TIMEOUT) fail(name, "one or more waiters never returned (hard hang)");
+
+    InterlockedExchange(&sh.stop, 1);
+    WaitForSingleObject(mon, INFINITE);
+
+    for (int i = 0; i < T3_POSTERS; i++) CloseHandle(posters[i]);
+    for (int i = 0; i < T3_WAITERS; i++) CloseHandle(waiters[i]);
+    CloseHandle(mon);
+
+    if (sh.posted_units != T3_ITERS) fail(name, "posted_units=%ld expected=%d", sh.posted_units, T3_ITERS);
+    if (sh.waited_units != T3_ITERS) fail(name, "waited_units=%ld expected=%d", sh.waited_units, T3_ITERS);
+
+    uint32_t out_addr = guest_alloc(4);
+    rc = call2((int64_t(*)(ppu_context*))sys_semaphore_get_value, &ctx, sid, out_addr);
+    int32_t final_val = (int32_t)read_be32(out_addr);
+    if (rc != CELL_OK || final_val != 0) {
+        fail(name, "final value=%d expected=0 (posts=%ld waits=%ld) rc=0x%08X",
+             final_val, sh.posted_units, sh.waited_units, (unsigned)rc);
+    }
+
+    int ok = (g_fail_count == before);
+    printf("[%s] posted=%ld waited=%ld final_value=%d violations=%ld -> %s\n",
+           name, sh.posted_units, sh.waited_units, final_val, sh.invariant_violations, ok ? "PASS" : "FAIL");
+    return ok ? 0 : 1;
+}
+
+/* =========================================================================
+ * TEST 4 -- Event queue: FIFO-per-source + exactly-one-receiver-per-event
+ *
+ * Two sub-tests against the SAME queue implementation, each isolating one
+ * half of the spec clause (they need different concurrency shapes to be
+ * checkable at all from OUTSIDE the runtime's own lock):
+ *
+ * 4a (FIFO-per-source): S producer threads push a monotonically increasing
+ *   per-source sequence number concurrently into one shared queue; ONE
+ *   dedicated receiver thread drains it. With a single consumer, the order
+ *   in which events are handed to guest code IS the order the receiver's
+ *   own call sequence observes them (no second racing thread to introduce
+ *   a scheduling artifact between "dequeued" and "recorded") -- so this is
+ *   a sound way to check the queue preserves each source's push order.
+ *   NOTE: an earlier draft of this test tried to check ordering with
+ *   MULTIPLE concurrent receivers, each recording under its own bookkeeping
+ *   lock after sys_event_queue_receive returned. That is NOT sound: the
+ *   queue's internal CRITICAL_SECTION only serializes the dequeue itself
+ *   (sys_event.c's `q->lock`); once two receiver threads' calls return,
+ *   nothing pins the thread that got the earlier item ahead of the thread
+ *   that got the later item at any SECOND, unrelated lock -- that measures
+ *   OS scheduling, not queue order (confirmed via independent code-reading
+ *   review of sys_event_queue_receive / event_queue_push before committing
+ *   to this design; see the test's final report for the discarded output).
+ *
+ * 4b (exactly-one-receiver-per-event): R receiver threads pop concurrently
+ *   from one shared queue fed by S producers. This property (no duplicate
+ *   delivery, no silent drop) is a set-membership fact, NOT a timing fact,
+ *   so it stays sound under full receiver concurrency: every (source,seq)
+ *   must end up marked exactly once across all receivers, however they
+ *   interleave.
+ * ========================================================================= */
+#define T4_SOURCES        6
+#define T4_PER_SOURCE     1667  /* 4a: * 6 sources ~= 10000 events, 1 receiver */
+#define T4_RECEIVERS      4
+#define T4B_PER_SOURCE    417   /* 4b: * 6 sources ~= 2500 events, 4 receivers */
+#define T4_QUEUE_CAP      96    /* < SYS_EVENT_QUEUE_BUF_MAX(127); push retries on full */
+
+/* --- 4a: FIFO-per-source, single receiver --- */
+typedef struct {
+    uint32_t queue_id;
+    LONG volatile total_events;
+    LONG volatile order_violations;
+    LONG volatile last_seq[T4_SOURCES];
+} t4a_shared;
+
+static unsigned __stdcall t4a_source(void* p)
+{
+    typedef struct { t4a_shared* sh; int source_idx; } t4a_sarg;
+    t4a_sarg* arg = (t4a_sarg*)p;
+    t4a_shared* sh = arg->sh;
+
+    for (int seq = 0; seq < T4_PER_SOURCE; seq++) {
+        for (;;) {
+            int r = sys_event_queue_push_by_id(sh->queue_id,
+                                                (uint64_t)(arg->source_idx + 1) /* source, 1-based */,
+                                                (uint64_t)seq, 0, 0);
+            if (r == 0) break;
+            Sleep(0); /* queue full, back off and retry (never drop) */
+        }
+        InterlockedIncrement(&sh->total_events);
+    }
+    return 0;
+}
+
+static unsigned __stdcall t4a_receiver(void* p)
+{
+    t4a_shared* sh = (t4a_shared*)p;
+    uint32_t tid = alloc_tid(); t_tid = tid;
+    ppu_context ctx; ctx_init_for_thread(&ctx, tid);
+    uint32_t event_addr = guest_alloc(32);
+    LONG total_expected = T4_SOURCES * T4_PER_SOURCE;
+    LONG received = 0;
+
+    while (received < total_expected) {
+        int32_t rc = call3((int64_t(*)(ppu_context*))sys_event_queue_receive, &ctx, sh->queue_id, event_addr, (uint64_t)1000000 /* 1s */);
+        if (rc == (int32_t)CELL_ETIMEDOUT) continue;
+        if (rc != CELL_OK) { fail("test4a", "receive rc=0x%08X", (unsigned)rc); return 1; }
+
+        uint64_t source = ctx.gpr[4];
+        uint64_t seq64 = ctx.gpr[5];
+        int src_idx = (int)source - 1;
+        int seq = (int)seq64;
+
+        if (src_idx < 0 || src_idx >= T4_SOURCES || seq < 0 || seq >= T4_PER_SOURCE) {
+            fail("test4a", "out-of-range event source=%llu seq=%llu",
+                 (unsigned long long)source, (unsigned long long)seq64);
+            received++;
+            continue;
+        }
+
+        /* Sole receiver: this thread's own call sequence IS the delivery
+         * order, so a plain (non-atomic) compare is sound here. */
+        LONG prev = sh->last_seq[src_idx];
+        if (seq <= prev) {
+            sh->order_violations++;
+            fail("test4a", "FIFO violation source=%d: got seq=%d after seq=%ld", src_idx, seq, prev);
+        } else {
+            sh->last_seq[src_idx] = seq;
+        }
+        received++;
+    }
+    return 0;
+}
+
+static int test4a_fifo_per_source(void)
+{
+    const char* name = "test4a_fifo_per_source";
+    LONG before = g_fail_count;
+    ppu_context ctx; ctx_init_for_thread(&ctx, alloc_tid());
+
+    uint32_t qattr = make_equeue_attr(SYS_SYNC_FIFO, SYS_PPU_QUEUE);
+    uint32_t qid_addr = guest_alloc(4);
+    int32_t rc = call4((int64_t(*)(ppu_context*))sys_event_queue_create, &ctx, qid_addr, qattr, 0, T4_QUEUE_CAP);
+    if (rc != CELL_OK) { fail(name, "queue_create rc=0x%08X", (unsigned)rc); return 1; }
+    uint32_t qid = read_be32(qid_addr);
+
+    t4a_shared sh; memset(&sh, 0, sizeof(sh));
+    sh.queue_id = qid;
+    for (int i = 0; i < T4_SOURCES; i++) sh.last_seq[i] = -1;
+
+    typedef struct { t4a_shared* sh; int source_idx; } t4a_sarg;
+    HANDLE sources[T4_SOURCES];
+    t4a_sarg sargs[T4_SOURCES];
+
+    HANDLE receiver = (HANDLE)_beginthreadex(NULL, 0, t4a_receiver, &sh, 0, NULL);
+    for (int i = 0; i < T4_SOURCES; i++) {
+        sargs[i].sh = &sh;
+        sargs[i].source_idx = i;
+        sources[i] = (HANDLE)_beginthreadex(NULL, 0, t4a_source, &sargs[i], 0, NULL);
+    }
+
+    WaitForMultipleObjects(T4_SOURCES, sources, TRUE, INFINITE);
+    DWORD wr = WaitForSingleObject(receiver, 30000);
+    if (wr == WAIT_TIMEOUT) fail(name, "receiver never returned (hard hang)");
+
+    for (int i = 0; i < T4_SOURCES; i++) CloseHandle(sources[i]);
+    CloseHandle(receiver);
+
+    int ok = (g_fail_count == before);
+    printf("[%s] total_events=%ld order_violations=%ld -> %s\n",
+           name, sh.total_events, sh.order_violations, ok ? "PASS" : "FAIL");
+    return ok ? 0 : 1;
+}
+
+/* --- 4b: exactly-one-receiver-per-event, concurrent receivers --- */
+typedef struct {
+    uint32_t queue_id;
+    LONG volatile total_received;
+    LONG volatile total_events;
+    LONG volatile duplicate_violations;
+    uint8_t* seen[T4_SOURCES];       /* T4B_PER_SOURCE bytes each */
+    CRITICAL_SECTION seen_lock;      /* bookkeeping only -- NOT an ordering oracle */
+} t4b_shared;
+
+static unsigned __stdcall t4b_source(void* p)
+{
+    typedef struct { t4b_shared* sh; int source_idx; } t4b_sarg;
+    t4b_sarg* arg = (t4b_sarg*)p;
+    t4b_shared* sh = arg->sh;
+
+    for (int seq = 0; seq < T4B_PER_SOURCE; seq++) {
+        for (;;) {
+            int r = sys_event_queue_push_by_id(sh->queue_id,
+                                                (uint64_t)(arg->source_idx + 1),
+                                                (uint64_t)seq, 0, 0);
+            if (r == 0) break;
+            Sleep(0);
+        }
+        InterlockedIncrement(&sh->total_events);
+    }
+    return 0;
+}
+
+static unsigned __stdcall t4b_receiver(void* p)
+{
+    t4b_shared* sh = (t4b_shared*)p;
+    uint32_t tid = alloc_tid(); t_tid = tid;
+    ppu_context ctx; ctx_init_for_thread(&ctx, tid);
+    uint32_t event_addr = guest_alloc(32);
+    LONG total_expected = T4_SOURCES * T4B_PER_SOURCE;
+
+    for (;;) {
+        if (sh->total_received >= total_expected) return 0;
+
+        int32_t rc = call3((int64_t(*)(ppu_context*))sys_event_queue_receive, &ctx, sh->queue_id, event_addr, (uint64_t)1000000 /* 1s */);
+        if (rc == (int32_t)CELL_ETIMEDOUT) continue;
+        if (rc != CELL_OK) { fail("test4b", "receive rc=0x%08X", (unsigned)rc); return 1; }
+
+        uint64_t source = ctx.gpr[4];
+        uint64_t seq64 = ctx.gpr[5];
+        int src_idx = (int)source - 1;
+        int seq = (int)seq64;
+
+        if (src_idx < 0 || src_idx >= T4_SOURCES || seq < 0 || seq >= T4B_PER_SOURCE) {
+            fail("test4b", "out-of-range event source=%llu seq=%llu",
+                 (unsigned long long)source, (unsigned long long)seq64);
+            InterlockedIncrement(&sh->total_received);
+            continue;
+        }
+
+        /* Set-membership check only -- timing-independent, sound under
+         * full receiver concurrency (see block comment above). */
+        EnterCriticalSection(&sh->seen_lock);
+        if (sh->seen[src_idx][seq]) {
+            sh->duplicate_violations++;
+            fail("test4b", "DUPLICATE delivery source=%d seq=%d", src_idx, seq);
+        } else {
+            sh->seen[src_idx][seq] = 1;
+        }
+        LeaveCriticalSection(&sh->seen_lock);
+
+        InterlockedIncrement(&sh->total_received);
+    }
+}
+
+static int test4b_exactly_once_delivery(void)
+{
+    const char* name = "test4b_exactly_once_delivery";
+    LONG before = g_fail_count;
+    ppu_context ctx; ctx_init_for_thread(&ctx, alloc_tid());
+
+    uint32_t qattr = make_equeue_attr(SYS_SYNC_FIFO, SYS_PPU_QUEUE);
+    uint32_t qid_addr = guest_alloc(4);
+    int32_t rc = call4((int64_t(*)(ppu_context*))sys_event_queue_create, &ctx, qid_addr, qattr, 0, T4_QUEUE_CAP);
+    if (rc != CELL_OK) { fail(name, "queue_create rc=0x%08X", (unsigned)rc); return 1; }
+    uint32_t qid = read_be32(qid_addr);
+
+    t4b_shared sh; memset(&sh, 0, sizeof(sh));
+    sh.queue_id = qid;
+    InitializeCriticalSection(&sh.seen_lock);
+    for (int i = 0; i < T4_SOURCES; i++) sh.seen[i] = (uint8_t*)calloc(T4B_PER_SOURCE, 1);
+
+    typedef struct { t4b_shared* sh; int source_idx; } t4b_sarg;
+    HANDLE sources[T4_SOURCES];
+    t4b_sarg sargs[T4_SOURCES];
+    HANDLE receivers[T4_RECEIVERS];
+
+    for (int i = 0; i < T4_RECEIVERS; i++) {
+        receivers[i] = (HANDLE)_beginthreadex(NULL, 0, t4b_receiver, &sh, 0, NULL);
+    }
+    for (int i = 0; i < T4_SOURCES; i++) {
+        sargs[i].sh = &sh;
+        sargs[i].source_idx = i;
+        sources[i] = (HANDLE)_beginthreadex(NULL, 0, t4b_source, &sargs[i], 0, NULL);
+    }
+
+    WaitForMultipleObjects(T4_SOURCES, sources, TRUE, INFINITE);
+    DWORD wr = WaitForMultipleObjects(T4_RECEIVERS, receivers, TRUE, 30000);
+    if (wr == WAIT_TIMEOUT) fail(name, "one or more receivers never returned (hard hang)");
+
+    for (int i = 0; i < T4_SOURCES; i++) CloseHandle(sources[i]);
+    for (int i = 0; i < T4_RECEIVERS; i++) CloseHandle(receivers[i]);
+    DeleteCriticalSection(&sh.seen_lock);
+
+    int expected_total = T4_SOURCES * T4B_PER_SOURCE;
+    if (sh.total_received != expected_total) {
+        fail(name, "total_received=%ld expected=%d (dropped or over-consumed)", sh.total_received, expected_total);
+    }
+    int missing = 0;
+    for (int i = 0; i < T4_SOURCES; i++) {
+        for (int s = 0; s < T4B_PER_SOURCE; s++) {
+            if (!sh.seen[i][s]) missing++;
+        }
+        free(sh.seen[i]);
+    }
+    if (missing > 0) fail(name, "%d (source,seq) events never delivered to any receiver", missing);
+
+    int ok = (g_fail_count == before);
+    printf("[%s] total_events=%ld total_received=%ld dup_violations=%ld missing=%d -> %s\n",
+           name, sh.total_events, sh.total_received, sh.duplicate_violations, missing, ok ? "PASS" : "FAIL");
+    return ok ? 0 : 1;
+}
+
+static int test4_event_queue(void)
+{
+    int a = test4a_fifo_per_source();
+    int b = test4b_exactly_once_delivery();
+    return (a || b) ? 1 : 0;
+}
+
+/* =========================================================================
+ * main
+ * ========================================================================= */
+int main(int argc, char** argv)
+{
+    g_seed = 0;
+    if (argc > 1) {
+        g_seed = (uint32_t)strtoul(argv[1], NULL, 10);
+    }
+    /* xorshift32 requires a nonzero state. */
+    if (g_seed == 0) g_seed = 0x2545F491u;
+    printf("=== ps3recomp sync_stress -- seed=%u ===\n", (unsigned)(argc > 1 ? strtoul(argv[1], NULL, 10) : 0));
+
+    ULONGLONG t_start = now_ms();
+
+    int rc1a = test1b_rendezvous_park();
+    int rc1 = test1_no_lost_wakeup();
+    int rc2 = test2_timed_wait_semantics();
+    int rc3 = test3_semaphore_counting();
+    int rc4 = test4_event_queue();
+
+    ULONGLONG total_ms = now_ms() - t_start;
+    printf("=== total wall time: %llums ===\n", (unsigned long long)total_ms);
+
+    int failed = rc1a || rc1 || rc2 || rc3 || rc4 || (g_fail_count != 0);
+    printf("=== RESULT: %s (fail_count=%ld) ===\n", failed ? "FAIL" : "PASS", g_fail_count);
+    return failed ? 1 : 0;
+}

--- a/tools/disasm_audit.py
+++ b/tools/disasm_audit.py
@@ -1,0 +1,548 @@
+#!/usr/bin/env py -3
+"""disasm_audit.py - PPU decoder cross-check: tools/ppu_disasm.py vs Capstone.
+
+Purpose: catch the crnand/crnor bug class (decode-table swaps/scrambles --
+the most expensive bug class in project history) EXHAUSTIVELY, in one run,
+by decoding every 4-byte word of the game's executable segments with two
+independent decoders and diffing the mnemonics.
+
+Decoders:
+  (a) ours   -- tools/ppu_disasm.py's decode()
+  (b) oracle -- Capstone, CS_ARCH_PPC + CS_MODE_64 + CS_MODE_BIG_ENDIAN
+
+Capstone is an OPTIONAL, DEV-ONLY dependency (`py -3 -m pip install
+capstone`). It must NEVER be imported by runtime/lifter code -- this script
+is the only place in the repo that touches it, and it degrades to a one-line
+install hint if the import fails (never a crash or a silent skip).
+
+Scope (v1): MNEMONIC comparison only. Operand normalization is a planned v2.
+Known alias classes -- where Capstone's *simplified* PowerPC
+mnemonic legitimately differs from our *canonical* mnemonic for the exact
+same encoding -- are handled via an explicit WHITELIST table below, each
+entry MEASURED against a hand-built encoding + both decoders (see the
+comments next to ALIAS_WHITELIST). Whitelisted pairs are reported separately
+as INFO, never counted as mismatches.
+
+Usage:
+    py -3 tools\\disasm_audit.py game\\EBOOT.elf [--limit N] [--top N]
+                                 [--dump-mismatches FILE]
+    py -3 tools\\disasm_audit.py --self-test        (seeded-bug harness)
+
+Exit code: 0 if residual (non-whitelisted) mismatch count is 0, else 1.
+Always runs to completion and prints the full report either way -- the exit
+code is a machine-checkable summary, not a reason to stop early.
+"""
+
+import argparse
+import os
+import struct
+import sys
+from collections import Counter, defaultdict
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from elf_parser import ELFFile, PT_LOAD  # noqa: E402
+from ppu_disasm import decode  # noqa: E402
+
+
+def _capstone_or_die():
+    """Import capstone or exit with a one-line install hint.
+
+    Capstone is sanctioned as an OPTIONAL dev-only dependency for THIS
+    script only. It must never be added to runtime/lifter requirements.
+    """
+    try:
+        import capstone
+        return capstone
+    except ImportError:
+        print("disasm_audit: capstone not installed -- "
+              "run: py -3 -m pip install capstone", file=sys.stderr)
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Alias whitelist
+#
+# Each entry: (ours_mnemonic, capstone_mnemonic) -> one-line reason.
+# Every pair here was MEASURED directly: a hand-built encoding was fed to
+# BOTH decode() (tools/ppu_disasm.py) and Capstone (CS_ARCH_PPC, CS_MODE_64
+# + CS_MODE_BIG_ENDIAN, detail=False) and the mnemonics recorded verbatim.
+# This is not a guess list -- extend it only after doing the same probe.
+# ---------------------------------------------------------------------------
+ALIAS_WHITELIST = {
+    ("or", "mr"):
+        "or rD,rA,rA (Rc=0) -- Capstone simplifies register-move form to "
+        "'mr'; ours prints the canonical 'or'. Confirmed: rA==rB required; "
+        "'or.' (Rc=1) does NOT get simplified by Capstone (stays 'or.') so "
+        "that pair is NOT in this whitelist -- a mismatch there is real.",
+    ("ori", "nop"):
+        "ori r0,r0,0 -- both decoders treat this specific all-zero encoding "
+        "as the canonical no-op spelling; 'ori' with any non-zero rD/rA/UI "
+        "does NOT alias (confirmed ori r3,r4,0 -> both print 'ori').",
+    ("rlwinm", "slwi"):
+        "rlwinm rD,rA,n,0,31-n (n<32) -- Capstone simplifies the common "
+        "'shift left logical immediate' shape; ours keeps canonical rlwinm "
+        "with explicit mb/me. Real rlwinm mismatches (wrong mb/me/sh from a "
+        "table-encoding bug) still show up as (rlwinm, rlwinm) pairs with "
+        "differing operands -- but v1 is mnemonic-only, so note this as a "
+        "known blind spot for a future operand-level v2 check.",
+    ("rlwinm", "srwi"):
+        "rlwinm rD,rA,32-n,n,31 -- Capstone's 'shift right logical "
+        "immediate' simplification, same family as slwi above.",
+    ("rlwinm", "clrlwi"):
+        "rlwinm rD,rA,0,n,31 -- Capstone's 'clear left n bits' "
+        "simplification (rotate amount 0, mb=n, me=31).",
+    ("rlwinm", "rotlwi"):
+        "rlwinm rD,rA,n,0,31 -- Capstone's 'rotate left immediate' "
+        "simplification (full-width rotate, mb=0, me=31).",
+    ("rlwnm", "rotlw"):
+        "rlwnm rD,rA,rB,0,31 -- register-shift-count analog of rotlwi.",
+    ("cror", "crmove"):
+        "cror bt,ba,ba (BA==BB) -- Capstone's 'copy one CR bit' "
+        "simplification. Distinct-operand cror (e.g. cror 2,3,4) is NOT "
+        "simplified -- confirmed both decoders print 'cror' there, so a "
+        "mismatch on a distinct-operand crXXX instruction is still real "
+        "(this is exactly the crnand/crnor swap bug class the tool exists "
+        "to catch).",
+    ("crnor", "crnot"):
+        "crnor bt,ba,ba (BA==BB) -- Capstone's 'invert one CR bit' "
+        "simplification ('crnot' aka 'crnotc0lt' family).",
+    ("creqv", "crset"):
+        "creqv bt,ba,ba (BA==BB) -- Capstone's 'set CR bit' simplification "
+        "(A==B makes A eqv A always true).",
+    ("crxor", "crclr"):
+        "crxor bt,ba,ba (BA==BB) -- Capstone's 'clear CR bit' "
+        "simplification (A==B makes A xor A always false).",
+    ("mtcr", "mtcrf"):
+        "mtcrf 0xff,rS (all 8 CRM nibbles set) -- ours always prints the "
+        "'mtcr' short form for the full-mask case; Capstone always prints "
+        "the general 'mtcrf mask,rS' form regardless of mask value.",
+    ("rldicl", "clrldi"):
+        "rldicl rD,rA,0,mb -- Capstone's 'clear left mb bits, 64-bit' "
+        "simplification (sh=0, so it's a pure mask, no rotate); the 64-bit "
+        "analog of rlwinm/clrlwi above. MEASURED at 0x0001058C (real game "
+        "code): rldicl r3,r3,0,32 <-> clrldi r3,r3,0x20.",
+    ("rldicl", "rotldi"):
+        "rldicl rD,rA,sh,0 -- Capstone's 'rotate left doubleword immediate' "
+        "simplification (mb=0, so it's a pure rotate, no mask). MEASURED at "
+        "0x0110EA84: rldicl r19,r11,0,0 <-> rotldi r19,r11,0.",
+    ("rldicr", "sldi"):
+        "rldicr rD,rA,sh,me with me==63-sh -- Capstone's 'shift left "
+        "doubleword immediate' simplification, the 64-bit analog of "
+        "rlwinm/slwi above. MEASURED at 0x00010564: rldicr r4,r4,4,59 <-> "
+        "sldi r4,r4,4 (63-4==59).",
+    ("vnor", "vnot"):
+        "vnor vD,vA,vA (vA==vB) -- Capstone's vector 'not' simplification, "
+        "the VMX analog of the scalar or/mr and nor/not families. MEASURED "
+        "at 0x0002563C: vnor v6,v6,v6 <-> vnot v6,v6.",
+    ("mfcr", "mfocrf"):
+        "mfcr/mfocrf share opcd=31,XO=19 and differ only in bit 11 (the "
+        "'L' mode-select bit, introduced post-Cell in later Power ISA "
+        "revisions as 'move one CR field' vs the original 'move whole "
+        "CR'). The Cell PPU predates this ISA revision (based on PowerPC "
+        "2.02) so ours always emits the older 'mfcr' form; Capstone "
+        "supports the newer encoding and emits 'mfocrf' whenever L=1. "
+        "MEASURED: ALL 248 real mismatch sites have L-bit=1 (confirmed by "
+        "direct bit extraction over every opcd=31/XO=19 word in "
+        "game/EBOOT.elf) -- deterministic, bit-driven, not noise.",
+    ("mtcrf", "mtocrf"):
+        "mtcrf/mtocrf share opcd=31,XO=144 and differ only in bit 11 (same "
+        "'L' mode-select bit as mfcr/mfocrf above, same pre-Cell-ISA "
+        "reasoning). MEASURED: ALL 221 real mismatch sites have L-bit=1 "
+        "(confirmed by direct bit extraction over every opcd=31/XO=144 "
+        "word in game/EBOOT.elf).",
+}
+
+# ---------------------------------------------------------------------------
+# Alias RULES (pattern-based, not literal pairs)
+#
+# 1. Branch-prediction hint suffix ('+'/'-'): the PowerPC BO field's "at"
+#    hint bits (Book I p.20 Fig.22: at=10 not-taken '-', at=11 taken '+')
+#    are a pure annotation -- tools/ppu_disasm.py never emits them, Capstone
+#    always does when at != 00. MEASURED across many real base mnemonics
+#    (blt/blt+, bdz/bdz-, beq/beq-, bdnz/bdnz+, bsola/bsola+, bdzla/bdzla-,
+#    ...); a literal per-mnemonic whitelist would be an unbounded list, so
+#    this is a suffix RULE instead: capstone_mn in (ours_mn+'+', ours_mn+'-').
+#
+# 2. Friendly condition-name vs raw bit-test name on COMBINED decrement+
+#    condition branches (bdnz/bdz + true/false condition): ours spells the
+#    derived friendly name (bdnzge, bdnzle, bdnzne, bdnzns for the "false"
+#    tests; bdnzlt/bdnzgt/bdnzeq/bdnzso for the "true" tests, and the bdz
+#    analogs), Capstone keeps the raw bdnzt/bdnzf/bdzt/bdzf root + the CR
+#    bit name as an operand (e.g. bdnzf 'lt'). MEASURED at BO=0..3 (dnz+
+#    false) and BO=8..11 (dnz+true), and the bdz (BO=2/3, 10/11) analogs.
+#    Rule: capstone_mn in ('bdnzt','bdnzf','bdzt','bdzf') and
+#          ours_mn startswith the matching 'bdnz'/'bdz' root.
+#
+# 3. tdi/twi TO-field friendly names: ours always prints the raw numeric TO
+#    field (tdi TO,rA,SI); Capstone maps common TO values to friendly names
+#    (tdlgti = TO=1 "logical greater than immediate", tdlti = TO=16
+#    "logical less than immediate", etc. -- the full TO table has ~10
+#    named combinations). MEASURED at 0x0110D834 (TO=1 -> tdlgti) and
+#    0x0110C308 (TO=16 -> tdlti); BOTH sample sites are OUTSIDE any
+#    functions.json range (confirmed via bisect over functions.json), i.e.
+#    these are very likely data-in-.text words being guessed at by both
+#    decoders, not real trap instructions -- flagged as INFO either way
+#    since the mnemonic-alias relationship itself is real and documented
+#    (see PPC_Vers202_Book1_public.pdf's trap extended-mnemonic table).
+#    Rule: ours_mn in ('tdi','twi') and capstone_mn startswith the
+#          corresponding 't'+('d'|'w') root.
+# ---------------------------------------------------------------------------
+
+_BDNZ_BDZ_FRIENDLY = {
+    "bdnzt": "bdnz", "bdnzf": "bdnz", "bdzt": "bdz", "bdzf": "bdz",
+}
+
+# LK/AA suffix combinations that can trail the bdnz(t|f)/bdz(t|f) root:
+# '' (plain), 'l' (LK=1), 'a' (AA=1), 'la' (LK=1,AA=1) -- MEASURED across
+# the real mismatch set (e.g. bdnzgela/bdnzfla, bdzsol/bdztl, bdnzlea/
+# bdnzfa all appear in game/EBOOT.elf), same suffix on both sides.
+_BRANCH_LKAA_SUFFIXES = ("", "l", "a", "la")
+
+_TRAP_ROOTS = {"tdi": "td", "twi": "tw"}
+
+
+def is_whitelisted_by_rule(ours_mn: str, cs_mn: str) -> str | None:
+    """Return a reason string if (ours_mn, cs_mn) matches a RULE-based
+    alias class (not a literal-pair lookup); None if no rule matches.
+    """
+    # Rule 1: branch-hint suffix
+    if cs_mn == ours_mn + "+" or cs_mn == ours_mn + "-":
+        return ("branch-prediction hint suffix ('+'=likely taken, "
+                "'-'=likely not taken, Book I p.20 Fig.22 'at' bits) -- "
+                "ours never emits the hint suffix, Capstone always does "
+                "when at != 0b00; same base mnemonic otherwise.")
+
+    # Rule 2: bdnz/bdz friendly-name vs raw bit-test name, optionally with
+    # a trailing LK/AA suffix ('l'/'a'/'la') on BOTH sides (e.g.
+    # ours='bdnzgela' vs capstone='bdnzfla': strip 'la', roots become
+    # 'bdnzge' vs 'bdnzf', which then matches the bare rule below).
+    for suf in _BRANCH_LKAA_SUFFIXES:
+        if suf and not (ours_mn.endswith(suf) and cs_mn.endswith(suf)):
+            continue
+        cs_root = cs_mn[:len(cs_mn) - len(suf)] if suf else cs_mn
+        ours_root = ours_mn[:len(ours_mn) - len(suf)] if suf else ours_mn
+        friendly_root = _BDNZ_BDZ_FRIENDLY.get(cs_root)
+        if friendly_root is not None and ours_root.startswith(friendly_root) \
+                and ours_root != friendly_root:
+            return ("combined decrement+condition branch (optionally with "
+                    "an 'l'/'a'/'la' LK/AA suffix on both sides): ours "
+                    "spells the derived friendly condition name (e.g. "
+                    "bdnzge/bdnzlt, or bdnzgela/bdnzltla with suffix), "
+                    "Capstone keeps the raw '" + cs_root + "' root + the "
+                    "CR bit name as an operand -- same instruction, "
+                    "naming-convention difference only.")
+
+    # Rule 3: tdi/twi TO-field friendly names
+    trap_root = _TRAP_ROOTS.get(ours_mn)
+    if trap_root is not None and cs_mn.startswith(trap_root):
+        return ("trap TO-field friendly name: ours prints the raw numeric "
+                "TO field (e.g. 'tdi 1,rA,SI'), Capstone maps common TO "
+                "values to named forms (e.g. 'tdlgti'/'tdlti'). Sample "
+                "sites measured at 0x0110D834/0x0110C308 are OUTSIDE any "
+                "functions.json range -- likely data-in-.text, not real "
+                "trap instructions (T8's territory), but the alias "
+                "relationship itself is real either way.")
+
+    return None
+
+
+# Mnemonic PAIRS that are cheap to sanity-check are never expected to
+# mismatch at all (sanity gate in the acceptance section) -- kept as a
+# constant so --self-test and the sanity check share one list.
+SANITY_COMMON_OPS = ("add", "lwz", "bl", "stw")
+
+
+def executable_words(elf_path: str):
+    """Yield (addr, word32) for every 4-byte word of every PF_X PT_LOAD
+    segment in *elf_path*, reusing tools/elf_parser.py.
+
+    Big-endian is asserted (PS3 PPU binaries are always big-endian); if a
+    file somehow parses as little-endian this is surfaced, not silently
+    reinterpreted.
+    """
+    elf = ELFFile(elf_path)
+    elf.load()
+    if not elf.elf_header.big_endian:
+        print("disasm_audit: WARNING -- ELF parsed as little-endian; "
+              "PS3 PPU binaries should be big-endian", file=sys.stderr)
+
+    segments = []
+    for idx, ph in enumerate(elf.program_headers):
+        if ph.p_type == PT_LOAD and (ph.p_flags & 1) and ph.p_filesz > 0:
+            data = elf.get_segment_data(idx)
+            segments.append((ph.p_vaddr, data))
+
+    if not segments:
+        print("disasm_audit: no PF_X PT_LOAD segments found", file=sys.stderr)
+        return
+
+    fmt = ">I" if elf.elf_header.big_endian else "<I"
+    for base_vaddr, data in segments:
+        n_words = len(data) // 4
+        for i in range(n_words):
+            off = i * 4
+            word = struct.unpack_from(fmt, data, off)[0]
+            yield base_vaddr + off, word
+
+
+def decode_ours(word: int, addr: int) -> str:
+    """Return ONLY the mnemonic from tools/ppu_disasm.py's decode()."""
+    insn = decode(word, addr)
+    return insn.mnemonic
+
+
+def make_capstone_decoder():
+    """Return a callable(word, addr) -> mnemonic-or-None using Capstone."""
+    capstone = _capstone_or_die()
+    md = capstone.Cs(capstone.CS_ARCH_PPC,
+                      capstone.CS_MODE_64 + capstone.CS_MODE_BIG_ENDIAN)
+    md.detail = False
+
+    def _decode(word: int, addr: int):
+        data = struct.pack(">I", word)
+        insns = list(md.disasm(data, addr))
+        if not insns:
+            return None  # capstone refused to decode (illegal/unknown word)
+        return insns[0].mnemonic
+
+    return _decode
+
+
+def classify_pair(ours_mn: str, cs_mn: str):
+    """Return (is_whitelisted, reason_or_None) for a mismatching pair,
+    checking the literal ALIAS_WHITELIST table first, then the pattern
+    RULES (is_whitelisted_by_rule). reason_or_None is only set when
+    is_whitelisted is True.
+    """
+    pair = (ours_mn, cs_mn)
+    if pair in ALIAS_WHITELIST:
+        return True, ALIAS_WHITELIST[pair]
+    rule_reason = is_whitelisted_by_rule(ours_mn, cs_mn)
+    if rule_reason is not None:
+        return True, rule_reason
+    return False, None
+
+
+def run_audit(elf_path: str, limit: int = 0):
+    """Decode every word with both decoders; return (total, mismatch_counter,
+    whitelist_counter, mismatch_samples, whitelist_reasons, none_count,
+    none_samples) where:
+      mismatch_counter: Counter[(ours_mn, cs_mn)] for NON-whitelisted pairs
+      whitelist_counter: Counter[(ours_mn, cs_mn)] for whitelisted pairs
+        (literal-table AND rule-based combined; rule-based pairs are the
+        ones not already keys of ALIAS_WHITELIST)
+      mismatch_samples: dict[(ours_mn, cs_mn)] -> list[addr] (up to 3)
+      whitelist_reasons: dict[(ours_mn, cs_mn)] -> reason string (needed
+        because rule-based reasons aren't in the static ALIAS_WHITELIST
+        dict the way literal-pair reasons are)
+      none_count: words Capstone refused to decode at all (reported, not
+                  silently dropped -- these are NOT counted as mismatches
+                  since there is no oracle mnemonic to pair against, but a
+                  large none_count would itself be a red flag worth noting)
+    """
+    cs_decode = make_capstone_decoder()
+
+    total = 0
+    mismatch_counter = Counter()
+    whitelist_counter = Counter()
+    mismatch_samples = defaultdict(list)
+    whitelist_reasons = {}
+    none_count = 0
+    none_samples = []
+
+    for addr, word in executable_words(elf_path):
+        if limit and total >= limit:
+            break
+        total += 1
+        ours_mn = decode_ours(word, addr)
+        cs_mn = cs_decode(word, addr)
+
+        if cs_mn is None:
+            none_count += 1
+            if len(none_samples) < 3:
+                none_samples.append(addr)
+            continue
+
+        if ours_mn == cs_mn:
+            continue
+
+        pair = (ours_mn, cs_mn)
+        is_wl, reason = classify_pair(ours_mn, cs_mn)
+        if is_wl:
+            whitelist_counter[pair] += 1
+            whitelist_reasons[pair] = reason
+        else:
+            mismatch_counter[pair] += 1
+            if len(mismatch_samples[pair]) < 3:
+                mismatch_samples[pair].append(addr)
+
+    return total, mismatch_counter, whitelist_counter, mismatch_samples, \
+        whitelist_reasons, none_count, none_samples
+
+
+def print_report(total, mismatch_counter, whitelist_counter,
+                  mismatch_samples, whitelist_reasons, none_count,
+                  none_samples, top_n: int):
+    print(f"disasm_audit: {total} words decoded")
+    print(f"disasm_audit: {none_count} words Capstone could not decode "
+          f"at all (not counted as mismatches; no oracle mnemonic to "
+          f"compare)")
+    if none_samples:
+        sample_str = ", ".join(f"0x{a:08X}" for a in none_samples)
+        print(f"  sample addresses: {sample_str}")
+
+    residual = sum(mismatch_counter.values())
+    residual_pairs = len(mismatch_counter)
+    whitelisted = sum(whitelist_counter.values())
+
+    print()
+    print(f"=== Mismatches: {residual} words across {residual_pairs} "
+          f"non-whitelisted (ours_mn, capstone_mn) pairs ===")
+    print(f"top {top_n} by count (descending):")
+    for pair, count in mismatch_counter.most_common(top_n):
+        ours_mn, cs_mn = pair
+        addrs = ", ".join(f"0x{a:08X}" for a in mismatch_samples[pair])
+        print(f"  {count:8d}  ours={ours_mn!r:14s} capstone={cs_mn!r:14s}"
+              f"  samples: {addrs}")
+
+    print()
+    print(f"=== Whitelisted alias pairs (INFO, {whitelisted} words across "
+          f"{len(whitelist_counter)} pairs) ===")
+    for pair, count in whitelist_counter.most_common():
+        ours_mn, cs_mn = pair
+        reason = whitelist_reasons[pair]
+        print(f"  INFO  {count:8d}  ours={ours_mn!r:14s} "
+              f"capstone={cs_mn!r:14s}  -- {reason}")
+
+    print()
+    print("=== Sanity check: common ops (add, lwz, bl, stw) ===")
+    sanity_ok = True
+    for op in SANITY_COMMON_OPS:
+        bad_pairs = [(pair, c) for pair, c in mismatch_counter.items()
+                     if pair[0] == op]
+        if bad_pairs:
+            sanity_ok = False
+            for pair, c in bad_pairs:
+                print(f"  FAIL  {op}: {c} non-whitelisted mismatches as "
+                      f"{pair[1]!r}")
+        else:
+            print(f"  PASS  {op}: 0 non-whitelisted mismatches")
+    if not sanity_ok:
+        print("  ** SANITY FAILED ** -- see FAIL lines above")
+
+    print()
+    print(f"SUMMARY: total_words={total} residual_mismatch_words={residual} "
+          f"residual_pairs={residual_pairs} whitelisted_words={whitelisted} "
+          f"capstone_refused={none_count}")
+
+    return residual
+
+
+# ---------------------------------------------------------------------------
+# Seeded self-test (acceptance item: seeded-bug self-test)
+#
+# This NEVER touches the real tools/ppu_disasm.py. It builds a corrupted
+# COPY of decode() in-process (monkeypatching a local copy's dispatch, not
+# the imported module) by wrapping decode_ours() with a mnemonic swap
+# table, exactly emulating "swap two mnemonics" the way the historical
+# crnand/crnor bug did.
+# ---------------------------------------------------------------------------
+
+SELF_TEST_SWAP = {"crnor": "crnand", "crnand": "crnor"}
+
+
+def decode_ours_corrupted(word: int, addr: int) -> str:
+    mn = decode_ours(word, addr)
+    return SELF_TEST_SWAP.get(mn, mn)
+
+
+def run_self_test(elf_path: str, limit: int):
+    """Re-run the audit with a corrupted ours-side decoder (crnor/crnand
+    swapped, mirroring the real historical bug) and confirm the pair
+    surfaces at the top of the mismatch report.
+    """
+    print("disasm_audit --self-test: seeding a crnor/crnand mnemonic swap "
+          "in an IN-PROCESS COPY of the decode call (tools/ppu_disasm.py "
+          "on disk is untouched)")
+    cs_decode = make_capstone_decoder()
+
+    total = 0
+    mismatch_counter = Counter()
+    mismatch_samples = defaultdict(list)
+
+    for addr, word in executable_words(elf_path):
+        if limit and total >= limit:
+            break
+        total += 1
+        ours_mn = decode_ours_corrupted(word, addr)
+        cs_mn = cs_decode(word, addr)
+        if cs_mn is None or ours_mn == cs_mn:
+            continue
+        pair = (ours_mn, cs_mn)
+        is_wl, _reason = classify_pair(ours_mn, cs_mn)
+        if is_wl:
+            continue
+        mismatch_counter[pair] += 1
+        if len(mismatch_samples[pair]) < 3:
+            mismatch_samples[pair].append(addr)
+
+    print(f"self-test: {total} words decoded with corrupted ours-side "
+          f"decoder")
+    top = mismatch_counter.most_common(10)
+    print("top 10 mismatch pairs:")
+    for pair, count in top:
+        addrs = ", ".join(f"0x{a:08X}" for a in mismatch_samples[pair])
+        print(f"  {count:8d}  ours={pair[0]!r:14s} capstone={pair[1]!r:14s}"
+              f"  samples: {addrs}")
+
+    # A swapped crnor/crnand should surface as (crnor, crnand) and/or
+    # (crnand, crnor) pairs (crnand has no simplification alias against
+    # distinct operands -- confirmed above) at or near the top.
+    seeded_pairs_present = any(
+        pair[0] in SELF_TEST_SWAP for pair, _ in top
+    )
+    if not seeded_pairs_present or not top:
+        print("SELF-TEST FAILED: seeded crnor/crnand swap did NOT surface "
+              "at the top of the mismatch report")
+        return False
+
+    print("SELF-TEST PASSED: seeded crnor/crnand swap surfaced at the top "
+          "of the mismatch report (as expected)")
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Cross-check tools/ppu_disasm.py against Capstone "
+                    "(PPC64 big-endian) over an ELF's executable segments.")
+    parser.add_argument("elf", help="Input PPU ELF to audit (e.g. game/EBOOT.elf)")
+    parser.add_argument("--limit", type=int, default=0,
+                        help="Stop after N words (0 = all, default)")
+    parser.add_argument("--top", type=int, default=20,
+                        help="How many mismatch pairs to print (default 20)")
+    parser.add_argument("--self-test", action="store_true",
+                        help="Run the seeded crnor/crnand self-test instead "
+                            "of the real audit (never touches the real "
+                            "decoder file on disk)")
+    args = parser.parse_args()
+
+    if args.self_test:
+        ok = run_self_test(args.elf, args.limit)
+        sys.exit(0 if ok else 1)
+
+    if not os.path.exists(args.elf):
+        print(f"disasm_audit: input file not found: {args.elf}",
+              file=sys.stderr)
+        sys.exit(1)
+
+    total, mismatch_counter, whitelist_counter, mismatch_samples, \
+        whitelist_reasons, none_count, none_samples = \
+        run_audit(args.elf, args.limit)
+    residual = print_report(total, mismatch_counter, whitelist_counter,
+                            mismatch_samples, whitelist_reasons, none_count,
+                            none_samples, args.top)
+    sys.exit(0 if residual == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/disasm_audit_operands.py
+++ b/tools/disasm_audit_operands.py
@@ -1,0 +1,674 @@
+#!/usr/bin/env py -3
+"""disasm_audit_operands.py - PPU decoder OPERAND-level cross-check: v2 of
+tools/disasm_audit.py.
+
+Purpose: v1 (disasm_audit.py) cross-checks tools/ppu_disasm.py's decode()
+against Capstone at the MNEMONIC level only and is blind to the `il`-class
+of bug: a mnemonic decodes correctly but an OPERAND (register index,
+immediate value, shift/mask field, or operand count/order) is wrong. This
+is historically the most expensive bug class in this project (double
+sign-extension, wrong register field, swapped operand order) because our
+disasm and lifter can independently agree with each other and both be
+wrong -- Capstone is the independent oracle needed to catch it.
+
+Scope: for every word where ours and Capstone already AGREE on the
+mnemonic (mnemonic mismatches are v1's job -- this tool doesn't re-derive
+them), parse both operand strings into a canonical comparable form and
+diff. A DIVERGENCE = same mnemonic, differing canonical operand (register
+index, immediate VALUE, or operand count/order).
+
+Canonicalization:
+  - Registers (any of r/f/v/cr prefix, or a bare "crN"/"crN lt" CR-bit
+    name, or Capstone's occasional bare-integer register operand) map to
+    ("reg", class_letter_or_None, index).
+  - Immediates (hex "0x..", "-0x..", plain decimal, negative decimal) map
+    to ("imm", signed_python_int).
+  - Anything else that isn't a recognized register/immediate token
+    (rare -- e.g. a CR-bit condition-name operand like "lt") is kept as a
+    normalized string token: ("raw", token.lower()).
+  - Operand ORDER is part of the comparison (a swapped-operand-order bug
+    is exactly what this tool must catch), but see the WHITELIST for
+    known legitimate operand-order/format differences between the two
+    printers (e.g. Capstone shows an absolute branch target while ours
+    shows... no, both show absolute -- see whitelist file for the actual
+    seeded/measured cases).
+
+Whitelist: tools/disasm_audit_operands_whitelist.txt, one entry per
+KNOWN-benign format difference, of the form:
+    mnemonic | short reason
+A mnemonic listed there has ALL its divergences reported as INFO instead
+of REAL. Entries must be added only after direct measurement (hand-built
+encoding through both decoders) -- see the comments in the seed list
+below for the measured basis of each seeded entry.
+
+Usage:
+    py -3 tools\\disasm_audit_operands.py game\\EBOOT.elf [--limit N] [--top N]
+    py -3 tools\\disasm_audit_operands.py --self-test-immediate-bug
+    py -3 tools\\disasm_audit_operands.py --self-test-mask-bug
+
+Exit code: 0 if residual (non-whitelisted) REAL divergence count is 0 for
+the run, else 1.
+"""
+
+import argparse
+import os
+import re
+import struct
+import sys
+from collections import Counter, defaultdict
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from elf_parser import ELFFile, PT_LOAD  # noqa: E402
+from ppu_disasm import decode  # noqa: E402
+
+WHITELIST_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                               "disasm_audit_operands_whitelist.txt")
+
+
+def _capstone_or_die():
+    try:
+        import capstone
+        return capstone
+    except ImportError:
+        print("disasm_audit_operands: capstone not installed -- "
+              "run: py -3 -m pip install capstone", file=sys.stderr)
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Operand canonicalization
+# ---------------------------------------------------------------------------
+
+# Register token forms seen from EITHER decoder:
+#   ours:      r3, f3, v3, cr3, cr3lt/cr3gt/cr3eq/cr3so (via _cr_bit_name),
+#              bare "lt"/"gt"/"eq"/"so" (cr0 bit name with empty prefix)
+#   capstone:  r3, f3, v3, cr3, occasionally bare "3" for some XO-form regs,
+#              condition register bit field names as an operand for BOnly
+#              forms (not relevant here -- mnemonic differs, v1's job)
+_REG_RE = re.compile(r"^(?P<cls>[rfv]|cr)(?P<idx>\d+)$", re.IGNORECASE)
+_CR_BIT_RE = re.compile(r"^(?:cr(?P<idx>\d+))?(?P<bit>lt|gt|eq|so|un)$",
+                         re.IGNORECASE)
+# "un" (unordered) is Capstone's alternate name for CR sub-bit 3 -- the
+# SAME physical bit as "so" (summary overflow); Capstone spells it "un"
+# specifically on crand/cror/crxor/etc. (raw CR-bit logical ops, which
+# don't know whether the bit's producer was an integer or FP compare),
+# reserving "so" for contexts where the bit demonstrably came from an
+# integer-compare/XER path. MEASURED: 0x01293918 real EBOOT code,
+# "crxor 7, 31, 24" (ours, raw indices) vs "crxor cr1un, cr7un, cr6lt"
+# (capstone) -- bit 7 -> field 1, sub 3 -> "un" here (not "so"); same
+# numeric bit-value either way.
+_CR_BIT_VALUE = {"lt": 0, "gt": 1, "eq": 2, "so": 3, "un": 3}
+_HEX_RE = re.compile(r"^-?0x[0-9a-fA-F]+$")
+_DEC_RE = re.compile(r"^-?\d+$")
+# Capstone displacement-form operand: "-0x8000(r5)" / "8(r3)" / "-4(r5)".
+# Capstone ALSO uses a bare "0" (no letter prefix) for the base-register
+# slot whenever RA==0 in a D-form load/store (PowerPC semantics: RA field
+# of 0 means "no base register, EA = 0 + disp", so Capstone prints the
+# architectural constant 0 instead of the register name r0). Ours always
+# prints "r0" there regardless. MEASURED: 0x00014838 real EBOOT code,
+# "lwz r0, 0x0(r0)" (ours) vs "lwz r0, 0(0)" (capstone) -- both compute
+# EA=0, pure spelling difference, not a value divergence. The regex below
+# accepts either "rN" or a bare integer (always 0 in practice) as the base.
+_DISP_RE = re.compile(
+    r"^(?P<disp>-?(?:0x[0-9a-fA-F]+|\d+))\((?P<reg>[a-zA-Z]+\d+|\d+)\)$")
+
+
+def _parse_int_token(tok: str):
+    """Parse a bare hex/decimal token to a signed Python int, or None."""
+    if _HEX_RE.match(tok):
+        return int(tok, 16)
+    if _DEC_RE.match(tok):
+        return int(tok, 10)
+    return None
+
+
+def canon_operand(tok: str):
+    """Canonicalize a single operand token to a comparable tuple.
+
+    Returns one of:
+      ("reg", class_letter, index)   -- class_letter in {'r','f','v','cr',None}
+      ("crbit", cr_field, bit_value) -- cr_field 0..7, bit_value 0..3 (lt/gt/eq/so)
+      ("imm", value)                 -- signed python int
+      ("dispmem", disp_value, base_reg_index) -- D-form "disp(rN)" memory operand
+      ("raw", lowercased_token)      -- fallback, unrecognized token
+    """
+    tok = tok.strip()
+    if not tok:
+        return ("raw", "")
+
+    m = _DISP_RE.match(tok)
+    if m:
+        disp = _parse_int_token(m.group("disp"))
+        reg_tok = m.group("reg")
+        base = _REG_RE.match(reg_tok)
+        if base:
+            base_idx = int(base.group("idx"))
+        elif reg_tok.isdigit():
+            # Capstone's bare-"0" spelling of "RA field is architecturally
+            # zero" (no base register) -- canonicalize to the same base
+            # index as an explicit r0 token (see _DISP_RE comment above).
+            base_idx = int(reg_tok)
+        else:
+            base_idx = reg_tok
+        return ("dispmem", disp, base_idx)
+
+    m = _REG_RE.match(tok)
+    if m:
+        return ("reg", m.group("cls").lower(), int(m.group("idx")))
+
+    m = _CR_BIT_RE.match(tok)
+    if m and (m.group("idx") is not None or m.group("bit")):
+        field = int(m.group("idx")) if m.group("idx") is not None else 0
+        return ("crbit", field, _CR_BIT_VALUE[m.group("bit").lower()])
+
+    val = _parse_int_token(tok)
+    if val is not None:
+        return ("imm", val)
+
+    return ("raw", tok.lower())
+
+
+# CR-logical XL-form ops (Book I Ch.2): all operands are raw CR-BIT indices
+# (0..31), NOT general integers or GPRs. Ours prints the bare numeric bit
+# index (e.g. "cror 6, 1, 2"); Capstone always spells the "crNbit" named
+# form (e.g. "cror cr1eq, cr0gt, cr0eq"). MEASURED equivalent at
+# 0x00011288 (bt=6->cr1eq, ba=1->cr0gt, bb=2->cr0eq) -- pure naming
+# convention, not a value divergence, so these mnemonics' bare-integer
+# operands are reinterpreted as ("crbit", field, bit) tuples below instead
+# of ("imm", value), to compare equal to Capstone's named spelling.
+_CR_LOGICAL_MNEMONICS = {
+    "crand", "cror", "crxor", "crnand", "crnor", "creqv", "crandc", "crorc",
+}
+
+
+def _reinterpret_as_crbit(canon):
+    """If canon is ("imm", v) with v in [0,31], reinterpret as a CR-bit
+    index tuple ("crbit", field, bit); otherwise return canon unchanged.
+    """
+    if canon[0] == "imm" and 0 <= canon[1] <= 31:
+        v = canon[1]
+        return ("crbit", v >> 2, v & 3)
+    return canon
+
+
+def canon_operand_list(op_str: str, mnemonic: str = ""):
+    """Split an operand string on top-level commas and canonicalize each.
+
+    D-form memory operands like "4(r5)" contain no comma so a naive split
+    on ',' is safe here (no operand ever nests a comma inside parens in
+    either decoder's output for PPC).
+    """
+    op_str = op_str.strip()
+    if not op_str:
+        return []
+    parts = [p.strip() for p in op_str.split(",") if p.strip() != ""]
+    canon = [canon_operand(p) for p in parts]
+    if mnemonic in _CR_LOGICAL_MNEMONICS:
+        canon = [_reinterpret_as_crbit(c) for c in canon]
+    return canon
+
+
+# ---------------------------------------------------------------------------
+# Value-equivalence normalization between canon operand lists
+#
+# Some (mnemonic-agreeing) pairs are STRUCTURALLY worded differently but
+# numerically identical -- e.g. ours may print a raw CR-bit name where
+# Capstone prints "crN, bit" split differently. We normalize a handful of
+# known-shape differences here (measured against real decoder output,
+# see disasm_audit_operands_whitelist.txt for the mnemonic-level list of
+# what's tolerated); this function only smooths PURELY SYNTACTIC splits,
+# never changes an actual value.
+# ---------------------------------------------------------------------------
+
+def _standalone_reg0_equiv(a, b):
+    """True if *a* and *b* are the SAME position's canon operand and one is
+    ("reg", "r", 0) while the other is ("imm", 0) -- i.e. one decoder wrote
+    a bare register token "r0" and the other wrote the literal integer 0
+    for an X-form base-register field where the architecture defines
+    RA==0 as "no base register / value 0" (Book I: any X-form/D-form base
+    register field). This ONLY fires for index 0 in either direction --
+    r1..r31 vs any "imm" never match here, so it cannot mask a genuine
+    register-index divergence. MEASURED: 0x00012830 real EBOOT code,
+    "dcbt r0, r7" (ours) vs "dcbt 0, r7" (capstone) -- same architectural
+    value (EA contribution 0), pure base-register spelling difference
+    (same class as the dispmem "(0)" vs "(r0)" case handled in
+    canon_operand's _DISP_RE, but here the register stands alone, not
+    inside parens, e.g. dcbt/dcbst/icbi/lvx/stvx/lfsx-family RA operand).
+    """
+    reg0 = ("reg", "r", 0)
+    imm0 = ("imm", 0)
+    return (a == reg0 and b == imm0) or (a == imm0 and b == reg0)
+
+
+def _abs_branch_target_equiv(a, b):
+    """True if *a* and *b* are ("imm", v1)/("imm", v2) and v1, v2 agree on
+    the low 32 bits with the difference explained PURELY by 32-bit-vs-64-
+    bit sign-extension of an ABSOLUTE branch target (AA=1 forms: b/bl/ba/
+    bla and every conditional b<cond><l><a> variant, e.g. bdnzla, bnsla).
+    tools/ppu_disasm.py deliberately masks every absolute branch target to
+    32 bits (`target & 0xFFFFFFFF`, ppu_disasm.py:159/166/180/194/197 and
+    all the bclr/bcctr sites) -- a documented, consistent convention across
+    this whole codebase, since Cell/PS3 PPU effective addresses for this
+    game are 32-bit. Capstone, running in CS_MODE_64, instead sign-extends
+    the same target to a full 64-bit hex display (e.g. ours "0xFFFF9998"
+    vs capstone "0xffffffffffff9998"). MEASURED across many real EBOOT
+    branch sites (e.g. 0x009B0780 bdza, 0x0110C530 ba): masking either
+    side's value to 32 bits always makes them equal. Scoped tightly to
+    avoid masking a real bug: both values must already agree on the low
+    32 bits, AND the higher-magnitude one must be a canonical sign
+    extension of the low 32 bits (all 1s above bit 31, i.e. the low-32
+    value's bit 31 was set) -- so this can never quietly accept two
+    genuinely different small immediates or two different register
+    indices; it only fires for the specific "same low 32 bits, one side
+    64-bit-sign-extended" shape.
+    """
+    if a[0] != "imm" or b[0] != "imm":
+        return False
+    v1, v2 = a[1], b[1]
+    # Canon_operand's _parse_int_token parses hex/decimal tokens (including
+    # Capstone's "0xffffffffffff9998" spelling) as plain non-negative
+    # Python ints -- there is no leading '-' in that token, so v1/v2 here
+    # are the RAW unsigned integer value of whatever hex/decimal digits
+    # were printed, never a Python-negative int. Compare on that basis:
+    # both must already agree on the low 32 bits, and the numerically
+    # LARGER of the two must equal the low-32 value widened with all 1s
+    # in bits 32..63 (i.e. it must equal low32 | 0xFFFFFFFF00000000) --
+    # the canonical unsigned-64-bit spelling of a sign-extended-negative
+    # 32-bit value. This can only fire when bit 31 of the low 32 bits is
+    # set (a "negative-looking" 32-bit value), so it never accepts two
+    # unrelated positive immediates.
+    if (v1 & 0xFFFFFFFF) != (v2 & 0xFFFFFFFF):
+        return False
+    low32 = v1 & 0xFFFFFFFF
+    if v1 == v2:
+        return True  # identical already (no sign-extension involved)
+    if not (low32 & 0x80000000):
+        return False  # bit 31 clear -> no valid sign-extension story
+    sign_ext_64_unsigned = low32 | 0xFFFFFFFF00000000
+    return {v1, v2} == {low32, sign_ext_64_unsigned}
+
+
+def _capstone_dropped_zero_branch_target(ours_list, cs_list, addr):
+    """True if ours_list has exactly one MORE trailing operand than
+    cs_list, that extra trailing operand is an immediate whose value is
+    consistent with an architectural BD (branch-displacement) field of
+    exactly 0, and the remaining (leading) operands already match. This
+    is Capstone's PPC-backend quirk of omitting the branch-target operand
+    entirely whenever the raw BD field (bits 16-29) is exactly 0.
+
+    Two shapes, both MEASURED on real EBOOT sites:
+      - PC-relative conditional branches (AA=0): architectural target =
+        PC+0 = the instruction's own address, so ours prints the resolved
+        absolute address equal to *addr* itself (e.g. 0x00023220 "bge
+        0x23220" -- 0x23220 == addr).
+      - Absolute conditional+LK branches (AA=1): architectural target =
+        literal 0, so ours prints ("imm", 0) (e.g. 0x01241820 "bgela
+        0x0").
+    In both shapes Capstone prints nothing. Scoped tightly: the extra
+    trailing operand must be EITHER exactly 0 OR exactly equal to the
+    instruction's own address -- no other value is accepted, so this can
+    never mask a genuine wrong-target bug (a real miscomputed target
+    essentially never equals literal 0 or the instruction's own PC).
+    """
+    if len(ours_list) != len(cs_list) + 1:
+        return False
+    extra = ours_list[-1]
+    if extra[0] != "imm":
+        return False
+    if extra[1] not in (0, addr):
+        return False
+    return ours_list[:-1] == cs_list
+
+
+def operands_equal(ours_list, cs_list, addr=None):
+    if ours_list == cs_list:
+        return True
+    if addr is not None and \
+            _capstone_dropped_zero_branch_target(ours_list, cs_list, addr):
+        return True
+    if len(ours_list) != len(cs_list):
+        return False
+    for a, b in zip(ours_list, cs_list):
+        if a == b:
+            continue
+        if _standalone_reg0_equiv(a, b):
+            continue
+        if _abs_branch_target_equiv(a, b):
+            continue
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Whitelist (mnemonic -> reason). A mnemonic in this table has ALL its
+# divergences reported as INFO, never counted in the REAL residual.
+# ---------------------------------------------------------------------------
+
+def load_whitelist(path: str):
+    wl = {}
+    if not os.path.exists(path):
+        return wl
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "|" not in line:
+                continue
+            mn, reason = line.split("|", 1)
+            wl[mn.strip()] = reason.strip()
+    return wl
+
+
+# ---------------------------------------------------------------------------
+# ELF word iteration (same as v1)
+# ---------------------------------------------------------------------------
+
+def executable_words(elf_path: str):
+    elf = ELFFile(elf_path)
+    elf.load()
+    if not elf.elf_header.big_endian:
+        print("disasm_audit_operands: WARNING -- ELF parsed as "
+              "little-endian; PS3 PPU binaries should be big-endian",
+              file=sys.stderr)
+
+    segments = []
+    for idx, ph in enumerate(elf.program_headers):
+        if ph.p_type == PT_LOAD and (ph.p_flags & 1) and ph.p_filesz > 0:
+            data = elf.get_segment_data(idx)
+            segments.append((ph.p_vaddr, data))
+
+    if not segments:
+        print("disasm_audit_operands: no PF_X PT_LOAD segments found",
+              file=sys.stderr)
+        return
+
+    fmt = ">I" if elf.elf_header.big_endian else "<I"
+    for base_vaddr, data in segments:
+        n_words = len(data) // 4
+        for i in range(n_words):
+            off = i * 4
+            word = struct.unpack_from(fmt, data, off)[0]
+            yield base_vaddr + off, word
+
+
+def decode_ours(word: int, addr: int):
+    insn = decode(word, addr)
+    return insn.mnemonic, insn.operands
+
+
+def make_capstone_decoder():
+    capstone = _capstone_or_die()
+    md = capstone.Cs(capstone.CS_ARCH_PPC,
+                      capstone.CS_MODE_64 + capstone.CS_MODE_BIG_ENDIAN)
+    md.detail = False
+
+    def _decode(word: int, addr: int):
+        data = struct.pack(">I", word)
+        insns = list(md.disasm(data, addr))
+        if not insns:
+            return None
+        return insns[0].mnemonic, insns[0].op_str
+
+    return _decode
+
+
+# ---------------------------------------------------------------------------
+# Main audit
+# ---------------------------------------------------------------------------
+
+def run_audit(elf_path: str, limit: int, whitelist: dict, ours_decoder=None,
+              label="real"):
+    """Decode every word with both decoders. For words where the mnemonic
+    already matches, canonicalize + compare operands.
+
+    Returns a dict of counters/samples; see print_report for consumption.
+    """
+    cs_decode = make_capstone_decoder()
+    if ours_decoder is None:
+        ours_decoder = decode_ours
+
+    total = 0
+    mnemonic_match = 0
+    divergence_counter = Counter()          # (mnemonic, kind) -> count, REAL only
+    divergence_samples = defaultdict(list)  # (mnemonic, kind) -> [(addr, ours_op, cs_op)]
+    info_counter = Counter()                # whitelisted mnemonic divergences
+    info_samples = defaultdict(list)
+
+    for addr, word in executable_words(elf_path):
+        if limit and total >= limit:
+            break
+        total += 1
+
+        ours_mn, ours_ops = ours_decoder(word, addr)
+        cs_result = cs_decode(word, addr)
+        if cs_result is None:
+            continue
+        cs_mn, cs_ops = cs_result
+
+        if ours_mn != cs_mn:
+            continue  # v1's territory
+        mnemonic_match += 1
+
+        ours_canon = canon_operand_list(ours_ops, ours_mn)
+        cs_canon = canon_operand_list(cs_ops, ours_mn)
+
+        if operands_equal(ours_canon, cs_canon, addr):
+            continue
+
+        # Classify divergence kind
+        if len(ours_canon) != len(cs_canon):
+            kind = "operand-count"
+        else:
+            kind = "operand-value"
+            # refine: is it purely an order permutation of the same
+            # multiset of canonical operands? (helps spot swapped-operand
+            # bugs distinctly from value/register-index bugs)
+            if sorted(map(repr, ours_canon)) == sorted(map(repr, cs_canon)):
+                kind = "operand-order"
+
+        key = (ours_mn, kind)
+        if ours_mn in whitelist:
+            info_counter[key] += 1
+            if len(info_samples[key]) < 5:
+                info_samples[key].append((addr, ours_ops, cs_ops))
+        else:
+            divergence_counter[key] += 1
+            if len(divergence_samples[key]) < 5:
+                divergence_samples[key].append((addr, ours_ops, cs_ops))
+
+    return {
+        "total": total,
+        "mnemonic_match": mnemonic_match,
+        "divergence_counter": divergence_counter,
+        "divergence_samples": divergence_samples,
+        "info_counter": info_counter,
+        "info_samples": info_samples,
+        "label": label,
+    }
+
+
+def print_report(result, top_n: int, whitelist: dict):
+    total = result["total"]
+    mnemonic_match = result["mnemonic_match"]
+    divergence_counter = result["divergence_counter"]
+    divergence_samples = result["divergence_samples"]
+    info_counter = result["info_counter"]
+    info_samples = result["info_samples"]
+
+    print(f"disasm_audit_operands [{result['label']}]: {total} words "
+          f"decoded, {mnemonic_match} had matching mnemonic (the operand-"
+          f"comparison population)")
+
+    residual = sum(divergence_counter.values())
+    residual_groups = len(divergence_counter)
+    info_total = sum(info_counter.values())
+
+    print()
+    print(f"=== REAL operand divergences (non-whitelisted): {residual} "
+          f"words across {residual_groups} (mnemonic, kind) groups ===")
+    print(f"top {top_n} by count (descending):")
+    for (mn, kind), count in divergence_counter.most_common(top_n):
+        samples = divergence_samples[(mn, kind)]
+        print(f"  {count:8d}  mnemonic={mn!r:14s} kind={kind:16s}")
+        for addr, ours_op, cs_op in samples:
+            print(f"        0x{addr:08X}: ours=\"{mn} {ours_op}\" "
+                  f"capstone=\"{mn} {cs_op}\"")
+
+    print()
+    print(f"=== Whitelisted operand-format noise (INFO): {info_total} "
+          f"words across {len(info_counter)} (mnemonic, kind) groups ===")
+    for (mn, kind), count in info_counter.most_common():
+        reason = whitelist.get(mn, "(no reason recorded)")
+        print(f"  INFO  {count:8d}  mnemonic={mn!r:14s} kind={kind:16s}"
+              f"  -- {reason}")
+        for addr, ours_op, cs_op in info_samples[(mn, kind)][:2]:
+            print(f"        0x{addr:08X}: ours=\"{mn} {ours_op}\" "
+                  f"capstone=\"{mn} {cs_op}\"")
+
+    print()
+    print("=== Sanity check: common ops (addi, lwz, stw, ori, rlwinm) ===")
+    sanity_ok = True
+    for op in ("addi", "lwz", "stw", "ori", "rlwinm"):
+        bad = [((mn, kind), c) for (mn, kind), c in divergence_counter.items()
+               if mn == op]
+        if bad:
+            sanity_ok = False
+            for (mn, kind), c in bad:
+                print(f"  FAIL  {op}: {c} non-whitelisted operand "
+                      f"divergences (kind={kind})")
+        else:
+            print(f"  PASS  {op}: 0 non-whitelisted operand divergences")
+    if not sanity_ok:
+        print("  ** SANITY FAILED ** -- canonicalization is incomplete, "
+              "see FAIL lines above")
+
+    print()
+    print(f"SUMMARY[{result['label']}]: total_words={total} "
+          f"mnemonic_match_population={mnemonic_match} "
+          f"residual_real_divergence_words={residual} "
+          f"residual_groups={residual_groups} "
+          f"whitelisted_info_words={info_total}")
+
+    return residual, sanity_ok
+
+
+# ---------------------------------------------------------------------------
+# Seeded self-tests (build a corrupted COPY of decode() in-process; never
+# touches tools/ppu_disasm.py on disk).
+# ---------------------------------------------------------------------------
+
+def _make_corrupted_decoder_double_sign_extend():
+    """Simulate the classic `il`-class bug: an immediate that gets
+    sign-extended TWICE (or equivalently, off by a power-of-two wraparound)
+    on D-form loads (lwz/addi/etc). We corrupt just 'addi' operands: take
+    ours' real decode, then if mnemonic is 'addi', re-render the operand
+    string with the immediate corrupted by subtracting 0x10000 (simulating
+    a double 16-bit sign-extension) whenever the immediate is negative.
+    """
+    def _decode(word, addr):
+        mn, ops = decode_ours(word, addr)
+        if mn == "addi":
+            parts = [p.strip() for p in ops.split(",")]
+            if len(parts) == 3:
+                imm = _parse_int_token(parts[2])
+                if imm is not None and imm < 0:
+                    corrupted = imm - 0x10000  # double sign-extension bug
+                    parts[2] = f"{corrupted}" if corrupted >= 0 \
+                        else f"-0x{-corrupted:X}"
+                    ops = ", ".join(parts)
+        return mn, ops
+    return _decode
+
+
+def _make_corrupted_decoder_mask_bug():
+    """Simulate a wrong-mask-field bug on rlwinm: corrupt the `me` operand
+    (last field) by adding 1 (off-by-one mask bug), whenever me < 31, to
+    ensure it produces a genuinely different runtime rotate/mask -- an
+    operand-VALUE bug, distinct from the immediate-class self-test above.
+    """
+    def _decode(word, addr):
+        mn, ops = decode_ours(word, addr)
+        if mn == "rlwinm" or mn == "rlwinm.":
+            parts = [p.strip() for p in ops.split(",")]
+            if len(parts) == 5:
+                me = _parse_int_token(parts[4])
+                if me is not None and me < 31:
+                    parts[4] = str(me + 1)
+                    ops = ", ".join(parts)
+        return mn, ops
+    return _decode
+
+
+def run_self_test(elf_path: str, limit: int, kind: str, whitelist: dict):
+    if kind == "immediate":
+        print("disasm_audit_operands --self-test-immediate-bug: seeding a "
+              "double-sign-extension bug on 'addi' negative immediates in "
+              "an IN-PROCESS COPY of decode() (tools/ppu_disasm.py on disk "
+              "is untouched)")
+        corrupted = _make_corrupted_decoder_double_sign_extend()
+        target_mn = "addi"
+    elif kind == "mask":
+        print("disasm_audit_operands --self-test-mask-bug: seeding an "
+              "off-by-one ME-field bug on 'rlwinm' in an IN-PROCESS COPY "
+              "of decode() (tools/ppu_disasm.py on disk is untouched)")
+        corrupted = _make_corrupted_decoder_mask_bug()
+        target_mn = "rlwinm"
+    else:
+        raise ValueError(kind)
+
+    result = run_audit(elf_path, limit, whitelist, ours_decoder=corrupted,
+                        label=f"self-test-{kind}")
+    residual, _sanity = print_report(result, 15, whitelist)
+
+    hit = any(mn == target_mn
+              for (mn, _kind) in result["divergence_counter"])
+    if not hit or residual == 0:
+        print(f"SELF-TEST FAILED: seeded {kind} bug on {target_mn!r} did "
+              f"NOT surface as a REAL operand divergence")
+        return False
+    print(f"SELF-TEST PASSED: seeded {kind} bug on {target_mn!r} surfaced "
+          f"as a REAL operand divergence ({residual} words)")
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Operand-level cross-check of tools/ppu_disasm.py vs "
+                    "Capstone (PPC64 big-endian) over an ELF's executable "
+                    "segments, restricted to mnemonic-matching words.")
+    parser.add_argument("elf", help="Input PPU ELF to audit (e.g. game/EBOOT.elf)")
+    parser.add_argument("--limit", type=int, default=0,
+                        help="Stop after N words (0 = all, default)")
+    parser.add_argument("--top", type=int, default=30,
+                        help="How many divergence groups to print "
+                            "(default 30)")
+    parser.add_argument("--self-test-immediate-bug", action="store_true",
+                        help="Seeded double-sign-extension bug on addi "
+                            "(never touches ppu_disasm.py on disk)")
+    parser.add_argument("--self-test-mask-bug", action="store_true",
+                        help="Seeded off-by-one ME-field bug on rlwinm "
+                            "(never touches ppu_disasm.py on disk)")
+    args = parser.parse_args()
+
+    whitelist = load_whitelist(WHITELIST_PATH)
+
+    if args.self_test_immediate_bug:
+        ok = run_self_test(args.elf, args.limit, "immediate", whitelist)
+        sys.exit(0 if ok else 1)
+    if args.self_test_mask_bug:
+        ok = run_self_test(args.elf, args.limit, "mask", whitelist)
+        sys.exit(0 if ok else 1)
+
+    if not os.path.exists(args.elf):
+        print(f"disasm_audit_operands: input file not found: {args.elf}",
+              file=sys.stderr)
+        sys.exit(1)
+
+    result = run_audit(args.elf, args.limit, whitelist)
+    residual, sanity_ok = print_report(result, args.top, whitelist)
+    sys.exit(0 if (residual == 0 and sanity_ok) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/disasm_audit_operands_whitelist.txt
+++ b/tools/disasm_audit_operands_whitelist.txt
@@ -1,0 +1,173 @@
+# disasm_audit_operands_whitelist.txt
+#
+# Known-benign OPERAND-FORMAT (not value) differences between
+# tools/ppu_disasm.py and Capstone, for mnemonics where the two decoders
+# already agree (mnemonic-mismatches are tools/disasm_audit.py's job, not
+# this file's). One mnemonic per line:
+#
+#   mnemonic | one-line reason (state how it was MEASURED)
+#
+# A mnemonic listed here has ALL its divergences reported as INFO instead
+# of counting toward the REAL residual. Be conservative: add an entry only
+# after triaging real sample addresses from a run and confirming by hand
+# (re-derive the raw encoding) that the divergence is a pure textual/
+# format difference, never a genuine register-index or immediate-VALUE
+# difference. Blank lines and lines starting with '#' are ignored.
+#
+# Every entry below was triaged against a real 200,000-word prefix run of
+# game/EBOOT.elf (2026-07-05) with hand re-derivation of the raw encoding
+# AND a read of the corresponding tools/ppu_lifter.py handler to confirm
+# the LIFTED C code is unaffected (not just that the divergence looks
+# cosmetic) -- see disasm_audit_operands_whitelist.txt entries' reasons.
+
+# --- FP load/store register-class prefix (r vs f) -------------------------
+# ours prints the FPR destination/source with an "r" prefix (reusing the
+# same rd/ra field-decode path as integer load/stores); Capstone correctly
+# prints "f". MEASURED: numeric index always matches (e.g. 0x0001144C
+# "lfd r31,0x98(r1)" vs "lfd f31,0x98(r1)" -- same index 31, only the
+# class letter differs). LIFT-SAFE: tools/ppu_lifter.py's _reg_idx() regex
+# is `[rfv](\d+)` -- it strips whichever of r/f/v prefixes the disasm
+# printed and keeps only the numeric index, so the lifted C
+# (ctx->fpr[N] = ...) is correct regardless of the printed letter. Pure
+# disassembly-TEXT bug (cosmetic to a human reading `show_func.py --asm`
+# output), zero lift impact.
+lfs | FPR shown as rN instead of fN (see block comment above); _reg_idx accepts r/f/v, lift unaffected
+lfsu | same class as lfs
+lfd | same class as lfs
+lfdu | same class as lfs
+stfs | same class as lfs
+stfsu | same class as lfs
+stfd | same class as lfs
+stfdu | same class as lfs
+lfsx | same class as lfs (X-form load, same rd-field reuse)
+lfdx | same class as lfs
+stfsx | same class as lfs
+stfdx | same class as lfs
+stfiwx | same class as lfs (stores FPR frs's low word, same prefix bug)
+lfsux | same class as lfs, BUT ppu_lifter.py has NO handler for lfsux/lfdux/stfsux/stfdux at all (only the non-update lfsx/lfdx/stfsx/stfdx X-form are handled; see tools/ppu_lifter.py:775) -- a separate, PRE-EXISTING gap, so the prefix bug is currently inert for this one site (1 in the whole binary); noted as a landmine for whoever implements the X-form-update FP variants
+
+# --- vmaddfp / vnmsubfp operand order -------------------------------------
+# ours prints "vD, vA, vB, vC" (raw bit-position order: va=bits11-15,
+# vb=bits16-20, vc=bits21-25); the conventional PowerPC disassembly
+# convention (Capstone, and RPCS3's PPUDisAsm.cpp VMADDFP/VNMSUBFP calling
+# DisAsm_V4(..., op.vd, op.va, op.vc, op.vb) -- semantics-only citation,
+# no code copied) prints "vD, vA, vC, vB" instead (VC=multiplicand printed
+# before VB=addend). MEASURED at 0x00014C3C: raw fields vd=2,va=3,vb=31,
+# vc=2 (bit positions) -- ours prints "v2,v3,v31,v2" (va,vb,vc order),
+# capstone prints "v2,v3,v2,v31" (va,vc,vb order); same four register
+# indices, reordered last two. LIFT-SAFE: tools/ppu_lifter.py's vmaddfp/
+# vnmsubfp handlers read ops[2] into a local it calls "vb" and ops[3] into
+# a local it calls "vc" (the handler's own inline comment claims "operand
+# order is vD,vA,vC,vB" but its variable NAMES are actually bound to
+# ops[2]/ops[3] positionally, i.e. to our disasm's raw vB/vC fields) and
+# then computes r=a*c+b (vmaddfp) / r=b-a*c (vnmsubfp) using those two
+# locals in the roles that match the ACTUAL architectural VB(addend)/
+# VC(multiplicand) held in those raw fields -- so the emitted C is
+# formula-correct. Confirmed by independent re-derivation of both
+# operand-order convention AND the lifter's index-to-role mapping;
+# nothing here changes VALUES, only which of the two orderings each
+# printer chooses to display in the (v2,v3) trailing pair.
+vmaddfp | operand-order convention (vD,vA,vB,vC vs vD,vA,vC,vB); lifter reads ops[2]/ops[3] with roles matching our disasm's actual field layout, lift correct
+vnmsubfp | same class as vmaddfp
+
+# --- addis / lis immediate display (unsigned hex vs signed decimal) -------
+# ours prints the raw 16-bit UI field as unsigned hex (e.g. "0x8889");
+# Capstone sign-extends it into the 32-bit-context signed decimal/hex
+# convention (e.g. "-0x7777"). MEASURED: 0x8889 - 0x10000 == -0x7777
+# exactly (same bit pattern, different display convention) at real site
+# 0x00012578. LIFT-SAFE: tools/ppu_lifter.py's lis/addis handlers do
+# `(uint32_t)UI << 16` then cast to (int32_t) then (int64_t) -- shifting
+# the UNSIGNED 16-bit field left by 16 and THEN sign-extending the 32-bit
+# result from bit 31 is mathematically identical to sign-extending UI
+# from bit 15 first and then shifting (verified both give the same
+# int64 value for a representative negative case, -2004287488). Pure
+# unsigned-vs-signed display convention, zero lift impact.
+addis | unsigned-hex vs signed-decimal display of the same UI field; lifter shift-then-sign-extend is equivalent to sign-extend-then-shift
+lis | same class as addis
+
+# --- vrefp / vrsqrtefp extra bogus vA operand -----------------------------
+# these are 2-operand unary ops (vD, vB only; the VA field, bits 11-15, is
+# architecturally unused/reserved and always 0 in valid encodings) but
+# fall through tools/ppu_disasm.py's generic 3-operand vmx_vx table
+# formatter ("vD, vA, vB"), so ours prints a spurious extra v0 operand
+# (e.g. "vrefp v11, v0, v8" instead of "vrefp v11, v8"). MEASURED:
+# 0x000248DC, VA field = 0 in every sampled site. LIFT-SAFE:
+# tools/ppu_lifter.py's vrefp/vrsqrtefp/vrfim handlers deliberately read
+# `ops[-1]` (the LAST operand, with an inline comment noting exactly this
+# quirk: "vB = last operand (vmx_vx emits vD, vA, vB)"), so the real vB
+# is correctly extracted regardless of the bogus leading vA. Zero lift
+# impact -- contrast with `fsqrt` below, which does NOT have this
+# protection and IS a real bug.
+vrefp | extra bogus reserved-vA operand from the generic vmx_vx table; lifter uses ops[-1], lift unaffected
+vrsqrtefp | same class as vrefp
+vrfin | same class as vrefp; tools/ppu_lifter.py:1931-1936 also uses ops[-1] (vrfin/vrfiz/vrfip share one handler)
+vrfip | same class as vrfin (shares the vrfin/vrfiz/vrfip handler, ops[-1])
+vrfiz | same class as vrfin (shares the vrfin/vrfiz/vrfip handler, ops[-1])
+vrfim | same class as vrefp; tools/ppu_lifter.py:1922-1926 also uses ops[-1] (dedicated vrfim handler, same idiom)
+vexptefp | same class as vrefp; tools/ppu_lifter.py:1941-1946 also uses ops[-1] (vexptefp/vlogefp share one handler)
+vlogefp | same class as vexptefp (shares the vexptefp/vlogefp handler, ops[-1])
+vupkhsh | same class as vrefp; tools/ppu_lifter.py:2051-2058 also uses ops[-1]
+vupklsb | same disasm-format bug class as vrefp (extra bogus vA), BUT ppu_lifter.py has NO handler for vupklsb at all (falls to the generic TODO catch-all, which never reads ops) -- a separate, PRE-EXISTING gap unrelated to this operand-format bug; noted here only as a landmine so a future vupklsb implementation copies the ops[-1] idiom, not a fixed ops[1]/ops[2] index (the mistake fsqrt made)
+vupkhsb | same as vupklsb (no lifter handler; landmine note applies)
+vupklsh | same as vupklsb (no lifter handler; landmine note applies)
+
+# --- Capstone-side quirk: bd=0 conditional branches (target field==0) ----
+# Capstone's PPC backend omits the branch-target operand entirely when
+# the raw BD field (bits 16-29) is exactly 0, for BOTH PC-relative forms
+# (AA=0: architectural target = PC+0 = the instruction's own address) and
+# absolute forms (AA=1: architectural target = literal 0). MEASURED at 9
+# PC-relative sites (bge/bdz/blt/bdnz, e.g. 0x00023220 = word 0x40A00000)
+# and 12 absolute+LK sites (bgela/bdzla, e.g. 0x01241820 "bgela 0x0" vs
+# capstone "bgela "). Ours always prints the explicit (correct) target
+# value; Capstone prints nothing. This is handled as a GENERAL STRUCTURAL
+# RULE in disasm_audit_operands.py's operands_equal() (see
+# _capstone_dropped_zero_branch_target), not a per-mnemonic whitelist
+# entry, since the affected mnemonic set spans every b<cond>[l][a]
+# combination and a literal list would be incomplete/fragile. No entry
+# needed here; this comment documents why bge/bdz/blt/bdnz/bgela/bdzla/etc
+# do NOT appear in the whitelist counters despite the divergence being
+# benign -- the general rule suppresses it before whitelist lookup even
+# runs. Likely gap-rescue mis-scanned DATA words at these specific
+# BD==0 sites regardless (same reasoning as tools/disasm_audit.py's
+# tdi/twi rule-3 note), but the alias relationship is real either way.
+
+# --- sc LEV field not decoded ----------------------------------------------
+# ours never extracts/prints the 7-bit LEV field (bits 20-26) of `sc`;
+# Capstone does (e.g. "sc 0x4c"). MEASURED: exactly 1 site in the
+# 200,000-word sample (0x00026CA0). LIFT-SAFE: tools/ppu_lifter.py's `sc`
+# handler is a bare mnemonic dispatch (`if mn == "sc": return
+# "lv2_syscall(ctx);"`) that never reads ops at all -- LEV is unused by
+# the lift regardless. Minor decode-completeness gap, zero lift impact,
+# zero boot relevance (this project's ABI carries the syscall number in a
+# GPR per LV2 convention, not in LEV).
+sc | LEV field (bits 20-26) not decoded/printed; lifter's sc handler ignores operands entirely, zero lift impact
+
+# --- mftb TBR value not printed --------------------------------------------
+# ours prints only "rD" for mftb; Capstone additionally shows the TBR
+# constant as a second operand ("mftb r3, 0x10c" -- 0x10c==268==TBR for
+# the lower half). MEASURED: 0x00E5EEF4. No information is actually lost:
+# the mnemonic itself already distinguishes mftb (TBR=268) from mftbu
+# (TBR=269) -- see tools/ppu_disasm.py:696-706. LIFT-SAFE:
+# tools/ppu_lifter.py's mftb/mftbu handlers dispatch purely on mnemonic
+# and only read ops[0] (rd); the (unprinted) TBR operand is never
+# consulted.
+mftb | TBR constant (268) not printed as a second operand; mnemonic alone already disambiguates from mftbu, lifter never reads it
+
+# --- mtspr/mfspr SPR display: friendly name vs raw hex ---------------------
+# ours has a curated SPR_NAMES table (VRSAVE, LR, CTR, XER, ...) and falls
+# back to "spr{decimal N}" for anything not in the table; Capstone always
+# prints the raw SPR number in hex. MEASURED: 0x00FBD518 "mtspr VRSAVE,
+# r0" (ours) vs "mtspr 0x100, r0" (capstone) -- 0x100==256==VRSAVE;
+# 0x011425E0 "mtspr spr916, r26" vs "mtspr 0x394, r26" -- 0x394==916,
+# same value, decimal-in-a-fallback-name-string vs hex. LIFT-SAFE: the
+# ONLY mtspr/mfspr SPR the lifter special-cases is VRSAVE, matched by
+# testing the operand STRING equals "VRSAVE" (tools/ppu_lifter.py:968-972)
+# -- this still fires correctly since ours' SPR_NAMES table does contain
+# 256->"VRSAVE" (confirmed: the one real VRSAVE site round-trips). Every
+# other SPR (spr916/835/832 in the sample) falls through to the same
+# unhandled path regardless of which decoder's naming convention is used
+# -- a separate, pre-existing decode/lift gap (not something this
+# operand-value divergence changes), not a new bug introduced by the
+# display convention.
+mtspr | SPR shown as a curated friendly name (or spr{dec} fallback) vs Capstone's raw hex; same numeric SPR either way, lifter's only special-case (VRSAVE) still matches
+mfspr | same class as mtspr; MEASURED 0x00FBD3D4 "mfspr r0, VRSAVE" vs "mfspr r0, 0x100" (the VRSAVE round-trip pair's read side); lifter's VRSAVE special-case matches ops[-1]=="VRSAVE" (tools/ppu_lifter.py:968), unaffected

--- a/tools/endian_audit.py
+++ b/tools/endian_audit.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+"""
+endian_audit.py -- HLE out-param endianness heuristic auditor (INFO-level).
+
+Purpose: the endianness/packing bug class (project blockers #11/#16/#18/#19d)
+has so far been swept manually, module by module, as code gets exercised.
+This is a STATIC heuristic pass: it ranks suspects, it does not prove bugs.
+Expect noise -- false positives are handled via
+tools/endian_audit_whitelist.txt, not by making the heuristic "smarter".
+
+Heuristic (deliberately simple):
+  For each exported (non-static, file-scope) function defined in libs/**/*.c
+  whose signature has at least one pointer out-param of scalar or struct type
+  (u16*/u32*/u64*/SomeStruct* -- NOT char*/void*/const-qualified-only), flag it
+  INFO if the function body contains an assignment THROUGH that pointer
+  (`*p = ...`, `p->field = ...`, `p[i] = ...`) but calls NEITHER `ps3_bswapNN(`
+  NOR `vm_writeNN(` anywhere in the body.
+
+This is a heuristic, not a data-flow analysis:
+  - It does not verify the bswap/vm_write call actually touches the SAME
+    out-param (any bswap/vm_write call anywhere in the function silences the
+    flag for the whole function). That is intentional simplicity -- it
+    trades false negatives for a MUCH simpler, auditable rule.
+  - It does not track typedef chains beyond a small built-in scalar list plus
+    a "looks like a PS3-struct-pointer" fallback (Capitalized* or CellFoo*).
+  - const-qualified pointers (`const Foo* out`) are never flagged: they are
+    almost always [in] params by SDK convention.
+  - char*/void*/FILE*/function-pointer params are excluded: too often byte
+    buffers or host-only handles (known false-positive classes to
+    whitelist).
+
+Usage:
+    py -3 tools\\endian_audit.py [--libs-root libs] [--whitelist tools\\endian_audit_whitelist.txt]
+                                 [--module MODNAME] [--verbose] [--top N]
+
+Always exits 0 -- this is an advisory sweep, never a CI gate.
+"""
+
+import argparse
+import os
+import re
+import sys
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+# Boot-relevance priority: modules matching these substrings (case-insensitive,
+# matched against the FILE STEM, e.g. "cellAudio") sort first, in this order.
+# Anything not matching any bucket sorts after, alphabetically.
+PRIORITY_BUCKETS = [
+    ("audio", ["audio", "voice", "mic"]),
+    ("fs", ["fs", "savedata"]),
+    ("gcm_video", ["gcm", "video", "rsx", "resc"]),
+    ("sysutil", ["sysutil", "sysmodule", "sys_interrupt", "userinfo"]),
+]
+
+# Bswap / vm_write call families that silence a flag (verified 2026-07-05
+# against libs/filesystem/cellFs.c and runtime/ppu/ppu_memory.h -- the only
+# two helper families used in this codebase for guest-endian stores).
+SILENCING_CALL_RE = re.compile(r"\b(?:ps3_bswap(?:16|32|64)|vm_write(?:8|16|32|64))\s*\(")
+
+# Built-in scalar out-param types we always recognize (host-endian-native
+# types that the guest will read back big-endian).
+SCALAR_PTR_TYPES = ("u8", "u16", "u32", "u64", "s8", "s16", "s32", "s64",
+                    "b8", "ps3_addr_t", "float", "double",
+                    "unsigned char", "unsigned short", "unsigned int", "unsigned long long",
+                    "uint8_t", "uint16_t", "uint32_t", "uint64_t",
+                    "int8_t", "int16_t", "int32_t", "int64_t")
+
+# Excluded pointee types: byte buffers / opaque host handles / too noisy.
+EXCLUDED_PTR_TYPES = ("char", "void", "FILE", "u8")  # u8*/char* = byte buffers by convention
+
+# Struct-like pointee fallback: identifier starting uppercase (Cell*, Sce*, a
+# project struct, etc.) -- these are almost always guest-visible ABI structs.
+STRUCT_PTR_RE = re.compile(r"^[A-Z][A-Za-z0-9_]*$")
+
+DEFAULT_WHITELIST = os.path.join("tools", "endian_audit_whitelist.txt")
+
+
+# ---------------------------------------------------------------------------
+# C source scanning helpers
+# ---------------------------------------------------------------------------
+
+def strip_comments_and_strings(text):
+    """Replace comment/string/char-literal contents with spaces (preserving
+    line structure and total length) so brace-matching and regexes never
+    trip on braces/parens/quotes inside them."""
+    out = []
+    i = 0
+    n = len(text)
+    while i < n:
+        c = text[i]
+        if c == "/" and i + 1 < n and text[i + 1] == "/":
+            j = text.find("\n", i)
+            if j == -1:
+                j = n
+            out.append(" " * (j - i))
+            i = j
+        elif c == "/" and i + 1 < n and text[i + 1] == "*":
+            j = text.find("*/", i + 2)
+            if j == -1:
+                j = n
+                span = text[i:j]
+            else:
+                j += 2
+                span = text[i:j]
+            out.append("".join(ch if ch == "\n" else " " for ch in span))
+            i = j
+        elif c == '"':
+            j = i + 1
+            while j < n and text[j] != '"':
+                if text[j] == "\\":
+                    j += 2
+                else:
+                    j += 1
+            j = min(j + 1, n)
+            span = text[i:j]
+            out.append("".join(ch if ch == "\n" else " " for ch in span))
+            i = j
+        elif c == "'":
+            j = i + 1
+            while j < n and text[j] != "'":
+                if text[j] == "\\":
+                    j += 2
+                else:
+                    j += 1
+            j = min(j + 1, n)
+            span = text[i:j]
+            out.append("".join(ch if ch == "\n" else " " for ch in span))
+            i = j
+        else:
+            out.append(c)
+            i += 1
+    return "".join(out)
+
+
+# Matches a top-level (column-0-ish) function definition start: a return
+# type, a name, an open paren, params (possibly spanning lines), then '{' on
+# the line where the params close (allow whitespace/newlines before '{').
+# We intentionally require the function name + '(' to start at brace depth 0
+# and not be preceded by ';' immediately (i.e. not a prototype) -- verified
+# by requiring the matched '{' (not ';') to be the very next non-ws token
+# after the ')'.
+FUNC_HEAD_RE = re.compile(
+    r"""^(?P<ret>[A-Za-z_][A-Za-z0-9_ \t]*?[ \t*])
+        (?P<name>[A-Za-z_][A-Za-z0-9_]*)
+        \s*\((?P<params>[^;{}]*?)\)
+        \s*
+        \{""",
+    re.MULTILINE | re.VERBOSE | re.DOTALL,
+)
+
+
+def iter_toplevel_functions(clean_text):
+    """Yield (name, ret_type, params_str, body_start, body_end) for every
+    non-static, file-scope function DEFINITION in clean_text (comments/
+    strings already blanked). body_start/body_end are indices of the
+    matching '{' and '}' (inclusive of both braces)."""
+    for m in FUNC_HEAD_RE.finditer(clean_text):
+        ret = m.group("ret").strip()
+        name = m.group("name")
+        params = m.group("params")
+
+        # Skip obvious non-functions: control keywords mis-parsed as "ret name(...)",
+        # and macro-looking all-caps invocations.
+        if ret.split()[-1] if ret.split() else "" in ("return", "if", "while", "for", "switch"):
+            pass
+        first_ret_tok = ret.split()[0] if ret.split() else ""
+        if first_ret_tok in ("return", "if", "while", "for", "switch", "sizeof", "else"):
+            continue
+        if "static" in ret.split():
+            continue  # not exported
+        if name in ("if", "for", "while", "switch", "sizeof"):
+            continue
+
+        brace_start = m.end() - 1  # index of the '{'
+        depth = 0
+        i = brace_start
+        n = len(clean_text)
+        body_end = None
+        while i < n:
+            ch = clean_text[i]
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    body_end = i
+                    break
+            i += 1
+        if body_end is None:
+            continue  # unterminated (shouldn't happen in valid C); skip defensively
+
+        yield name, ret, params, brace_start, body_end
+
+
+# Splits a parameter list on top-level commas (none of our params contain
+# function-pointer commas inside parens in practice, but guard anyway by
+# tracking paren depth).
+def split_params(params_str):
+    parts = []
+    depth = 0
+    cur = []
+    for ch in params_str:
+        if ch == "(":
+            depth += 1
+            cur.append(ch)
+        elif ch == ")":
+            depth -= 1
+            cur.append(ch)
+        elif ch == "," and depth == 0:
+            parts.append("".join(cur))
+            cur = []
+        else:
+            cur.append(ch)
+    if cur:
+        parts.append("".join(cur))
+    return [p.strip() for p in parts if p.strip()]
+
+
+PARAM_RE = re.compile(
+    r"""^(?P<quals1>(?:const|volatile|struct|unsigned|signed)\s+)*
+        (?P<base>[A-Za-z_][A-Za-z0-9_]*)
+        \s*
+        (?P<stars>\**)
+        \s*
+        (?P<qual_after>(?:const\s+)*)
+        (?P<pname>[A-Za-z_][A-Za-z0-9_]*)?
+        (?:\s*\[[^\]]*\])?
+        $""",
+    re.VERBOSE,
+)
+
+
+def classify_out_params(params_str):
+    """Return a list of (param_name, pointee_type, is_const_pointee) for
+    params that look like NON-CONST pointer out-params of a scalar or
+    struct-like type, excluding char*/void*/function-pointers."""
+    results = []
+    if params_str.strip() in ("", "void"):
+        return results
+
+    for raw in split_params(params_str):
+        raw = raw.strip()
+        if not raw or raw == "void":
+            continue
+        if "(" in raw and "*" in raw.split("(")[0]:
+            # crude function-pointer param heuristic: "RetT (*name)(...)"
+            continue
+
+        # Detect const-ness of the POINTEE (const applied before the base type,
+        # i.e. "const Foo* x" -- pointee is const, exclude; but "Foo* const x"
+        # is a const pointer to non-const pointee -- NOT excluded).
+        stripped = raw.strip()
+        pointee_const = bool(re.match(r"^\s*const\b", stripped))
+
+        m = PARAM_RE.match(stripped)
+        if not m:
+            continue
+        stars = m.group("stars")
+        if len(stars) != 1:
+            continue  # only single-indirection out-params (u32*), skip **/none
+        base = m.group("base")
+
+        if pointee_const:
+            continue  # [in] param by convention
+
+        if base in EXCLUDED_PTR_TYPES:
+            continue
+
+        if base in SCALAR_PTR_TYPES:
+            results.append((m.group("pname") or "?", base, False))
+        elif STRUCT_PTR_RE.match(base):
+            results.append((m.group("pname") or "?", base, False))
+        # else: lowercase non-scalar typedef (e.g. "mutex_t*") -- skip, too
+        # likely to be a host-only internal type rather than guest ABI.
+    return results
+
+
+# A store THROUGH a given pointer name: "*name =", "name->field =", "name[i] ="
+def store_through_pointer_re(pname):
+    esc = re.escape(pname)
+    return re.compile(
+        r"(?:\*\s*" + esc + r"\s*(?:=[^=]|[+\-*/|&^]=)"
+        r"|\b" + esc + r"\s*->\s*[A-Za-z_][A-Za-z0-9_]*\s*(?:=[^=]|[+\-*/|&^]=)"
+        r"|\b" + esc + r"\s*\[[^\]]*\]\s*(?:=[^=]|[+\-*/|&^]=))"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Priority bucket sort
+# ---------------------------------------------------------------------------
+
+def module_priority(stem):
+    low = stem.lower()
+    for idx, (_bucket_name, needles) in enumerate(PRIORITY_BUCKETS):
+        for needle in needles:
+            if needle in low:
+                return idx
+    return len(PRIORITY_BUCKETS)
+
+
+# ---------------------------------------------------------------------------
+# Whitelist
+# ---------------------------------------------------------------------------
+
+def load_whitelist(path):
+    """tools/endian_audit_whitelist.txt format: one entry per line,
+    `function_name<TAB or multiple-spaces>reason text`. '#' comment lines and
+    blank lines ignored."""
+    names = set()
+    if not os.path.isfile(path):
+        return names
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.rstrip("\n")
+            if not line.strip() or line.lstrip().startswith("#"):
+                continue
+            name = re.split(r"\s+", line.strip(), maxsplit=1)[0]
+            if name:
+                names.add(name)
+    return names
+
+
+# ---------------------------------------------------------------------------
+# Core scan
+# ---------------------------------------------------------------------------
+
+def scan_file(path):
+    """Return list of dicts: {func, params, file, line} for suspect functions
+    in one .c file."""
+    with open(path, "r", encoding="utf-8", errors="replace") as f:
+        raw = f.read()
+    clean = strip_comments_and_strings(raw)
+
+    suspects = []
+    for name, _ret, params_str, body_start, body_end in iter_toplevel_functions(clean):
+        out_params = classify_out_params(params_str)
+        if not out_params:
+            continue
+
+        body = clean[body_start:body_end + 1]
+
+        if SILENCING_CALL_RE.search(body):
+            continue  # some bswap/vm_write call exists somewhere in the body
+
+        stored_params = []
+        for pname, ptype, _const in out_params:
+            if pname == "?":
+                continue
+            if store_through_pointer_re(pname).search(body):
+                stored_params.append((pname, ptype))
+
+        if not stored_params:
+            continue  # out-param never actually stored through -> not a suspect
+
+        line_no = raw.count("\n", 0, body_start) + 1
+        # correct for the function head starting a few lines above body_start;
+        # walk back to the function name occurrence for a more useful line no.
+        name_idx = raw.rfind(name, 0, body_start)
+        if name_idx != -1:
+            line_no = raw.count("\n", 0, name_idx) + 1
+
+        suspects.append({
+            "func": name,
+            "params": ", ".join(f"{t}* {n}" for n, t in stored_params),
+            "file": path,
+            "line": line_no,
+        })
+    return suspects
+
+
+def find_c_files(libs_root):
+    out = []
+    for dirpath, _dirnames, filenames in os.walk(libs_root):
+        for fn in filenames:
+            if fn.endswith(".c"):
+                out.append(os.path.join(dirpath, fn))
+    return sorted(out)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="HLE out-param endianness heuristic auditor (INFO-level, advisory)."
+    )
+    ap.add_argument("--libs-root", default="libs", help="root to scan (default: libs)")
+    ap.add_argument("--whitelist", default=DEFAULT_WHITELIST,
+                    help="whitelist file (function names + reasons)")
+    ap.add_argument("--module", default=None,
+                    help="only scan files whose stem matches this substring")
+    ap.add_argument("--top", type=int, default=10, help="how many top suspects to print")
+    ap.add_argument("--verbose", action="store_true", help="print every suspect, not just top-N")
+    args = ap.parse_args()
+
+    if not os.path.isdir(args.libs_root):
+        print(f"[endian_audit] libs root not found: {args.libs_root}", file=sys.stderr)
+        sys.exit(0)  # advisory tool: never a hard failure exit
+
+    whitelist = load_whitelist(args.whitelist)
+
+    files = find_c_files(args.libs_root)
+    if args.module:
+        files = [f for f in files if args.module.lower() in os.path.basename(f).lower()]
+
+    by_module = {}  # stem -> list[suspect dict]
+    total_scanned_functions_with_outparams = 0
+
+    for path in files:
+        stem = os.path.splitext(os.path.basename(path))[0]
+        suspects = scan_file(path)
+        kept = []
+        for s in suspects:
+            total_scanned_functions_with_outparams += 1
+            if s["func"] in whitelist:
+                continue
+            kept.append(s)
+        if kept:
+            by_module.setdefault(stem, []).extend(kept)
+
+    # Sort modules by boot-relevance priority bucket, then alphabetically.
+    module_order = sorted(by_module.keys(), key=lambda s: (module_priority(s), s.lower()))
+
+    print("=" * 78)
+    print("endian_audit.py -- HLE out-param endianness heuristic (INFO-level, advisory)")
+    print(f"Scanned {len(files)} file(s) under '{args.libs_root}'"
+          + (f" (module filter: {args.module})" if args.module else ""))
+    print(f"Whitelist: {args.whitelist} ({len(whitelist)} entries loaded)")
+    print("Rule: exported fn has a non-const scalar/struct pointer out-param that is")
+    print("      STORED THROUGH in the body, with NO ps3_bswap*/vm_write* call anywhere")
+    print("      in that function body.")
+    print("=" * 78)
+
+    total_suspects = sum(len(v) for v in by_module.values())
+    print(f"\nTotal suspects (post-whitelist): {total_suspects}")
+    print("\nPer-module suspect counts (boot-relevance order):")
+    for stem in module_order:
+        bucket_idx = module_priority(stem)
+        bucket_name = PRIORITY_BUCKETS[bucket_idx][0] if bucket_idx < len(PRIORITY_BUCKETS) else "other"
+        print(f"  [{bucket_name:9s}] {stem:24s} {len(by_module[stem]):4d}")
+
+    # Flat suspect list in module-priority order for the "top-N" print.
+    flat = []
+    for stem in module_order:
+        for s in by_module[stem]:
+            flat.append(s)
+
+    print(f"\nTop {args.top if not args.verbose else len(flat)} suspects:")
+    show = flat if args.verbose else flat[:args.top]
+    for s in show:
+        print(f"  {s['file']}:{s['line']}  {s['func']}({s['params']})")
+
+    if not flat:
+        print("  (none)")
+
+    print()
+    print("Advisory tool -- exit code is always 0.")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/endian_audit_whitelist.txt
+++ b/tools/endian_audit_whitelist.txt
@@ -1,0 +1,23 @@
+# endian_audit_whitelist.txt
+#
+# Function names (one per line) that tools/endian_audit.py should NOT flag,
+# even though the heuristic's local-function-body rule fires on them.
+# Format: `function_name<whitespace>one-line reason`. '#'-comment and blank
+# lines are ignored. Matched by exact function name (not module-qualified) --
+# if a name collides across modules with different correctness, split the
+# heuristic rather than fight the collision here.
+#
+# Seeded 2026-07-05 by triaging the FIRST unfiltered run (290 raw suspects
+# across 104 files) for two false-positive classes: (a) already-audited
+# modules whose bswap call lives in a HELPER function, invisible to this
+# tool's single-function-body rule; and (b) host-only internal structs that
+# never cross the guest vm-memory boundary. Real per-field endianness bugs
+# (e.g. cellFontOpenFontFile's font->handle/scale_x, cellFsUtilGetFileSize's
+# *size, cellRtc's tick structs) were LEFT AS SUSPECTS on purpose -- they
+# match the shape of bugs already fixed elsewhere in sibling functions
+# (cellFsRead's `*nread = ps3_bswap64(...)`) and are exactly the class of
+# bug this heuristic exists to surface.
+
+cellFsFstat	already-audited: calls fill_cellfs_stat() -> cellfs_stat_to_be() (libs/filesystem/cellFs.c:167,155) which DOES ps3_bswap32/64 every CellFsStat field; the swap call is one indirection away from this function's own body, outside this tool's single-function-body scope (documented limitation).
+cellFsStat	same helper-indirection class as cellFsFstat (calls fill_cellfs_stat() only; verified correct via cellfs_stat_to_be()).
+rsx_dsp_fragment_program	host-only internal RSX-dispatch accessor (libs/video/rsx_dispatch.c); `location` out-param is filled from register state and consumed only by libs/video/rsx_live_draw.c's local host variable `fp_loc` -- never written to or read from guest vm memory, so guest-endianness does not apply.

--- a/tools/hle_abi_audit.py
+++ b/tools/hle_abi_audit.py
@@ -1,0 +1,924 @@
+#!/usr/bin/env python3
+"""hle_abi_audit.py -- differential ABI-signature audit for HLE functions.
+
+Same technique as the PPU/SPU decode conformance audits, applied one layer up:
+instead of diffing our instruction lifter against the PowerISA reference, this
+diffs our HLE C function signatures (libs/**/*.c) against RPCS3's real,
+shipped implementation of the same PS3 module functions
+(rpcs3/rpcs3/Emu/Cell/Modules/*.cpp).
+
+This is the bug class that produced blocker #16 (cellGcmGetTimeStampLocation),
+#18 (CellFsStat), #19d, and cellGcmGetTiledPitchSize: we quietly turn a
+function that PS3 games expect to *return* a value into one that writes an
+out-param and returns an error code (or vice versa), or we drop/add a
+parameter. Those are silent ABI mismatches -- they compile fine, and only
+misbehave at runtime when a caller reads the return register/parameter that
+we didn't populate the way it expects.
+
+RPCS3 (rpcs3/ in this repo) is GPLv2. We read ONLY the function signature
+(return type + parameter types) as ground truth for the real PS3 ABI --
+never copy its function bodies. This repo stays MIT/clean-room.
+
+Usage:
+    py -3 tools/hle_abi_audit.py [--libs DIR] [--oracle DIR] [--whitelist FILE]
+                                  [--json OUT.json]
+
+Stdlib-only, py -3, LF line endings, 4-space indent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+
+
+# ---------------------------------------------------------------------------
+# Boot-relevance ordering (hardcoded, per the task spec): gcm/video, fs,
+# audio, sysutil first, everything else after, alphabetically within a tier.
+# ---------------------------------------------------------------------------
+
+MODULE_PRIORITY = [
+    "cellGcmSys",
+    "cellVideoOut",
+    "cellResc",
+    "sys_fs",
+    "cellFsUtility",
+    "cellAudio",
+    "cellSysutil",
+    "cellSysmodule",
+]
+
+
+def module_rank(module: str) -> tuple:
+    try:
+        return (0, MODULE_PRIORITY.index(module))
+    except ValueError:
+        return (1, module)
+
+
+# ---------------------------------------------------------------------------
+# Shared signature model
+# ---------------------------------------------------------------------------
+
+NAME_PREFIXES = ("cell", "sce", "sys_")
+
+_IDENT = r"[A-Za-z_][A-Za-z0-9_]*"
+
+
+@dataclass
+class Param:
+    raw_type: str
+    name: str
+    is_pointer: bool
+    base_type: str  # normalized scalar base type, e.g. "u32", "char", "void"
+
+
+@dataclass
+class Signature:
+    name: str
+    return_raw: str
+    return_is_pointer: bool
+    return_base: str
+    params: list = field(default_factory=list)  # list[Param]
+    file: str = ""
+    line: int = 0
+    # True if this function's body demonstrably treats its s32/int return
+    # as a status code (see body_looks_like_status_return()). Only ever set
+    # on OUR side (we have the body; for RPCS3 we deliberately never read
+    # bodies -- signature-only, per the clean-room rule in the module
+    # docstring). None means "not applicable / not scanned" (e.g. RPCS3
+    # signatures, or a non-ambiguous return type).
+    return_is_status_by_body: object = None
+
+    def param_sig(self) -> str:
+        return ", ".join(f"{p.raw_type} {p.name}".strip() for p in self.params)
+
+    def pretty(self) -> str:
+        return f"{self.return_raw} {self.name}({self.param_sig()})"
+
+
+# ---------------------------------------------------------------------------
+# Type normalization
+# ---------------------------------------------------------------------------
+
+# Scalar-equivalence classes: our spelling vs RPCS3's spelling collapse to the
+# same "kind" for comparison purposes. This is intentionally coarse (KIND,
+# not exact width) per the task spec -- we only want to catch the OUT-PARAM
+# vs RETURN class and the POINTER vs VALUE class, not int-vs-long nitpicks.
+_INT_ALIASES = {
+    "u8", "u16", "u32", "u64", "s8", "s16", "s32", "s64",
+    "int", "unsigned", "unsigned int", "unsigned char", "unsigned short",
+    "unsigned long", "unsigned long long", "long", "long long",
+    "short", "char", "signed char", "bool", "size_t", "ssize_t",
+    "float", "f32", "f64", "double",
+    "be_t<u8>", "be_t<u16>", "be_t<u32>", "be_t<u64>",
+    "be_t<s8>", "be_t<s16>", "be_t<s32>", "be_t<s64>",
+}
+
+# Return-type "error status" family, UNAMBIGUOUS spellings only: a type
+# whose name can *only* mean "this is a status code" on either side of the
+# diff. error_code/CellError/CellFsErrno never denote a real payload value
+# in this codebase, so treating them as "error" kind is safe.
+#
+# s32/int are DELIBERATELY EXCLUDED from this set: the Cell ABI is
+# ambiguous about it (s32 is CELL_OK-or-negative-error in some functions,
+# but a genuine signed count/value return in others, e.g.
+# cellPamfReaderGetNumberOfStreams). Treating every s32 as "error" produced
+# a measured false positive (that function flagged against RPCS3's `u8`
+# even though both are plain value returns). s32/int are classified as
+# "value" like any other scalar -- see AMBIGUOUS_STATUS_TYPES below for the
+# one place their ambiguity still matters.
+ERROR_RETURN_TYPES = {
+    "error_code", "cellerror", "cellfserrno",
+}
+
+# s32/int returns are ambiguous (see above), but a s32/int return paired
+# with a `void` return on the other side is still worth flagging: either
+# we invented a status return the ABI doesn't have, or RPCS3 collapsed a
+# real error path to void because it's asserted CELL_OK -- both are
+# information a verify-then-implement reviewer wants to see. So: s32/int
+# vs void keeps flagging (via classify_return's return kind = "error" only
+# in that one contrast); s32/int vs another concrete integer type does not.
+AMBIGUOUS_STATUS_TYPES = {"s32", "int"}
+
+VOID_TYPES = {"void"}
+
+
+def strip_cv(t: str) -> str:
+    t = t.strip()
+    t = re.sub(r"\bconst\b", "", t)
+    t = re.sub(r"\bvolatile\b", "", t)
+    t = re.sub(r"\s+", " ", t).strip()
+    return t
+
+
+def normalize_base(t: str) -> str:
+    """Reduce a type spelling to a normalized base-type token."""
+    t = strip_cv(t)
+    t = t.replace("*", "").strip()
+    t = re.sub(r"\s+", " ", t)
+
+    # RPCS3 vm::ptr<T> / vm::cptr<T> / vm::bptr<T> / vm::pptr<T> -> T
+    m = re.match(r"^vm::(?:ptr|cptr|bptr|pptr)<\s*(.+?)\s*>$", t)
+    if m:
+        t = m.group(1)
+        t = strip_cv(t)
+
+    # be_t<T> -> T (RPCS3 big-endian wrapper is transparent for our purposes)
+    m = re.match(r"^be_t<\s*(.+?)\s*>$", t)
+    if m:
+        t = m.group(1)
+
+    t = t.lower()
+    if t in ("unsigned",):
+        t = "unsigned int"
+    return t
+
+
+#: Names of our own typedefs that resolve (transitively) to a function
+#: pointer, e.g. `typedef void (*CellGcmFlipHandler)(u32 head);`. Populated
+#: by scan_our_fnptr_typedefs() before extraction runs. A guest callback
+#: pointer is semantically a pointer (an address) on both sides, so these
+#: must be classified as pointer-kind, matching RPCS3's `vm::ptr<void(...)>`
+#: spelling of the same callback parameter -- otherwise every callback-taking
+#: HLE function false-flags as param-pointer-vs-value.
+OUR_FNPTR_TYPEDEFS: set = set()
+
+#: Names of RPCS3-side `using X = vm::ptr<T>;` / `using X = vm::pptr<T>;`
+#: aliases (e.g. cellSaveData.cpp's `PSetBuf`, `PSetList`). Populated by
+#: scan_oracle_ptr_aliases(). Needed because RPCS3 sometimes types a
+#: parameter with a local alias name instead of spelling out vm::ptr<...>
+#: inline; without resolving the alias, the same false pointer-vs-value
+#: mismatch appears, just with the polarity flipped (RPCS3 side looks like
+#: a bare value because the alias name doesn't match any known pattern).
+ORACLE_PTR_ALIASES: set = set()
+
+#: Our own typedef-to-integer "handle" idiom used throughout the Cell SDK
+#: (CellAdecHandle = u32, CellDmuxHandle = u32, ...). RPCS3 frequently
+#: models the *same* guest-visible u32 handle as `vm::ptr<InternalContext>`
+#: / `vm::pptr<InternalContext>` internally (the handle value IS the guest
+#: address of RPCS3's own tracking struct) -- that is an RPCS3
+#: implementation choice, not evidence the real PS3 ABI passes a pointer;
+#: the actual wire-visible quantity is a 4-byte handle either way. Populated
+#: by scan_our_handle_typedefs().
+OUR_HANDLE_TYPEDEFS: set = set()
+
+_HANDLE_NAME_RE = re.compile(r"^(Cell|Sce)[A-Za-z0-9]*Handle$")
+
+
+def is_pointer_type(t: str) -> bool:
+    """True if the RAW spelling denotes a pointer/out-param-capable type.
+
+    Our side: trailing '*', OR a typedef name known (via
+    OUR_FNPTR_TYPEDEFS) to resolve to a function pointer.
+    RPCS3 side: vm::ptr<T> / vm::cptr<T> / vm::bptr<T> / vm::pptr<T>
+    (vm::ref is rare and not used by module signatures we scan), OR a
+    `using` alias (via ORACLE_PTR_ALIASES) that resolves to one of those.
+    """
+    t = strip_cv(t)
+    bare = t.replace("*", "").strip()
+    if bare in OUR_FNPTR_TYPEDEFS or bare in ORACLE_PTR_ALIASES:
+        return True
+    if re.match(r"^vm::(?:ptr|cptr|bptr|pptr)<", t):
+        return True
+    if "*" in t:
+        return True
+    return False
+
+
+def is_handle_typedef(t: str) -> bool:
+    """True if `t` is one of our `Cell*Handle`/`Sce*Handle` typedefs that
+    resolve to a plain integer (the Cell SDK opaque-handle idiom)."""
+    t = strip_cv(t).replace("*", "").strip()
+    return t in OUR_HANDLE_TYPEDEFS or bool(_HANDLE_NAME_RE.match(t))
+
+
+def make_param(raw_type: str, name: str) -> Param:
+    raw_type = strip_cv(raw_type)
+    return Param(
+        raw_type=raw_type,
+        name=name,
+        is_pointer=is_pointer_type(raw_type),
+        base_type=normalize_base(raw_type),
+    )
+
+
+_RETURN_STMT_RE = re.compile(r"return\s+([^;]*?)\s*;")
+_STATUS_LITERAL_RE = re.compile(
+    r"^\(?\s*(?:\([A-Za-z_][A-Za-z0-9_]*\)\s*)?"
+    r"(?:CELL_OK"
+    r"|CELL_[A-Za-z0-9_]*_ERROR[A-Za-z0-9_]*"      # CELL_GCM_ERROR_INVALID_VALUE
+    r"|CELL_E[A-Z][A-Z0-9_]*"                      # CELL_EFAULT, CELL_ENOENT (POSIX-errno style)
+    r"|SCE_[A-Za-z0-9_]*_ERROR[A-Za-z0-9_]*"
+    r")\s*\)?$"
+)
+
+
+def find_matching_brace(text: str, open_brace_pos: int) -> int:
+    """Given the index of a '{' in text, return the index of its matching
+    '}' (naive depth counter; text_nc has comments already blanked out, so
+    braces inside string literals are the only remaining risk, and none of
+    the HLE sources in this repo put braces inside string literals in a
+    function body in a way that would fool this)."""
+    depth = 0
+    i = open_brace_pos
+    n = len(text)
+    while i < n:
+        c = text[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return n - 1
+
+
+def body_looks_like_status_return(body: str) -> bool:
+    """True if EVERY `return <expr>;` in a function body's expr is a
+    CELL_OK / CELL_*_ERROR* / SCE_*_ERROR* literal (bare, or cast to an
+    error enum) -- i.e. the s32/int return is unambiguously a status code
+    in THIS function, never a plain computed value.
+
+    Requiring ALL returns (not just one) to be status literals is what
+    distinguishes cellGcmGetTiledPitchSize (every return is CELL_OK or a
+    CELL_GCM_ERROR_* constant) from cellPamfReaderGetNumberOfStreams (the
+    validation path returns CELL_PAMF_ERROR_INVALID_ARG, but the success
+    path returns `reader->numStreams` -- a real value, so this function is
+    NOT status-only despite having one status-shaped return statement).
+    A function with zero return statements (e.g. a stub that falls off the
+    end) is not claimed as status-by-body either -- no evidence either way.
+    """
+    returns = [m.group(1).strip() for m in _RETURN_STMT_RE.finditer(body)]
+    if not returns:
+        return False
+    return all(_STATUS_LITERAL_RE.match(r) for r in returns)
+
+
+def classify_return(raw: str) -> tuple:
+    """Returns (is_pointer, base_kind) for a return type.
+
+    base_kind is one of: "void", "error", "value", "ambiguous-status",
+    "pointer" -- the KIND axis the task spec cares about (real value vs
+    void vs error-status vs pointer-return), not exact width.
+    "ambiguous-status" (s32/int) compares equal to "value" EXCEPT against
+    "void" -- see diff_signatures()'s return-kind block for the one place
+    that distinction is applied.
+    """
+    raw = strip_cv(raw)
+    if is_pointer_type(raw):
+        return True, "pointer"
+    base = normalize_base(raw)
+    if base in VOID_TYPES:
+        return False, "void"
+    if base in ERROR_RETURN_TYPES:
+        return False, "error"
+    if base in AMBIGUOUS_STATUS_TYPES:
+        return False, "ambiguous-status"
+    if base in _INT_ALIASES:
+        return False, "value"
+    # Unknown aggregate/struct-by-value return, or a class type (RPCS3 has
+    # some, e.g. custom result wrappers) -- treat as an opaque "value" kind
+    # distinct from "error"/"void" so a value<->void/error mismatch still
+    # flags, but two unknown-but-equal spellings don't false-positive.
+    return False, f"value:{base}"
+
+
+# ---------------------------------------------------------------------------
+# Typedef/alias pre-scans (must run before signature extraction so the
+# pointer/handle classifiers above have their name sets populated)
+# ---------------------------------------------------------------------------
+
+_OUR_FNPTR_TYPEDEF_RE = re.compile(
+    r"typedef\s+[A-Za-z_][A-Za-z0-9_\s]*?\(\s*\*\s*(" + _IDENT + r")\s*\)\s*\("
+)
+
+_OUR_HANDLE_TYPEDEF_RE = re.compile(
+    r"typedef\s+(?:u8|u16|u32|u64|s8|s16|s32|s64|int|unsigned\s+int)\s+"
+    r"(" + _IDENT + r")\s*;"
+)
+
+_ORACLE_PTR_ALIAS_RE = re.compile(
+    r"^using\s+(" + _IDENT + r")\s*=\s*vm::(?:ptr|cptr|bptr|pptr)\s*<",
+    re.MULTILINE,
+)
+
+
+def scan_our_fnptr_typedefs(root: str) -> set:
+    """Scan libs/**/*.h (and .c) for `typedef Ret (*Name)(...)` function
+    pointer typedefs; these are guest callback addresses and must be
+    classified as pointer-kind (see OUR_FNPTR_TYPEDEFS docstring above)."""
+    names = set()
+    for dirpath, _dirnames, filenames in os.walk(root):
+        for fn in filenames:
+            if not (fn.endswith(".h") or fn.endswith(".c")):
+                continue
+            path = os.path.join(dirpath, fn)
+            try:
+                with open(path, "r", encoding="utf-8", errors="replace") as f:
+                    text = f.read()
+            except OSError:
+                continue
+            for m in _OUR_FNPTR_TYPEDEF_RE.finditer(text):
+                names.add(m.group(1))
+    return names
+
+
+def scan_our_handle_typedefs(root: str) -> set:
+    """Scan libs/**/*.h for `typedef u32 CellXxxHandle;`-shaped opaque-handle
+    typedefs (see OUR_HANDLE_TYPEDEFS docstring above)."""
+    names = set()
+    for dirpath, _dirnames, filenames in os.walk(root):
+        for fn in filenames:
+            if not fn.endswith(".h"):
+                continue
+            path = os.path.join(dirpath, fn)
+            try:
+                with open(path, "r", encoding="utf-8", errors="replace") as f:
+                    text = f.read()
+            except OSError:
+                continue
+            for m in _OUR_HANDLE_TYPEDEF_RE.finditer(text):
+                name = m.group(1)
+                if _HANDLE_NAME_RE.match(name):
+                    names.add(name)
+    return names
+
+
+def scan_oracle_ptr_aliases(root: str) -> set:
+    """Scan RPCS3's Modules/**/*.cpp and *.h for `using X = vm::ptr<T>;`
+    (and cptr/bptr/pptr) local type aliases (see ORACLE_PTR_ALIASES
+    docstring above)."""
+    names = set()
+    for dirpath, _dirnames, filenames in os.walk(root):
+        for fn in filenames:
+            if not (fn.endswith(".cpp") or fn.endswith(".h")):
+                continue
+            path = os.path.join(dirpath, fn)
+            try:
+                with open(path, "r", encoding="utf-8", errors="replace") as f:
+                    text = f.read()
+            except OSError:
+                continue
+            for m in _ORACLE_PTR_ALIAS_RE.finditer(text):
+                names.add(m.group(1))
+    return names
+
+
+# ---------------------------------------------------------------------------
+# Our side: libs/**/*.c parser
+# ---------------------------------------------------------------------------
+
+# A "definition head" is: <return-type> <name>(<params>) NOT followed by ';'
+# i.e. it has a matching '{' (allowing whitespace/newlines in between).
+# We scan brace-depth-aware across the whole file so multi-line signatures
+# (e.g. cellGcmSetDisplayBuffer's wrapped params) are joined correctly.
+
+_RETTYPE_HEAD = re.compile(
+    r"^(?P<static>static\s+)?"
+    r"(?P<ret>(?:const\s+)?[A-Za-z_][A-Za-z0-9_:<>\s\*]*?)\s+"
+    r"(?P<name>" + _IDENT + r")\s*\((?P<params>[^;{}]*)\)\s*$",
+    re.MULTILINE,
+)
+
+
+def _split_top_level_commas(s: str):
+    parts = []
+    depth = 0
+    cur = []
+    for ch in s:
+        if ch in "<(":
+            depth += 1
+            cur.append(ch)
+        elif ch in ">)":
+            depth -= 1
+            cur.append(ch)
+        elif ch == "," and depth == 0:
+            parts.append("".join(cur))
+            cur = []
+        else:
+            cur.append(ch)
+    if cur:
+        parts.append("".join(cur))
+    return [p.strip() for p in parts if p.strip()]
+
+
+def parse_params(params_str: str) -> list:
+    params_str = params_str.strip()
+    if params_str == "" or params_str == "void":
+        return []
+    out = []
+    for part in _split_top_level_commas(params_str):
+        part = part.strip()
+        if not part:
+            continue
+        # Drop default values (not expected in C, but be safe)
+        part = re.split(r"=", part, maxsplit=1)[0].strip()
+        # Function pointer param: RetType (*name)(args)
+        m = re.match(r"^(.+?\(\s*\*\s*)(" + _IDENT + r")(\s*\).*)$", part)
+        if m:
+            raw_type = (m.group(1) + m.group(3)).strip()
+            name = m.group(2)
+            out.append(make_param(raw_type, name))
+            continue
+        # Normal: Type name  (name may be absent, e.g. prototypes -- rare in .c)
+        m = re.match(r"^(.*?[\s\*])(" + _IDENT + r")$", part)
+        if m:
+            raw_type = m.group(1).strip()
+            name = m.group(2)
+        else:
+            # No name at all (just a type, e.g. "void")
+            raw_type = part
+            name = ""
+        out.append(make_param(raw_type, name))
+    return out
+
+
+def extract_ours(root: str) -> dict:
+    """Scan libs/**/*.c for exported (non-static) function definitions whose
+    name starts with a recognized PS3 module prefix. Returns name -> Signature
+    (first definition wins if duplicated -- duplicates are rare/a separate
+    issue, not this tool's job).
+    """
+    sigs = {}
+    for dirpath, _dirnames, filenames in os.walk(root):
+        for fn in filenames:
+            if not fn.endswith(".c"):
+                continue
+            path = os.path.join(dirpath, fn)
+            try:
+                with open(path, "r", encoding="utf-8", errors="replace") as f:
+                    text = f.read()
+            except OSError:
+                continue
+
+            # Strip comments (block and line) so brace/paren scanning across
+            # commented-out signatures doesn't misfire, and so a ')' inside a
+            # comment never confuses the head matcher.
+            text_nc = re.sub(r"/\*.*?\*/", lambda m: re.sub(r"[^\n]", " ", m.group(0)), text, flags=re.DOTALL)
+            text_nc = re.sub(r"//[^\n]*", "", text_nc)
+
+            for m in re.finditer(
+                r"^(?P<static>static\s+)?"
+                r"(?P<ret>[A-Za-z_][A-Za-z0-9_:<>\s\*]*?)\s+"
+                r"(?P<name>" + _IDENT + r")\s*\(\s*(?P<params>[^;{}]*?)\s*\)\s*\n?\s*\{",
+                text_nc,
+                flags=re.MULTILINE,
+            ):
+                if m.group("static"):
+                    continue
+                name = m.group("name")
+                if not name.startswith(NAME_PREFIXES):
+                    continue
+                if name in ("sys_fs",):  # guard against accidental prefix-only match
+                    continue
+                ret_raw = m.group("ret").strip()
+                # Reject false positives: control-flow keywords, or a
+                # "return" caught by the regex, etc.
+                if ret_raw in ("return", "else", "if", "while", "for", "switch"):
+                    continue
+                params_raw = m.group("params")
+                line_no = text_nc.count("\n", 0, m.start()) + 1
+                is_ptr, base_kind = classify_return(ret_raw)
+
+                status_by_body = None
+                if base_kind == "ambiguous-status":
+                    # m.end() - 1 is the '{' itself (regex ends "...\{").
+                    open_brace = m.end() - 1
+                    close_brace = find_matching_brace(text_nc, open_brace)
+                    body = text_nc[open_brace:close_brace + 1]
+                    status_by_body = body_looks_like_status_return(body)
+
+                sig = Signature(
+                    name=name,
+                    return_raw=ret_raw,
+                    return_is_pointer=is_ptr,
+                    return_base=base_kind,
+                    params=parse_params(params_raw),
+                    file=os.path.relpath(path, root_start(root)),
+                    line=line_no,
+                    return_is_status_by_body=status_by_body,
+                )
+                if name not in sigs:
+                    sigs[name] = sig
+    return sigs
+
+
+def root_start(root: str) -> str:
+    # Report paths relative to the repo root (parent of libs/), matching the
+    # convention used elsewhere in this repo's reports (e.g. libs/video/x.c).
+    return os.path.dirname(os.path.normpath(root))
+
+
+# ---------------------------------------------------------------------------
+# Oracle side: rpcs3/rpcs3/Emu/Cell/Modules/*.cpp parser
+# ---------------------------------------------------------------------------
+
+REG_FUNC_RE = re.compile(
+    r"REG_FUNC\s*\(\s*(?P<module>" + _IDENT + r")\s*,\s*(?P<name>" + _IDENT + r")\s*\)"
+)
+
+
+def extract_oracle(root: str) -> tuple:
+    """Returns (sigs, name_to_module) where sigs: name -> Signature and
+    name_to_module: name -> module string (from REG_FUNC registrations, the
+    authoritative "this is a real HLE export" signal)."""
+    sigs = {}
+    name_to_module = {}
+
+    for dirpath, _dirnames, filenames in os.walk(root):
+        for fn in filenames:
+            if not fn.endswith(".cpp"):
+                continue
+            path = os.path.join(dirpath, fn)
+            try:
+                with open(path, "r", encoding="utf-8", errors="replace") as f:
+                    text = f.read()
+            except OSError:
+                continue
+
+            for m in REG_FUNC_RE.finditer(text):
+                name_to_module.setdefault(m.group("name"), m.group("module"))
+
+            text_nc = re.sub(r"/\*.*?\*/", lambda mm: re.sub(r"[^\n]", " ", mm.group(0)), text, flags=re.DOTALL)
+            text_nc = re.sub(r"//[^\n]*", "", text_nc)
+
+            for m in re.finditer(
+                r"^(?P<ret>[A-Za-z_][A-Za-z0-9_:<>\s\*&,]*?)\s+"
+                r"(?P<name>" + _IDENT + r")\s*\(\s*(?P<params>[^;{}]*?)\s*\)\s*\n?\s*\{",
+                text_nc,
+                flags=re.MULTILINE,
+            ):
+                name = m.group("name")
+                if not name.startswith(NAME_PREFIXES):
+                    continue
+                if "::" in m.group("ret"):
+                    # e.g. "audio_ringbuffer::backend_write_callback" is
+                    # actually matched with ret holding the class-qualified
+                    # leftover; also guard the name itself below.
+                    pass
+                ret_raw = m.group("ret").strip()
+                if ret_raw in ("return", "else", "if", "while", "for", "switch", "template"):
+                    continue
+                # Skip templated / out-of-line class-scoped defs like
+                # "void fmt_class_string<CellAudioError>::format" -- those
+                # have "::" immediately before the matched name's own text;
+                # detect via a scan backwards for "::" right before name.
+                pre_start = max(0, m.start("name") - 3)
+                if text_nc[pre_start:m.start("name")].endswith("::"):
+                    continue
+                params_raw = m.group("params")
+                line_no = text_nc.count("\n", 0, m.start()) + 1
+
+                params = parse_params(params_raw)
+                # Strip RPCS3's implicit leading ppu_thread& (or cpu_thread&)
+                # context param -- it's plumbing, not part of the PS3 ABI the
+                # guest program observes.
+                if params and re.match(r"^(ppu_thread|cpu_thread|spu_thread)\s*&$",
+                                        strip_cv(params[0].raw_type)):
+                    params = params[1:]
+
+                is_ptr, base_kind = classify_return(ret_raw)
+                sig = Signature(
+                    name=name,
+                    return_raw=ret_raw,
+                    return_is_pointer=is_ptr,
+                    return_base=base_kind,
+                    params=params,
+                    file=os.path.relpath(path, root_start_oracle(root)),
+                    line=line_no,
+                )
+                # First definition wins (some modules have forward decls with
+                # bodies further down guarded by #ifdef -- rare; good enough).
+                if name not in sigs:
+                    sigs[name] = sig
+    return sigs, name_to_module
+
+
+def root_start_oracle(root: str) -> str:
+    return root  # report paths relative to rpcs3/ itself (already deep enough)
+
+
+# ---------------------------------------------------------------------------
+# Diff logic
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Mismatch:
+    name: str
+    module: str
+    kind: str  # "return-kind" | "param-count" | "param-pointer-vs-value"
+    detail: str
+    ours: Signature
+    theirs: Signature
+
+
+def diff_signatures(ours: Signature, theirs: Signature) -> list:
+    problems = []
+
+    # --- Return type KIND mismatch ---
+    ours_kind = ours.return_base.split(":")[0]
+    theirs_kind = theirs.return_base.split(":")[0]
+
+    def _effective_kind(sig: Signature, k: str, other_k: str) -> str:
+        # "ambiguous-status" (s32/int) is resolved, in priority order:
+        #  1. body evidence (OUR side only -- does the function's own body
+        #     `return CELL_OK` / a CELL_*_ERROR* constant? If so it's
+        #     unambiguously a status code in THIS function, regardless of
+        #     what the other side returns.
+        #  2. otherwise collapse to "value" UNLESS the other side is
+        #     "void" -- an invented/dropped status return against a void
+        #     ABI is still worth flagging (see AMBIGUOUS_STATUS_TYPES).
+        if k == "ambiguous-status":
+            if sig.return_is_status_by_body:
+                return "error"
+            return "error" if other_k == "void" else "value"
+        return k
+
+    ours_eff = _effective_kind(ours, ours_kind, theirs_kind)
+    theirs_eff = _effective_kind(theirs, theirs_kind, ours_kind)
+
+    if ours.return_is_pointer != theirs.return_is_pointer:
+        problems.append((
+            "return-kind",
+            f"pointer-return mismatch: ours={'ptr' if ours.return_is_pointer else 'value'} "
+            f"({ours.return_raw}) vs RPCS3={'ptr' if theirs.return_is_pointer else 'value'} "
+            f"({theirs.return_raw})",
+        ))
+    elif ours_eff != theirs_eff:
+        # The headline bug class: one side is void/error (out-param carries
+        # the real result) and the other side returns a real value.
+        problems.append((
+            "return-kind",
+            f"ours returns {ours_eff} ({ours.return_raw}) but RPCS3 returns "
+            f"{theirs_eff} ({theirs.return_raw})",
+        ))
+
+    # --- Param count mismatch ---
+    count_differs = len(ours.params) != len(theirs.params)
+    if count_differs:
+        problems.append((
+            "param-count",
+            f"ours has {len(ours.params)} param(s), RPCS3 has {len(theirs.params)}",
+        ))
+
+    # --- Per-position pointer-vs-value mismatch (only over the common
+    #     prefix length; count mismatch already flagged above). CAVEAT: when
+    #     param-count also differs, a position-by-position compare can be
+    #     comparing params that don't actually correspond (e.g. RPCS3 has an
+    #     extra leading request-handle param that shifts everything after
+    #     it by one) -- flagged findings in that case are marked
+    #     "(unaligned)" so the report doesn't overstate confidence in the
+    #     exact position, while still surfacing that SOME divergence exists.
+    #     A count match means positions are apples-to-apples.
+    for i in range(min(len(ours.params), len(theirs.params))):
+        po, pt = ours.params[i], theirs.params[i]
+        if po.is_pointer != pt.is_pointer:
+            # BENIGN: our side spells an opaque Cell SDK handle as a
+            # typedef'd integer (CellAdecHandle = u32) while RPCS3 spells
+            # the *same* guest-visible 4-byte handle as vm::ptr<InternalCtx>
+            # / vm::pptr<InternalCtx> (RPCS3 uses the handle value as the
+            # guest address of its own tracking struct). Both sides carry
+            # one pointer-sized guest quantity; this is not a real ABI
+            # divergence -- see is_handle_typedef()'s docstring.
+            if (not po.is_pointer and is_handle_typedef(po.raw_type) and pt.is_pointer):
+                continue
+            tag = " (unaligned -- param count differs, position may not correspond)" if count_differs else ""
+            problems.append((
+                "param-pointer-vs-value",
+                f"param #{i + 1}: ours `{po.raw_type} {po.name}` is "
+                f"{'a pointer' if po.is_pointer else 'a value'} but RPCS3's "
+                f"`{pt.raw_type}` is {'a pointer' if pt.is_pointer else 'a value'}{tag}",
+            ))
+
+    return problems
+
+
+# ---------------------------------------------------------------------------
+# Whitelist
+# ---------------------------------------------------------------------------
+
+def load_whitelist(path: str) -> dict:
+    """Whitelist file format (one entry per line, '#'-comments allowed):
+
+        function_name : free-text reason
+
+    A whitelisted name suppresses ALL mismatch kinds for that function. This
+    is deliberately coarse (per-function, not per-kind) to keep the file
+    simple to audit; add a fresh line with a reason for every suppression.
+    """
+    entries = {}
+    if not os.path.isfile(path):
+        return entries
+    with open(path, "r", encoding="utf-8") as f:
+        for raw_line in f:
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if ":" not in line:
+                continue
+            name, reason = line.split(":", 1)
+            entries[name.strip()] = reason.strip()
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+def build_report(libs_root: str, oracle_root: str, whitelist_path: str):
+    # Pre-scan typedefs/aliases on both sides so the pointer/handle
+    # classifiers have full name sets before any signature is parsed.
+    global OUR_FNPTR_TYPEDEFS, ORACLE_PTR_ALIASES, OUR_HANDLE_TYPEDEFS
+    OUR_FNPTR_TYPEDEFS = scan_our_fnptr_typedefs(libs_root)
+    ORACLE_PTR_ALIASES = scan_oracle_ptr_aliases(oracle_root)
+    OUR_HANDLE_TYPEDEFS = scan_our_handle_typedefs(libs_root)
+
+    ours = extract_ours(libs_root)
+    theirs, name_to_module = extract_oracle(oracle_root)
+    whitelist = load_whitelist(whitelist_path)
+
+    mismatches = []
+    matched = []
+    ours_only = []
+    theirs_only = []
+
+    for name, our_sig in sorted(ours.items()):
+        their_sig = theirs.get(name)
+        if their_sig is None:
+            ours_only.append(our_sig)
+            continue
+        problems = diff_signatures(our_sig, their_sig)
+        if problems:
+            if name in whitelist:
+                continue
+            module = name_to_module.get(name, "?")
+            for kind, detail in problems:
+                mismatches.append(Mismatch(name, module, kind, detail, our_sig, their_sig))
+        else:
+            matched.append(name)
+
+    for name, their_sig in sorted(theirs.items()):
+        if name not in ours:
+            theirs_only.append(their_sig)
+
+    mismatches.sort(key=lambda m: (module_rank(m.module), m.name, m.kind))
+
+    return {
+        "ours_total": len(ours),
+        "theirs_total": len(theirs),
+        "matched": matched,
+        "mismatches": mismatches,
+        "ours_only": ours_only,
+        "theirs_only": theirs_only,
+        "whitelist": whitelist,
+    }
+
+
+def format_report(report: dict) -> str:
+    lines = []
+    lines.append("HLE ABI audit -- ours (libs/**/*.c) vs RPCS3 oracle (rpcs3/.../Modules/*.cpp)")
+    lines.append(f"functions parsed: ours={report['ours_total']}  RPCS3={report['theirs_total']}")
+    lines.append(f"name overlap checked: {len(report['matched']) + len({m.name for m in report['mismatches']})}")
+    lines.append(f"matched (ABI-compatible): {len(report['matched'])}")
+    lines.append(f"MISMATCHES: {len({m.name for m in report['mismatches']})} function(s), "
+                 f"{len(report['mismatches'])} finding(s)")
+    lines.append("")
+
+    if report["mismatches"]:
+        lines.append("=" * 78)
+        lines.append("MISMATCHES (grouped by module, boot-relevance order)")
+        lines.append("=" * 78)
+        current_module = None
+        for m in report["mismatches"]:
+            if m.module != current_module:
+                current_module = m.module
+                lines.append("")
+                lines.append(f"-- module: {current_module} --")
+            lines.append(f"[{m.kind}] {m.name}")
+            lines.append(f"    ours   : {m.ours.pretty()}")
+            lines.append(f"             ({m.ours.file}:{m.ours.line})")
+            lines.append(f"    RPCS3  : {m.theirs.pretty()}")
+            lines.append(f"             ({m.theirs.file}:{m.theirs.line})")
+            lines.append(f"    reason : {m.detail}")
+            lines.append("")
+    else:
+        lines.append("(no mismatches)")
+
+    lines.append("=" * 78)
+    lines.append(f"INFO: ours-only (RPCS3 doesn't implement/we couldn't match) = {len(report['ours_only'])}")
+    lines.append(f"INFO: RPCS3-only (we don't implement) = {len(report['theirs_only'])}")
+    lines.append("=" * 78)
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    here = os.path.dirname(os.path.abspath(__file__))
+    repo_root = os.path.dirname(here)
+    parser.add_argument("--libs", default=os.path.join(repo_root, "libs"),
+                         help="root of our HLE C sources (default: libs/)")
+    parser.add_argument("--oracle", default=os.path.join(repo_root, "rpcs3", "rpcs3", "Emu", "Cell", "Modules"),
+                         help="root of RPCS3's Modules/ (default: rpcs3/rpcs3/Emu/Cell/Modules)")
+    parser.add_argument("--whitelist", default=os.path.join(here, "hle_abi_audit_whitelist.txt"),
+                         help="known-benign name:reason list")
+    parser.add_argument("--json", default=None, help="also write a JSON report to this path")
+    args = parser.parse_args(argv)
+
+    if not os.path.isdir(args.libs):
+        print(f"error: libs root not found: {args.libs}", file=sys.stderr)
+        return 2
+    if not os.path.isdir(args.oracle):
+        print(f"error: oracle root not found: {args.oracle}", file=sys.stderr)
+        return 2
+
+    report = build_report(args.libs, args.oracle, args.whitelist)
+    print(format_report(report))
+
+    if args.json:
+        def sig_json(s: Signature) -> dict:
+            return {
+                "name": s.name,
+                "return_type": s.return_raw,
+                "params": [{"type": p.raw_type, "name": p.name} for p in s.params],
+                "file": s.file,
+                "line": s.line,
+            }
+
+        payload = {
+            "ours_total": report["ours_total"],
+            "theirs_total": report["theirs_total"],
+            "matched": report["matched"],
+            "mismatches": [
+                {
+                    "name": m.name,
+                    "module": m.module,
+                    "kind": m.kind,
+                    "detail": m.detail,
+                    "ours": sig_json(m.ours),
+                    "rpcs3": sig_json(m.theirs),
+                }
+                for m in report["mismatches"]
+            ],
+            "ours_only": [sig_json(s) for s in report["ours_only"]],
+            "theirs_only": [sig_json(s) for s in report["theirs_only"]],
+        }
+        with open(args.json, "w", encoding="utf-8", newline="\n") as f:
+            json.dump(payload, f, indent=2)
+            f.write("\n")
+
+    return 1 if report["mismatches"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/hle_abi_audit_whitelist.txt
+++ b/tools/hle_abi_audit_whitelist.txt
@@ -1,0 +1,12 @@
+# hle_abi_audit whitelist
+#
+# Format: function_name : free-text reason
+#
+# Each line suppresses ALL mismatch findings for that one function name.
+# Add an entry only after confirming (by reading both sides) that the
+# apparent mismatch is benign -- e.g. a deliberate, harmless simplification
+# that does not change observable guest behavior. Do NOT add an entry just
+# to silence a finding you haven't investigated; that defeats the tool.
+#
+# (kept intentionally sparse -- see the audit report for what was actually
+# investigated and why nothing is listed here yet)

--- a/tools/hle_dispatch_classify.py
+++ b/tools/hle_dispatch_classify.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""hle_dispatch_classify.py -- dispatch-layer classifier for hle_abi_audit.py.
+
+A raw libs/-vs-RPCS3 signature mismatch (as produced by hle_abi_audit.py) is
+only a *live* bug if the mismatched libs/ function is the one actually
+invoked at runtime. This tool reads a generated import-bridge table (a game
+project's mechanical NID -> function-pointer dispatch table, e.g. one
+produced by a `gen_imports.py`-style generator) with three dispatch layers
+per PS3 import NID: a `{ NID, fn, lle_opd }` bridge-table row (each with a
+`/* module::name */` trailing comment naming the PS3 export), where `fn` is
+either nullptr, an override-wrapper symbol, or a generated marshaling-wrapper
+symbol. The override/wrapper naming convention is game-project-specific and
+configurable via --imp-prefix/--ovr-prefix (default `yz_imp_`/`yz_ovr_`,
+this repo's own game project's convention -- see --bridges/--overrides for
+where its generated table lives):
+
+  1. fn == nullptr, lle_opd != 0
+         -> LLE-DISPATCHED: the call binds directly to a lifted-firmware
+            export OPD (Sony's own code, from recomp_prx/). The libs/ HLE
+            function of the same name, if any, is NEVER CALLED for this
+            import slot -- dead code for this dispatch path.
+  2. fn is a `<ovr-prefix><Name>` symbol (defined in --overrides)
+         -> OVERRIDE-WRAPPED: a hand-written wrapper shadows the libs/
+            function for this import slot. The override body may (a) call
+            the libs/ function of the same name internally (in which case
+            the libs/ signature still matters -- it's just marshaled
+            differently), or (b) be fully self-contained (the libs/
+            function, if it exists, is dead for this slot). Both sub-cases
+            are reported; see `override_calls_libs_fn`.
+  3. fn is `<imp-prefix><Name>` (the generated marshaling wrapper)
+         -> HLE-DISPATCHED: the generator's mechanical convention (verify
+            against your own --bridges file) is that `<imp-prefix><Name>`
+            ALWAYS calls the libs/ C function named `<Name>` directly (e.g.
+            with the default prefix, yz_imp_cellFsClose calls cellFsClose()
+            from libs/filesystem/cellFs.c). This is the one case where a
+            libs/ signature mismatch is a real, live ABI bug.
+  4. fn is `<imp-prefix>stub_<module>_<hex>`
+         -> HLE-DISPATCHED-STUB: a self-contained CELL_ENOSYS/CELL_OK stub
+            (confirmed by reading several bodies -- none call any libs/
+            function). Even if libs/ happens to have a same-named function,
+            it is NOT what runs for this slot -- folded into SHADOWED.
+  (not found in the bridge table at all)
+         -> UNKNOWN: this PS3 export is not in the game's import table, i.e.
+            not imported by this game build -- the mismatch, live or not,
+            can never fire.
+
+Ground-truth sanity check, this repo's own game project only (skipped, with
+a note, against any other --bridges file): cellGcmGetTiledPitchSize MUST
+classify as SHADOWED (LLE) -- see yakuza/import_bridges_gen.cpp:1864,
+`{ 0x010F3D2Cu, nullptr, 0x0210B944u }`.
+
+Stdlib-only, py -3, LF line endings, 4-space indent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+
+import hle_abi_audit as audit
+
+
+_IDENT = r"[A-Za-z_][A-Za-z0-9_]*"
+
+# One yz_imports[] table row, e.g.:
+#   { 0x010F3D2Cu, nullptr, 0x0210B944u }, /* cellGcmSys::cellGcmGetTiledPitchSize -> LLE */
+#   { 0x010F308Cu, yz_imp_cellFsClose, 0 }, /* sys_fs::cellFsClose */
+_BRIDGE_ROW_RE = re.compile(
+    r"\{\s*(?P<nid>0x[0-9A-Fa-f]+)u?\s*,\s*"
+    r"(?P<fn>nullptr|" + _IDENT + r")\s*,\s*"
+    r"(?P<lle>0x[0-9A-Fa-f]+|0)u?\s*\}\s*,"
+    r"\s*/\*\s*(?P<module>" + _IDENT + r")::(?P<name>" + _IDENT + r")\b"
+)
+
+def _ovr_def_re(ovr_prefix: str) -> re.Pattern:
+    """<ovr-prefix><Name> function bodies in --overrides, so we can test
+    whether an override delegates to the libs/ function of the same name."""
+    return re.compile(
+        r"^\s*(?:extern\s+\"C\"\s+)?(?:static\s+)?\w[\w\s\*]*?\b(?P<sym>"
+        + re.escape(ovr_prefix) + _IDENT + r")\s*\(\s*ppu_context\s*\*[^)]*\)\s*\{",
+        re.MULTILINE,
+    )
+
+
+@dataclass
+class DispatchInfo:
+    name: str                  # PS3 export name, e.g. "cellFsClose"
+    module: str                # e.g. "sys_fs"
+    nid: str
+    fn: str                    # "nullptr" | "yz_imp_X" | "yz_ovr_X" | "yz_imp_stub_..."
+    lle_opd: str
+    kind: str = ""             # "LLE-DISPATCHED" | "OVERRIDE-WRAPPED" | "HLE-DISPATCHED" | "HLE-DISPATCHED-STUB"
+    override_calls_libs_fn: object = None  # None (n/a) | True | False
+    all_rows: list = field(default_factory=list)  # every raw row seen for this name (dup NIDs)
+
+
+def _classify_row(fn: str, lle_opd: str, imp_prefix: str, ovr_prefix: str) -> str:
+    lle_nonzero = lle_opd not in ("0", "0x0", "0x00000000")
+    if fn == "nullptr":
+        if lle_nonzero:
+            return "LLE-DISPATCHED"
+        # fn==nullptr and lle==0 shouldn't occur in practice (unbound slot);
+        # keep a distinct label so it's visible rather than silently folded
+        # into another bucket.
+        return "UNBOUND-NULL"
+    if fn.startswith(ovr_prefix):
+        return "OVERRIDE-WRAPPED"
+    if fn.startswith(imp_prefix + "stub_"):
+        return "HLE-DISPATCHED-STUB"
+    if fn.startswith(imp_prefix):
+        return "HLE-DISPATCHED"
+    # Unrecognized naming convention -- don't silently misclassify.
+    return "UNRECOGNIZED-FN:" + fn
+
+
+def parse_bridge_table(bridges_path: str, imp_prefix: str, ovr_prefix: str) -> dict:
+    """Returns name -> DispatchInfo. If multiple rows share a name (a PS3
+    export imported into more than one library-linkage slot -- confirmed to
+    happen for a handful of sysPrxForUser sys_* functions, always with
+    matching dispatch across all rows), the rows are merged; a name whose
+    rows DISAGREE in dispatch kind is flagged (kind = "AMBIGUOUS:...") so it
+    is never silently misreported.
+    """
+    with open(bridges_path, "r", encoding="utf-8", errors="replace") as f:
+        text = f.read()
+
+    by_name: dict = {}
+    for m in _BRIDGE_ROW_RE.finditer(text):
+        name = m.group("name")
+        fn = m.group("fn")
+        lle = m.group("lle")
+        kind = _classify_row(fn, lle, imp_prefix, ovr_prefix)
+        row = (m.group("nid"), fn, lle, kind)
+        if name not in by_name:
+            by_name[name] = DispatchInfo(
+                name=name, module=m.group("module"), nid=m.group("nid"),
+                fn=fn, lle_opd=lle, kind=kind, all_rows=[row],
+            )
+        else:
+            info = by_name[name]
+            info.all_rows.append(row)
+            if info.kind != kind:
+                info.kind = f"AMBIGUOUS:{info.kind}+{kind}"
+    return by_name
+
+
+def scan_override_bodies(overrides_path: str, ovr_prefix: str) -> dict:
+    """Returns <ovr-prefix><Name> -> True/False: does the override body call
+    the libs/ C function `<Name>(...)` (same bare name, i.e. delegates to the
+    HLE impl the audit compared) or not (fully self-contained / calls a
+    DIFFERENT libs/ function / calls none)?
+
+    Method: slice each <ovr-prefix><Name> function body (brace-matched) and
+    search for a call to the identifier `<Name>` immediately followed by
+    '(' -- i.e. `Name(...)`, not `<ovr-prefix>Name(...)` or some other
+    symbol. This is a textual heuristic, not a semantic one -- labeled as
+    such in the report.
+    """
+    with open(overrides_path, "r", encoding="utf-8", errors="replace") as f:
+        text = f.read()
+    text_nc = re.sub(r"/\*.*?\*/", lambda mm: re.sub(r"[^\n]", " ", mm.group(0)), text, flags=re.DOTALL)
+    text_nc = re.sub(r"//[^\n]*", "", text_nc)
+
+    result = {}
+    for m in _ovr_def_re(ovr_prefix).finditer(text_nc):
+        sym = m.group("sym")
+        bare_name = sym[len(ovr_prefix):]
+        # one-line body (has both { and } on this match line's tail) --
+        # find_matching_brace handles both one-liners and multi-line.
+        open_brace = text_nc.find("{", m.end() - 1)
+        if open_brace == -1:
+            continue
+        close_brace = audit.find_matching_brace(text_nc, open_brace)
+        body = text_nc[open_brace:close_brace + 1]
+        call_re = re.compile(r"(?<![A-Za-z0-9_])" + re.escape(bare_name) + r"\s*\(")
+        result[bare_name] = bool(call_re.search(body))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Bucketing
+# ---------------------------------------------------------------------------
+
+BUCKET_LIVE = "LIVE"
+BUCKET_SHADOWED = "SHADOWED"
+BUCKET_UNKNOWN = "UNKNOWN"
+
+
+def bucket_for(name: str, dispatch: dict, override_delegates: dict) -> tuple:
+    """Returns (bucket, reason_str, dispatch_info_or_None)."""
+    info = dispatch.get(name)
+    if info is None:
+        return BUCKET_UNKNOWN, "not present in yakuza/import_bridges_gen.cpp yz_imports[] -- not imported by this game build", None
+
+    kind = info.kind
+    if kind == "LLE-DISPATCHED":
+        return BUCKET_SHADOWED, f"LLE-DISPATCHED: NID {info.nid} binds to lifted-firmware OPD {info.lle_opd}; libs/ impl never called", info
+    if kind == "HLE-DISPATCHED-STUB":
+        return BUCKET_SHADOWED, f"HLE-DISPATCHED-STUB: import slot runs a self-contained CELL_ENOSYS/CELL_OK stub ({info.fn}), not the libs/ function", info
+    if kind == "OVERRIDE-WRAPPED":
+        delegates = override_delegates.get(name)
+        if delegates is True:
+            return BUCKET_LIVE, f"OVERRIDE-WRAPPED but override {info.fn} DELEGATES to libs/ {name}(...) internally -- libs/ signature still reachable (mismatch may still be live, just via the override's own marshaling)", info
+        elif delegates is False:
+            return BUCKET_SHADOWED, f"OVERRIDE-WRAPPED: {info.fn} is self-contained (does not call libs/ {name}); libs/ impl bypassed", info
+        else:
+            return BUCKET_SHADOWED, f"OVERRIDE-WRAPPED: {info.fn} shadows this slot (override body not found to confirm delegation -- treated conservatively as shadowing)", info
+    if kind == "HLE-DISPATCHED":
+        return BUCKET_LIVE, f"HLE-DISPATCHED: import slot's {info.fn} calls libs/ {name}(...) directly (gen_imports.py mechanical convention)", info
+    if kind.startswith("AMBIGUOUS"):
+        return BUCKET_UNKNOWN, f"AMBIGUOUS dispatch across duplicate NIDs for this name ({kind}) -- rows: {info.all_rows}", info
+    if kind == "UNBOUND-NULL":
+        return BUCKET_UNKNOWN, "fn==nullptr but lle_opd==0 (unbound slot) -- not a normal dispatch state", info
+    return BUCKET_UNKNOWN, f"unrecognized dispatch shape: {kind}", info
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+def build_classified_report(libs_root: str, oracle_root: str, whitelist_path: str,
+                             bridges_path: str, overrides_path: str,
+                             imp_prefix: str, ovr_prefix: str) -> dict:
+    base = audit.build_report(libs_root, oracle_root, whitelist_path)
+    dispatch = parse_bridge_table(bridges_path, imp_prefix, ovr_prefix)
+    override_delegates = scan_override_bodies(overrides_path, ovr_prefix)
+
+    # One classification per function NAME (a name can have multiple
+    # mismatch findings/"kinds"; the dispatch classification is per-name,
+    # not per-finding).
+    names = sorted({m.name for m in base["mismatches"]})
+    classified = {}
+    for name in names:
+        bucket, reason, info = bucket_for(name, dispatch, override_delegates)
+        classified[name] = (bucket, reason, info)
+
+    live_names = [n for n in names if classified[n][0] == BUCKET_LIVE]
+    shadowed_names = [n for n in names if classified[n][0] == BUCKET_SHADOWED]
+    unknown_names = [n for n in names if classified[n][0] == BUCKET_UNKNOWN]
+
+    return {
+        "base": base,
+        "dispatch": dispatch,
+        "override_delegates": override_delegates,
+        "classified": classified,
+        "live_names": live_names,
+        "shadowed_names": shadowed_names,
+        "unknown_names": unknown_names,
+    }
+
+
+def _imported(name: str, dispatch: dict) -> bool:
+    return name in dispatch
+
+
+def format_classified_report(rep: dict) -> str:
+    lines = []
+    base = rep["base"]
+    classified = rep["classified"]
+
+    lines.append("=" * 78)
+    lines.append("DISPATCH-LAYER CLASSIFICATION of hle_abi_audit.py mismatches")
+    lines.append("=" * 78)
+    lines.append(f"total mismatched functions (raw, all buckets): "
+                 f"{len({m.name for m in base['mismatches']})}")
+    lines.append(f"  LIVE       (HLE-dispatched, real signature mismatch): {len(rep['live_names'])}")
+    lines.append(f"  SHADOWED   (LLE-dispatched or override-bypassed, libs/ dead for this slot): {len(rep['shadowed_names'])}")
+    lines.append(f"  UNKNOWN    (not in yz_imports[] / ambiguous dispatch): {len(rep['unknown_names'])}")
+    lines.append("")
+
+    # Sanity check the task explicitly asks for.
+    sanity_name = "cellGcmGetTiledPitchSize"
+    if sanity_name in classified:
+        bucket, reason, info = classified[sanity_name]
+        lines.append(f"SANITY CHECK: {sanity_name} -> {bucket}  ({reason})")
+        lines.append("  PASS (expected SHADOWED/LLE)" if bucket == BUCKET_SHADOWED else "  *** FAIL: expected SHADOWED -- classifier is WRONG ***")
+    else:
+        lines.append(f"SANITY CHECK: {sanity_name} not found among mismatches (no ABI mismatch flagged for it currently)")
+    lines.append("")
+
+    # ---- LIVE bug list ----
+    lines.append("=" * 78)
+    lines.append("LIVE bugs (HLE-dispatched; libs/ signature mismatch is real)")
+    lines.append("=" * 78)
+    mism_by_name: dict = {}
+    for m in base["mismatches"]:
+        mism_by_name.setdefault(m.name, []).append(m)
+
+    for name in sorted(rep["live_names"], key=lambda n: (audit.module_rank(mism_by_name[n][0].module), n)):
+        bucket, reason, info = classified[name]
+        imported = _imported(name, rep["dispatch"])
+        ms = mism_by_name[name]
+        lines.append("")
+        lines.append(f"-- {name} (module {ms[0].module}) --  imported={imported}")
+        lines.append(f"   dispatch: {reason}")
+        for m in ms:
+            lines.append(f"   [{m.kind}] ours: {m.ours.pretty()}")
+            lines.append(f"             ({m.ours.file}:{m.ours.line})")
+            lines.append(f"             RPCS3: {m.theirs.pretty()}")
+            lines.append(f"             ({m.theirs.file}:{m.theirs.line})")
+            lines.append(f"             reason: {m.detail}")
+    lines.append("")
+
+    # ---- SHADOWED examples (prove classifier works) ----
+    lines.append("=" * 78)
+    lines.append("SHADOWED examples (first 15, incl. cellGcm* sanity set)")
+    lines.append("=" * 78)
+    shown = 0
+    gcm_shown = []
+    others_shown = []
+    for name in rep["shadowed_names"]:
+        bucket, reason, info = classified[name]
+        if name.startswith("cellGcm") and len(gcm_shown) < 6:
+            gcm_shown.append((name, reason))
+        elif len(others_shown) < 9:
+            others_shown.append((name, reason))
+    for name, reason in gcm_shown + others_shown:
+        lines.append(f"  {name}: {reason}")
+    lines.append("")
+
+    # ---- UNKNOWN ----
+    lines.append("=" * 78)
+    lines.append(f"UNKNOWN ({len(rep['unknown_names'])}) -- not imported by this game build, or ambiguous")
+    lines.append("=" * 78)
+    for name in rep["unknown_names"][:20]:
+        bucket, reason, info = classified[name]
+        lines.append(f"  {name}: {reason}")
+    if len(rep["unknown_names"]) > 20:
+        lines.append(f"  ... and {len(rep['unknown_names']) - 20} more")
+
+    return "\n".join(lines)
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    here = os.path.dirname(os.path.abspath(__file__))
+    repo_root = os.path.dirname(here)
+    parser.add_argument("--libs", default=os.path.join(repo_root, "libs"))
+    parser.add_argument("--oracle", default=os.path.join(repo_root, "rpcs3", "rpcs3", "Emu", "Cell", "Modules"))
+    parser.add_argument("--whitelist", default=os.path.join(here, "hle_abi_audit_whitelist.txt"))
+    parser.add_argument("--bridges", default=os.path.join(repo_root, "yakuza", "import_bridges_gen.cpp"))
+    parser.add_argument("--overrides", default=os.path.join(repo_root, "yakuza", "import_overrides.cpp"))
+    parser.add_argument("--imp-prefix", default="yz_imp_",
+                         help="generated marshaling-wrapper symbol prefix in "
+                              "--bridges (default: yz_imp_, this repo's own "
+                              "game project's convention)")
+    parser.add_argument("--ovr-prefix", default="yz_ovr_",
+                         help="hand-written override-wrapper symbol prefix in "
+                              "--bridges/--overrides (default: yz_ovr_, this "
+                              "repo's own game project's convention)")
+    args = parser.parse_args(argv)
+
+    for p in (args.libs, args.oracle):
+        if not os.path.isdir(p):
+            print(f"error: not found: {p}", file=sys.stderr)
+            return 2
+    for p in (args.bridges, args.overrides):
+        if not os.path.isfile(p):
+            print(f"error: not found: {p}", file=sys.stderr)
+            return 2
+
+    rep = build_classified_report(args.libs, args.oracle, args.whitelist, args.bridges,
+                                   args.overrides, args.imp_prefix, args.ovr_prefix)
+    print(format_classified_report(rep))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/lift_audit.py
+++ b/tools/lift_audit.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python3
+"""PPU lift-structure census + relift regression diff.
+
+Purpose: the structure bug class (map gaps, stubbed jump-table dispatchers,
+fall-throughs, unresolved indirect targets -- boot blockers #6/#8/#14/#19b
+were THIS class) has no static sweep. This tool runs three census passes
+over the CURRENT relift output and the static function map, then diffs the
+totals against a saved baseline so a NEW structure anomaly is flagged the
+day a relift creates it.
+
+NOTE (spec correction, verified on disk 2026-07-05): a single
+`recomp/ppu_recomp.c` was assumed. That file does not exist -- the lifter
+emits 20 chunk files `recomp/ppu_recomp_000.cpp .. ppu_recomp_019.cpp` (see
+ppu_lifter.py's write_source_files / the stale-.c cleanup at its main(),
+~line 3037-3048). This tool globs `recomp/ppu_recomp_*.cpp` instead. recomp/
+is READ-ONLY here -- never edited.
+
+Three census passes:
+
+1. Marker census -- counts `/* TODO: <mn> ... */` emissions (grouped by
+   mnemonic) and `/* unresolved target 0x... */` stub emissions, by reading
+   the generated chunk files directly (this is what actually shipped, not
+   what the lifter *would* emit -- catches drift between the two).
+   Marker strings are emitted at exactly two call sites in ppu_lifter.py:
+     - line 2176: `return f"/* TODO: {mn} {insn.operands} */;"`
+       (the catch-all default for any mnemonic with no dedicated handler;
+       `.word` -- ppu_disasm.py's own "unknown opcode" fallback, line 1077 --
+       reaches this same site since the lifter has no special-case for it,
+       so ".word" TODOs and "real" unhandled-instruction TODOs are
+       distinguished here only by mnemonic grouping, matching the lifter's
+       own word_todos/insn_todos split at ppu_lifter.py ~line 3050-3066).
+     - line 2568: `f"/* unresolved target 0x{target:08X} */"` inside
+       _stub_and_table_lines() (no-op stub bodies for call/branch targets
+       that resolved to no lifted function and aren't in --extern-funcs).
+
+2. Fall-through census -- absorbs scratch/fallthrough_sweep.py's logic
+   in-place (same terminator test, same map-gap definition) rather than
+   shelling out, so this tool has zero external-script dependencies.
+
+3. Target coverage -- decodes every executable word of game/EBOOT.elf via
+   the SAME PT_LOAD/PF_X segment walk ppu_lifter.py's main() uses (reusing
+   tools/elf_parser.py + tools/ppu_disasm.py, never re-parsing the ELF by
+   hand), collects all unconditional-transfer targets (b/bl/ba/bla -- PPC
+   opcode 18, see ppu_disasm.py decode() ~line 151), and buckets each target
+   as:
+     - COVERED    -- falls inside some functions.json [start, end) entry
+     - GAP        -- outside every entry (a "gap target")
+     - MID-FUNC   -- inside an entry but not equal to its start (a split
+                     candidate: the lifter's mid-function-entry discovery
+                     pass, ppu_lifter.py ~line 3011-3029, is expected to
+                     absorb most of these -- this pass reports them as an
+                     independent cross-check of that mechanism, not a
+                     duplicate of it).
+
+CLI:
+    py -3 tools\\lift_audit.py [--elf game\\EBOOT.elf]
+                                [--functions functions.json]
+                                [--recomp-dir recomp]
+                                [--baseline scratch\\lift_audit_baseline.txt]
+                                [--update-baseline]
+
+--elf/--functions/--recomp-dir default to the repo-root game/EBOOT.elf,
+functions.json, and recomp/ paths respectively, but are overridable so this
+tool works against any relift target, not just this repo's checked-in game.
+
+Default mode prints the full census, then diffs summary counts against the
+baseline file. A NEW anomaly (a count that INCREASED, or a newly-appeared
+group key with nonzero count) vs baseline is a FAIL (nonzero exit). Counts
+that only decreased, or are unchanged, are fine. --update-baseline writes the
+current census as the new baseline and exits 0 without diffing.
+
+Evidence discipline: this is a pure static census over files that exist on
+disk at run time (recomp/*.cpp, functions.json, game/EBOOT.elf) -- every
+number printed is MEASURED from those files in this run, not inferred.
+"""
+import argparse
+import glob
+import os
+import re
+import struct
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.abspath(os.path.join(HERE, ".."))
+
+sys.path.insert(0, HERE)
+try:
+    from ppu_disasm import decode, disassemble_bytes  # noqa: E402
+    from elf_parser import ELFFile, PT_LOAD  # noqa: E402
+except ImportError as exc:
+    print(f"Error: could not import ppu_disasm/elf_parser from {HERE}: {exc}",
+          file=sys.stderr)
+    sys.exit(1)
+
+DEFAULT_BASELINE = os.path.join(ROOT, "scratch", "lift_audit_baseline.txt")
+
+TODO_RE = re.compile(r"/\* TODO: (\S+)")
+UNRESOLVED_RE = re.compile(r"/\* unresolved target 0x([0-9A-Fa-f]+) \*/")
+
+
+# ---------------------------------------------------------------------------
+# Pass 1: marker census (reads the generated chunk .cpp files as-shipped)
+# ---------------------------------------------------------------------------
+
+def marker_census(recomp_dir: str):
+    """Scan <recomp_dir>/ppu_recomp_*.cpp for the two marker emit sites.
+
+    Grouping: /* TODO: <mn> ... */ by mnemonic (mn is the first whitespace
+    token after "TODO: ", matching ppu_lifter.py line 2176's f-string
+    exactly: "{mn} {insn.operands}"). /* unresolved target 0x... */ has no
+    sub-grouping in the source (ppu_lifter.py line 2568 emits one per
+    address) -- reported as a single reason bucket "unresolved-call-or-
+    branch-target" with the total count and sample addresses.
+    """
+    chunk_paths = sorted(glob.glob(os.path.join(recomp_dir, "ppu_recomp_*.cpp")))
+    if not chunk_paths:
+        print(f"ERROR: no {recomp_dir}/ppu_recomp_*.cpp chunk files found -- "
+              "has the project ever been relifted? (the recomp output dir is "
+              "generated, never hand-edited; run tools/ppu_lifter.py first)",
+              file=sys.stderr)
+        sys.exit(2)
+
+    todo_by_mnemonic: dict[str, int] = {}
+    unresolved_addrs: list[int] = []
+
+    for path in chunk_paths:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                if "/* TODO:" in line:
+                    m = TODO_RE.search(line)
+                    if m:
+                        mn = m.group(1)
+                        todo_by_mnemonic[mn] = todo_by_mnemonic.get(mn, 0) + 1
+                elif "/* unresolved target" in line:
+                    m = UNRESOLVED_RE.search(line)
+                    if m:
+                        unresolved_addrs.append(int(m.group(1), 16))
+
+    return chunk_paths, todo_by_mnemonic, unresolved_addrs
+
+
+# ---------------------------------------------------------------------------
+# Pass 2: fall-through census (absorbs scratch/fallthrough_sweep.py in-place)
+# ---------------------------------------------------------------------------
+
+def _load_functions_json(functions_path: str):
+    import json
+    with open(functions_path) as f:
+        funcs = json.load(f)
+    return sorted((int(str(e["start"]), 0), int(str(e["end"]), 0)) for e in funcs)
+
+
+def _is_terminator_word(w: int) -> bool:
+    """Same terminator test as scratch/fallthrough_sweep.py's is_terminator():
+    unconditional b/ba (opcode 18, LK=0) or unconditional blr/bctr (opcode 19,
+    XO 16/528, LK=0, BO unconditional bits bo&0x14==0x14). sc (opcode 17)
+    returns control to the caller via the syscall path, so it is NOT treated
+    as a terminator (matches the sweep script: falls through)."""
+    op = w >> 26
+    if op == 18 and not (w & 1):
+        return True
+    if op == 19:
+        xo = (w >> 1) & 0x3FF
+        bo = (w >> 21) & 0x1F
+        if xo in (16, 528) and not (w & 1) and (bo & 0x14) == 0x14:
+            return True
+    return False
+
+
+def fallthrough_census(elf_data: bytes, functions_path: str):
+    entries = _load_functions_json(functions_path)
+
+    def word(addr):
+        off = addr - 0x10000
+        return struct.unpack(">I", elf_data[off:off + 4])[0]
+
+    hazards = []
+    gap_followed = 0
+    for i, (start, end) in enumerate(entries):
+        nxt = entries[i + 1][0] if i + 1 < len(entries) else None
+        if nxt is None or end == nxt:
+            continue
+        gap_followed += 1
+        last = word(end - 4)
+        if _is_terminator_word(last):
+            continue
+        hazards.append((start, end, nxt, last))
+
+    return entries, gap_followed, hazards
+
+
+# ---------------------------------------------------------------------------
+# Pass 3: target coverage (decode all executable words, bucket b/bl targets)
+# ---------------------------------------------------------------------------
+
+def _executable_instructions(elf_path: str):
+    """Same PT_LOAD/PF_X segment walk as ppu_lifter.py main() (~line 2840-
+    2857): decode every executable segment's words via disassemble_bytes.
+    Falls back to the first non-empty PT_LOAD segment if none are marked
+    executable (mirrors the lifter's own fallback), matching its behavior
+    exactly rather than reimplementing a heuristic."""
+    elf = ELFFile(elf_path)
+    elf.load()
+    big_endian = elf.elf_header.big_endian
+    all_insns = []
+    for idx, ph in enumerate(elf.program_headers):
+        if ph.p_type == PT_LOAD and (ph.p_flags & 1):
+            seg_data = elf.get_segment_data(idx)
+            all_insns.extend(disassemble_bytes(seg_data, ph.p_vaddr, big_endian))
+    if not all_insns:
+        for idx, ph in enumerate(elf.program_headers):
+            if ph.p_type == PT_LOAD and ph.p_filesz > 0:
+                seg_data = elf.get_segment_data(idx)
+                all_insns.extend(disassemble_bytes(seg_data, ph.p_vaddr, big_endian))
+                break
+    return all_insns
+
+
+def target_coverage_census(elf_path: str, entries: list[tuple[int, int]]):
+    """Decode all executable words; collect unconditional-transfer (b/bl/
+    ba/bla) targets; bucket vs functions.json coverage.
+
+    Unconditional transfer = PPC opcode 18 forms (mnemonic starts with 'b',
+    produced only by the opcd==18 branch in ppu_disasm.py decode() ~line
+    151: mnemonics "b"/"bl"/"ba"/"bla"). Conditional branches (opcode 16) and
+    CTR/LR-indirect forms are excluded -- their targets are either runtime-
+    resolved (not statically knowable) or already covered as conditional
+    in-function gotos by the lifter.
+    """
+    starts = sorted(s for s, _ in entries)
+    import bisect
+
+    def bucket(target: int) -> str:
+        i = bisect.bisect_right(starts, target) - 1
+        if i < 0:
+            return "GAP"
+        s, e = entries_by_start[starts[i]]
+        if s <= target < e:
+            return "COVERED" if target == s else "MID-FUNC"
+        return "GAP"
+
+    entries_by_start = {}
+    for s, e in entries:
+        # keep the widest/last end if duplicate starts exist (shouldn't, but
+        # be defensive rather than silently dropping data)
+        if s not in entries_by_start or e > entries_by_start[s][1]:
+            entries_by_start[s] = (s, e)
+    starts = sorted(entries_by_start.keys())
+
+    insns = _executable_instructions(elf_path)
+    total_words = len(insns)
+
+    targets: set[int] = set()
+    for insn in insns:
+        mn = insn.mnemonic
+        if mn in ("b", "bl", "ba", "bla"):
+            try:
+                targets.add(int(insn.operands, 16) & 0xFFFFFFFF)
+            except ValueError:
+                continue
+
+    gap_targets = []
+    midfunc_targets = []
+    for t in sorted(targets):
+        b = bucket(t)
+        if b == "GAP":
+            gap_targets.append(t)
+        elif b == "MID-FUNC":
+            midfunc_targets.append(t)
+
+    return total_words, len(targets), gap_targets, midfunc_targets
+
+
+# ---------------------------------------------------------------------------
+# Report formatting + baseline diff
+# ---------------------------------------------------------------------------
+
+def build_report(chunk_paths, todo_by_mnemonic, unresolved_addrs,
+                  fn_entries, gap_followed, ft_hazards,
+                  total_words, total_targets, gap_targets, midfunc_targets):
+    lines = []
+    lines.append("=== Pass 1: marker census (recomp/ppu_recomp_*.cpp, %d chunks) ==="
+                  % len(chunk_paths))
+    total_todo = sum(todo_by_mnemonic.values())
+    lines.append(f"TOTAL /* TODO: ... */ markers: {total_todo}")
+    word_todos = todo_by_mnemonic.get(".word", 0)
+    insn_todos = total_todo - word_todos
+    lines.append(f"  .word (data-in-text, KNOWN/harmless): {word_todos}")
+    lines.append(f"  other unhandled-instruction TODOs:    {insn_todos}")
+    lines.append("  by mnemonic (desc count):")
+    for mn, cnt in sorted(todo_by_mnemonic.items(), key=lambda kv: (-kv[1], kv[0])):
+        lines.append(f"    {mn:<12s} {cnt}")
+    lines.append(f"TOTAL /* unresolved target 0x... */ markers: {len(unresolved_addrs)}")
+    if unresolved_addrs:
+        sample = ", ".join(f"0x{a:08X}" for a in sorted(unresolved_addrs)[:10])
+        lines.append(f"  sample addresses: {sample}"
+                      + (" ..." if len(unresolved_addrs) > 10 else ""))
+    lines.append("")
+
+    lines.append("=== Pass 2: fall-through census (functions.json vs game/EBOOT.elf) ===")
+    lines.append(f"map entries: {len(fn_entries)}")
+    lines.append(f"entries followed by a gap: {gap_followed}")
+    lines.append(f"FALL-THROUGH-INTO-GAP hazards: {len(ft_hazards)}")
+    limit = 40
+    for s, e, n, w in ft_hazards[:limit]:
+        lines.append(f"  func {s:#010x}  end {e:#010x}  next-mapped {n:#010x}  "
+                      f"gap {n - e:#x}  last-insn {w:08X}")
+    if len(ft_hazards) > limit:
+        lines.append(f"  ... {len(ft_hazards) - limit} more")
+    lines.append("")
+
+    lines.append("=== Pass 3: target coverage (b/bl/ba/bla targets vs functions.json) ===")
+    lines.append(f"executable words decoded: {total_words}")
+    lines.append(f"unique unconditional-transfer targets: {total_targets}")
+    lines.append(f"GAP targets (outside any functions.json entry): {len(gap_targets)}")
+    for t in gap_targets[:40]:
+        lines.append(f"    0x{t:08X}")
+    if len(gap_targets) > 40:
+        lines.append(f"    ... {len(gap_targets) - 40} more")
+    lines.append(f"MID-FUNC targets (split candidates, inside an entry but != start): "
+                  f"{len(midfunc_targets)}")
+    for t in midfunc_targets[:40]:
+        lines.append(f"    0x{t:08X}")
+    if len(midfunc_targets) > 40:
+        lines.append(f"    ... {len(midfunc_targets) - 40} more")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def build_baseline_dict(todo_by_mnemonic, unresolved_addrs, ft_hazards,
+                         gap_targets, midfunc_targets):
+    """Flat key->count dict used for baseline persistence + diffing. Only
+    SUMMARY counts are diffed (not full address lists) -- new counts higher
+    than baseline are FAIL; the full lists are for human triage in the
+    printed report, not baseline-tracked line by line (address sets shift
+    harmlessly with unrelated relifts; count regressions are the signal)."""
+    d = {}
+    for mn, cnt in todo_by_mnemonic.items():
+        d[f"todo_mnemonic:{mn}"] = cnt
+    d["unresolved_targets_total"] = len(unresolved_addrs)
+    d["fallthrough_hazards_total"] = len(ft_hazards)
+    d["gap_targets_total"] = len(gap_targets)
+    d["midfunc_targets_total"] = len(midfunc_targets)
+    return d
+
+
+def write_baseline(path, d):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8", newline="\n") as f:
+        f.write("# lift_audit.py baseline -- generated file, do not hand-edit.\n")
+        f.write("# key<TAB>count, one per line, sorted by key.\n")
+        for k in sorted(d.keys()):
+            f.write(f"{k}\t{d[k]}\n")
+
+
+def read_baseline(path):
+    if not os.path.exists(path):
+        return None
+    d = {}
+    # utf-8-sig: tolerate a BOM if the file was ever touched by a BOM-adding
+    # editor/tool (this tool's own writer never adds one, but baseline files
+    # are plain text and easy to corrupt by hand on Windows).
+    with open(path, "r", encoding="utf-8-sig") as f:
+        for line in f:
+            line = line.rstrip("\r\n")
+            if not line or line.startswith("#"):
+                continue
+            k, _, v = line.partition("\t")
+            v = v.strip()
+            if not v:
+                continue
+            d[k] = int(v)
+    return d
+
+
+def diff_against_baseline(current: dict, baseline: dict) -> tuple[list[str], bool]:
+    """Returns (report_lines, has_new_anomaly). A NEW anomaly = a key whose
+    count increased vs baseline, or a key with nonzero count that is absent
+    from baseline entirely. Decreases and unchanged counts are fine."""
+    lines = []
+    fail = False
+    all_keys = sorted(set(current) | set(baseline))
+    any_diff = False
+    for k in all_keys:
+        cur = current.get(k, 0)
+        base = baseline.get(k, 0)
+        if cur == base:
+            continue
+        any_diff = True
+        if k not in baseline and cur > 0:
+            lines.append(f"  NEW key {k}: {cur} (not in baseline) -- FAIL")
+            fail = True
+        elif cur > base:
+            lines.append(f"  INCREASE {k}: {base} -> {cur} (+{cur - base}) -- FAIL")
+            fail = True
+        else:
+            lines.append(f"  decrease {k}: {base} -> {cur} ({cur - base}) -- ok")
+    if not any_diff:
+        lines.append("  (no diff vs baseline)")
+    return lines, fail
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                  formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--elf", default=os.path.join(ROOT, "game", "EBOOT.elf"),
+                     help="target ELF to census (default: repo-root game/EBOOT.elf)")
+    ap.add_argument("--functions", default=os.path.join(ROOT, "functions.json"),
+                     help="function boundary table (default: repo-root functions.json)")
+    ap.add_argument("--recomp-dir", default=os.path.join(ROOT, "recomp"),
+                     help="generated recomp output dir to scan (default: repo-root recomp/)")
+    ap.add_argument("--baseline", default=DEFAULT_BASELINE,
+                     help=f"baseline file path (default: {DEFAULT_BASELINE})")
+    ap.add_argument("--update-baseline", action="store_true",
+                     help="write current census as the new baseline and exit "
+                          "(no diff performed)")
+    args = ap.parse_args()
+
+    elf_path = args.elf
+    if not os.path.exists(elf_path):
+        print(f"ERROR: {elf_path} not found", file=sys.stderr)
+        sys.exit(2)
+    with open(elf_path, "rb") as f:
+        elf_data = f.read()
+
+    chunk_paths, todo_by_mnemonic, unresolved_addrs = marker_census(args.recomp_dir)
+    fn_entries, gap_followed, ft_hazards = fallthrough_census(elf_data, args.functions)
+    total_words, total_targets, gap_targets, midfunc_targets = \
+        target_coverage_census(elf_path, fn_entries)
+
+    report = build_report(chunk_paths, todo_by_mnemonic, unresolved_addrs,
+                           fn_entries, gap_followed, ft_hazards,
+                           total_words, total_targets, gap_targets, midfunc_targets)
+    print(report)
+
+    current = build_baseline_dict(todo_by_mnemonic, unresolved_addrs, ft_hazards,
+                                   gap_targets, midfunc_targets)
+
+    if args.update_baseline:
+        write_baseline(args.baseline, current)
+        print(f"=== Baseline written: {args.baseline} ({len(current)} keys) ===")
+        sys.exit(0)
+
+    baseline = read_baseline(args.baseline)
+    if baseline is None:
+        print(f"=== No baseline at {args.baseline} -- run with --update-baseline "
+              f"to seed one. Skipping diff. ===")
+        sys.exit(0)
+
+    print(f"=== Diff vs baseline ({args.baseline}) ===")
+    diff_lines, fail = diff_against_baseline(current, baseline)
+    for ln in diff_lines:
+        print(ln)
+
+    if fail:
+        print("=== FAIL: new structure anomaly vs baseline ===")
+        sys.exit(1)
+    print("=== PASS: no new anomaly vs baseline ===")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ppu_disasm.py
+++ b/tools/ppu_disasm.py
@@ -1137,6 +1137,10 @@ def main() -> None:
                         help="Start offset within file (for raw mode)")
     parser.add_argument("--length", type=lambda x: int(x, 0), default=0,
                         help="Number of bytes to disassemble (0=all)")
+    parser.add_argument("--va", type=lambda x: int(x, 0), default=None,
+                        help="Virtual address to disassemble (ELF: maps va->file via PT_LOAD segments; "
+                             "use with --length). Correct alternative to --raw --offset, which treats "
+                             "--offset as a raw FILE offset (off by the segment base).")
     parser.add_argument("--little-endian", action="store_true",
                         help="Decode as little-endian")
     args = parser.parse_args()
@@ -1146,6 +1150,28 @@ def main() -> None:
 
     big_endian = not args.little_endian
     base_addr = args.base
+
+    # --va: disassemble a window at a VIRTUAL address, mapping va->file offset through the ELF's
+    # PT_LOAD segments (fixes the long-standing footgun where --raw --offset <vaddr> read the wrong
+    # bytes because --offset is a file offset, off by the .text segment base e.g. 0x10000).
+    if args.va is not None:
+        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        from elf_parser import ELFFile, PT_LOAD
+        elf = ELFFile(args.input); elf.load()
+        big_endian = elf.elf_header.big_endian
+        va = args.va; seg = None
+        for ph in elf.program_headers:
+            if ph.p_type == PT_LOAD and ph.p_vaddr <= va < ph.p_vaddr + ph.p_filesz:
+                seg = ph; break
+        if seg is None:
+            print(f"Error: vaddr 0x{va:08X} not in any PT_LOAD file-backed range", file=sys.stderr)
+            sys.exit(1)
+        file_off = seg.p_offset + (va - seg.p_vaddr)
+        n = args.length or 0x40
+        data = file_data[file_off:file_off + n]
+        for i in disassemble_bytes(data, va, big_endian):
+            print(i)
+        return
 
     if args.raw:
         data = file_data[args.offset:]

--- a/tools/ppu_disasm.py
+++ b/tools/ppu_disasm.py
@@ -251,7 +251,7 @@ def decode(insn: int, addr: int = 0) -> Instruction:
         bb = bits(insn, 16, 20)
         cr_ops = {
             257: "crand", 449: "cror", 193: "crxor",
-            33: "crnand", 225: "crnor", 289: "creqv",
+            33: "crnor", 225: "crnand", 289: "creqv",
             129: "crandc", 417: "crorc",
             0: "mcrf",
         }

--- a/tools/ppu_lifter.py
+++ b/tools/ppu_lifter.py
@@ -116,6 +116,14 @@ SOURCE_PREAMBLE = """\
 #include <string.h>
 #include <math.h>
 
+/* The guest timebase (mftb/mftbu): one global monotonic clock scaled to the
+ * PS3's 79.8 MHz, provided by the runtime (runtime/syscalls/sys_timer.c). */
+#ifdef __cplusplus
+extern "C" uint64_t ppu_timebase_now(void);
+#else
+extern uint64_t ppu_timebase_now(void);
+#endif
+
 /* MSVC compatibility helpers */
 #ifdef _MSC_VER
 #include <intrin.h>
@@ -123,12 +131,17 @@ SOURCE_PREAMBLE = """\
  * redefining them is a hard error there -- only polyfill for real MSVC. */
 #ifndef __clang__
 static inline int __builtin_clz(unsigned int x) {
+    /* BSR leaves the index undefined for x==0; PowerPC cntlzw(0) is DEFINED
+     * as 32. Without the guard this returned 31 minus an uninitialized
+     * index for zero inputs. */
     unsigned long idx;
+    if (!x) return 32;
     _BitScanReverse(&idx, x);
     return 31 - (int)idx;
 }
 static inline int __builtin_clzll(unsigned long long x) {
     unsigned long idx;
+    if (!x) return 64;
     _BitScanReverse64(&idx, x);
     return 63 - (int)idx;
 }
@@ -503,16 +516,25 @@ class PPULifter:
             return f"ctx->gpr[{rd}] = (int64_t)(int32_t)((uint32_t){_imm(ops[1])} << 16);"
 
         if mn == "addi":
+            # Full 64-bit add (PowerISA): truncating to 32 bits corrupts any
+            # 64-bit pointer/counter arithmetic built with addi.
             rd, ra = _reg_idx(ops[0]), _reg_idx(ops[1])
-            return f"ctx->gpr[{rd}] = (int64_t)(int32_t)(ctx->gpr[{ra}] + {_imm(ops[2])});"
+            return f"ctx->gpr[{rd}] = ctx->gpr[{ra}] + (int64_t)({_imm(ops[2])});"
 
         if mn == "addis":
+            # 64-bit add of the sign-extended (imm << 16).
             rd, ra = _reg_idx(ops[0]), _reg_idx(ops[1])
-            return f"ctx->gpr[{rd}] = (int64_t)(int32_t)(ctx->gpr[{ra}] + ((uint32_t){_imm(ops[2])} << 16));"
+            return (f"ctx->gpr[{rd}] = ctx->gpr[{ra}] + "
+                    f"(int64_t)(int32_t)((uint32_t){_imm(ops[2])} << 16);")
 
         if mn == "addic" or mn == "addic.":
+            # 64-bit add + XER[CA] from the unsigned 64-bit carry-out
+            # (the old form truncated to 32 bits and never wrote CA).
             rd, ra = _reg_idx(ops[0]), _reg_idx(ops[1])
-            return f"ctx->gpr[{rd}] = (int64_t)(int32_t)(ctx->gpr[{ra}] + {_imm(ops[2])});"
+            return (f"{{ uint64_t _a = ctx->gpr[{ra}]; "
+                    f"uint64_t _r = _a + (uint64_t)(int64_t)({_imm(ops[2])}); "
+                    f"ctx->gpr[{rd}] = _r; "
+                    f"ctx->xer = (ctx->xer & ~(1u << 29)) | ((_r < _a) ? (1u << 29) : 0u); }}")
 
         if mn in ("add", "add.", "addo", "addo."):
             rd, ra, rb = _reg_idx(ops[0]), _reg_idx(ops[1]), _reg_idx(ops[2])
@@ -527,20 +549,34 @@ class PPULifter:
             return f"ctx->gpr[{rd}] = ctx->gpr[{rb}] - ctx->gpr[{ra}];"
 
         if mn == "subfic":
+            # RT = EXTS(SI) - RA over the full 64 bits; XER[CA] = NOT borrow
+            # (carry-out of NOT(RA) + EXTS(SI) + 1, i.e. EXTS(SI) >= RA
+            # unsigned). The old form computed in 32 bits and never wrote CA.
             rd, ra = _reg_idx(ops[0]), _reg_idx(ops[1])
-            return f"ctx->gpr[{rd}] = (int64_t)(int32_t)({_imm(ops[2])} - (int32_t)ctx->gpr[{ra}]);"
+            return (f"{{ uint64_t _a = ctx->gpr[{ra}]; "
+                    f"uint64_t _b = (uint64_t)(int64_t)({_imm(ops[2])}); "
+                    f"ctx->gpr[{rd}] = _b - _a; "
+                    f"ctx->xer = (ctx->xer & ~(1u << 29)) | ((_b >= _a) ? (1u << 29) : 0u); }}")
 
         if mn in ("neg", "neg."):
+            # 64-bit two's complement (neg of INT64_MIN stays INT64_MIN);
+            # the old 32-bit form zeroed the high word.
             rd, ra = _reg_idx(ops[0]), _reg_idx(ops[1])
-            return f"ctx->gpr[{rd}] = (int64_t)(int32_t)(-(int32_t)ctx->gpr[{ra}]);"
+            return f"ctx->gpr[{rd}] = (uint64_t)0 - ctx->gpr[{ra}];"
 
         if mn == "mulli":
+            # mulli is the low 64 bits of the full RA * EXTS(SI) product
+            # (PowerISA); a 32-bit multiply truncates it.
             rd, ra = _reg_idx(ops[0]), _reg_idx(ops[1])
-            return f"ctx->gpr[{rd}] = (int64_t)(int32_t)((int32_t)ctx->gpr[{ra}] * {_imm(ops[2])});"
+            return (f"ctx->gpr[{rd}] = (uint64_t)((int64_t)ctx->gpr[{ra}] * "
+                    f"(int64_t)({_imm(ops[2])}));")
 
         if mn in ("mullw", "mullw."):
+            # Full 64-bit product of the sign-extended low words (PowerISA);
+            # multiplying as int32 truncates the high 32 bits of the result.
             rd, ra, rb = _reg_idx(ops[0]), _reg_idx(ops[1]), _reg_idx(ops[2])
-            return f"ctx->gpr[{rd}] = (int64_t)(int32_t)((int32_t)ctx->gpr[{ra}] * (int32_t)ctx->gpr[{rb}]);"
+            return (f"ctx->gpr[{rd}] = (uint64_t)((int64_t)(int32_t)ctx->gpr[{ra}] * "
+                    f"(int64_t)(int32_t)ctx->gpr[{rb}]);")
 
         if mn in ("mulhw", "mulhw."):
             rd, ra, rb = _reg_idx(ops[0]), _reg_idx(ops[1]), _reg_idx(ops[2])
@@ -602,6 +638,11 @@ class PPULifter:
             ra, rs, rb = _reg_idx(ops[0]), _reg_idx(ops[1]), _reg_idx(ops[2])
             return f"ctx->gpr[{ra}] = ~(ctx->gpr[{rs}] | ctx->gpr[{rb}]);"
 
+        if mn in ("eqv", "eqv."):
+            # eqv = complemented XOR (bitwise equivalence); was unhandled.
+            ra, rs, rb = _reg_idx(ops[0]), _reg_idx(ops[1]), _reg_idx(ops[2])
+            return f"ctx->gpr[{ra}] = ~(ctx->gpr[{rs}] ^ ctx->gpr[{rb}]);"
+
         if mn in ("andc", "andc."):
             ra, rs, rb = _reg_idx(ops[0]), _reg_idx(ops[1]), _reg_idx(ops[2])
             return f"ctx->gpr[{ra}] = ctx->gpr[{rs}] & ~ctx->gpr[{rb}];"
@@ -623,8 +664,15 @@ class PPULifter:
             return f"ctx->gpr[{ra}] = (int64_t)(int32_t)ctx->gpr[{rs}];"
 
         if mn in ("cntlzw", "cntlzw."):
+            # cntlzw(0) is DEFINED as 32 on PowerPC; raw __builtin_clz(0) is
+            # UB (x86 BSR leaves the index undefined). cntlzd below already
+            # has the guard; mirror it. Sony's SPURS queue code gates its
+            # "queue was empty -> signal the waiting task" wakeup on
+            # cntlzw(pending)>>5, so an unguarded emission silently drops
+            # every such wakeup.
             ra, rs = _reg_idx(ops[0]), _reg_idx(ops[1])
-            return f"ctx->gpr[{ra}] = __builtin_clz((uint32_t)ctx->gpr[{rs}]);"
+            return (f"ctx->gpr[{ra}] = (uint32_t)ctx->gpr[{rs}] ? "
+                    f"__builtin_clz((uint32_t)ctx->gpr[{rs}]) : 32;")
 
         if mn in ("cntlzd", "cntlzd."):
             ra, rs = _reg_idx(ops[0]), _reg_idx(ops[1])
@@ -650,21 +698,24 @@ class PPULifter:
             # the count to 5 bits, yielding a wrong nonzero value (breaks code
             # that shifts a mask to zero, e.g. binned allocators). Mirror sld.
             ra, rs, rb = _reg_idx(ops[0]), _reg_idx(ops[1]), _reg_idx(ops[2])
-            return f"ctx->gpr[{ra}] = (int64_t)(int32_t)((ctx->gpr[{rb}] & 0x20) ? 0u : ((uint32_t)ctx->gpr[{rs}] << (ctx->gpr[{rb}] & 0x1F)));"
+            # slw/srw ZERO-extend: the rotate-and-mask definition clears the
+            # high 32 bits of RA. Sign-extending puts 0xFFFFFFFF in the high
+            # word whenever bit 31 of the 32-bit result is set.
+            return f"ctx->gpr[{ra}] = (uint64_t)((ctx->gpr[{rb}] & 0x20) ? 0u : ((uint32_t)ctx->gpr[{rs}] << (ctx->gpr[{rb}] & 0x1F)));"
 
         if mn in ("srw", "srw."):
             ra, rs, rb = _reg_idx(ops[0]), _reg_idx(ops[1]), _reg_idx(ops[2])
-            return f"ctx->gpr[{ra}] = (int64_t)(int32_t)((ctx->gpr[{rb}] & 0x20) ? 0u : ((uint32_t)ctx->gpr[{rs}] >> (ctx->gpr[{rb}] & 0x1F)));"
+            return f"ctx->gpr[{ra}] = (uint64_t)((ctx->gpr[{rb}] & 0x20) ? 0u : ((uint32_t)ctx->gpr[{rs}] >> (ctx->gpr[{rb}] & 0x1F)));"
 
         if mn in ("sraw", "sraw."):
             # PPC sraw: for shift >= 32 the result is the sign bit replicated
             # (equivalent to an arithmetic shift by 31).
             ra, rs, rb = _reg_idx(ops[0]), _reg_idx(ops[1]), _reg_idx(ops[2])
-            return f"ctx->gpr[{ra}] = (int64_t)(int32_t)((int32_t)ctx->gpr[{rs}] >> ((ctx->gpr[{rb}] & 0x20) ? 31 : (int)(ctx->gpr[{rb}] & 0x1F)));"
+            return f"ctx->gpr[{ra}] = ppc_sraw(&ctx->xer, (int32_t)ctx->gpr[{rs}], (int)(ctx->gpr[{rb}] & 0x3F));"
 
         if mn in ("srawi", "srawi."):
             ra, rs = _reg_idx(ops[0]), _reg_idx(ops[1])
-            return f"ctx->gpr[{ra}] = (int64_t)(int32_t)((int32_t)ctx->gpr[{rs}] >> {_imm(ops[2])});"
+            return f"ctx->gpr[{ra}] = ppc_sraw(&ctx->xer, (int32_t)ctx->gpr[{rs}], {_imm(ops[2])});"
 
         # ------- 64-bit Rotate / Shift -------
         if mn.startswith("rldicl"):
@@ -714,11 +765,11 @@ class PPULifter:
 
         if mn in ("srad", "srad."):
             ra, rs, rb = _reg_idx(ops[0]), _reg_idx(ops[1]), _reg_idx(ops[2])
-            return f"ctx->gpr[{ra}] = (uint64_t)((int64_t)ctx->gpr[{rs}] >> (ctx->gpr[{rb}] & 63));"
+            return f"ctx->gpr[{ra}] = (uint64_t)ppc_srad(&ctx->xer, (int64_t)ctx->gpr[{rs}], (int)(ctx->gpr[{rb}] & 0x7F));"
 
         if mn in ("sradi", "sradi."):
             ra, rs = _reg_idx(ops[0]), _reg_idx(ops[1])
-            return f"ctx->gpr[{ra}] = (uint64_t)((int64_t)ctx->gpr[{rs}] >> {_imm(ops[2])});"
+            return f"ctx->gpr[{ra}] = (uint64_t)ppc_srad(&ctx->xer, (int64_t)ctx->gpr[{rs}], {_imm(ops[2])});"
 
         # ------- Loads -------
         load_map = {
@@ -816,7 +867,8 @@ class PPULifter:
         if mn in ("stfsx", "stfdx"):
             frs, ra_i, rb_i = _reg_idx(ops[0]), _reg_idx(ops[1]), _reg_idx(ops[2])
             ea = f"(ctx->gpr[{ra_i}] + ctx->gpr[{rb_i}])" if ra_i != "0" else f"ctx->gpr[{rb_i}]"
-            if "s" in mn:
+            # stfdx also contains 's' -- match single explicitly [fork eb5451b3]
+            if mn == "stfsx":
                 return f"{{ float ftmp = (float)ctx->fpr[{frs}]; uint32_t tmp; memcpy(&tmp, &ftmp, 4); vm_write32({ea}, tmp); }}"
             else:
                 return f"{{ uint64_t tmp; memcpy(&tmp, &ctx->fpr[{frs}], 8); vm_write64({ea}, tmp); }}"
@@ -1024,8 +1076,22 @@ class PPULifter:
             rd_i = _reg_idx(ops[0])
             return f"ctx->gpr[{rd_i}] = ctx->cr;"
 
-        if mn in ("mtcr", "mtcrf"):
+        if mn == "mtcr":
             return f"ctx->cr = (uint32_t)ctx->gpr[{_reg_idx(ops[-1])}];"
+        if mn == "mtcrf":
+            # mtcrf CRM, rS -- update ONLY the CR fields whose CRM bit is set
+            # (the others are preserved). CR0 = cr bits 28-31 ... CR7 = bits 0-3;
+            # CRM 0x80 selects CR0 ... 0x01 selects CR7.
+            crm = int(ops[0], 0) if len(ops) > 1 else 0xFF
+            mask = 0
+            for f in range(8):
+                if crm & (0x80 >> f):
+                    mask |= 0xF << (28 - 4 * f)
+            rS = _reg_idx(ops[-1])
+            if mask == 0xFFFFFFFF:
+                return f"ctx->cr = (uint32_t)ctx->gpr[{rS}];"
+            return (f"ctx->cr = (ctx->cr & 0x{(~mask) & 0xFFFFFFFF:08X}u) | "
+                    f"((uint32_t)ctx->gpr[{rS}] & 0x{mask:08X}u);")
 
         # ------- Syscall -------
         if mn == "sc":
@@ -1047,7 +1113,12 @@ class PPULifter:
             frs = _reg_idx(ops[0])
             disp, base = _disp_base(ops[1])
             if disp is not None:
-                if "s" in mn:
+                # Match single-precision by EXPLICIT mnemonic, not `"s" in mn` --
+                # every "stf..." store contains an 's', so the substring test
+                # mis-classified stfd/stfdu as single and emitted a lossy 4-byte
+                # store, corrupting the double (breaks fctidz+stfd+ld float->GPR
+                # idioms and any stored double). [ps3recomp fork JonathanDC64 eb5451b3]
+                if mn in ("stfs", "stfsu"):
                     return (f"{{ float ftmp = (float)ctx->fpr[{frs}]; uint32_t tmp; "
                             f"memcpy(&tmp, &ftmp, 4); vm_write32(ctx->gpr[{base}] + {disp}, tmp); }}")
                 else:
@@ -1200,10 +1271,12 @@ class PPULifter:
 
         if mn in ("subfe", "subfe."):
             rd, ra, rb = _reg_idx(ops[0]), _reg_idx(ops[1]), _reg_idx(ops[2])
+            # XER[CA] = ADC carry-out of (~RA + RB + ca), per PowerISA / RPCS3 add64_flags.
             return (f"{{ uint64_t ca = (ctx->xer >> 29) & 1; "
-                    f"uint64_t result = ~ctx->gpr[{ra}] + ctx->gpr[{rb}] + ca; "
-                    f"ctx->xer = (ctx->xer & ~(1u << 29)) | "
-                    f"((result <= ctx->gpr[{rb}] && ca) ? (1u << 29) : 0); "
+                    f"uint64_t a = ~ctx->gpr[{ra}], b = ctx->gpr[{rb}]; "
+                    f"uint64_t s1 = a + b; uint64_t co = (s1 < a); "
+                    f"uint64_t result = s1 + ca; co |= (result < s1); "
+                    f"ctx->xer = (ctx->xer & ~(1u << 29)) | ((uint32_t)co << 29); "
                     f"ctx->gpr[{rd}] = result; }}")
 
         # ------- addc/subfc (carry arithmetic, carry-out only, no carry-in) -------
@@ -1416,15 +1489,20 @@ class PPULifter:
                     f"ctx->gpr[{rd}] = (int64_t)(int16_t)vm_read16(ea); ctx->gpr[{ra}] = ea; }}")
 
         # ------- Move from time base -------
+        # THE guest clock. The old emission was a per-call-site static that
+        # advanced 16667 ticks PER READ -- not time: every site had a private
+        # counter that only moved when polled, so all guest elapsed-time math
+        # (media pacers, throttles, profilers, timeout loops) computed garbage
+        # from it. Real semantics: one global monotonic timebase at 79.8 MHz
+        # (runtime ppu_timebase_now, consistent with
+        # sys_time_get_timebase_frequency).
         if mn == "mftb":
             rd = _reg_idx(ops[0])
-            return (f"{{ static uint64_t tb = 79800000ULL; tb += 16667; "
-                    f"ctx->gpr[{rd}] = tb; }}")
+            return f"ctx->gpr[{rd}] = ppu_timebase_now();"
 
         if mn == "mftbu":
             rd = _reg_idx(ops[0])
-            return (f"{{ static uint64_t tb = 79800000ULL; tb += 16667; "
-                    f"ctx->gpr[{rd}] = (tb >> 32); }}")
+            return f"ctx->gpr[{rd}] = (ppu_timebase_now() >> 32);"
 
         # ------- Cache/sync ops (safe to no-op) -------
         # dcbz zeros a 128-byte cache line — MUST be implemented, not no-oped!
@@ -1443,16 +1521,22 @@ class PPULifter:
         # ------- addme/subfme/subfze (carry arithmetic, 2-op) -------
         if mn.startswith("addme"):
             rd, ra = _reg_idx(ops[0]), _reg_idx(ops[1])
+            # addme = RA + CA - 1 = RA + (~0) + CA; XER[CA] = ADC carry-out.
             return (f"{{ uint64_t ca = (ctx->xer >> 29) & 1; "
-                    f"uint64_t result = ctx->gpr[{ra}] + ca - 1; "
-                    f"ctx->xer = (ctx->xer & ~(1u << 29)) | "
-                    f"((result >= ctx->gpr[{ra}]) ? (1u << 29) : 0); "
+                    f"uint64_t a = ctx->gpr[{ra}], b = ~0ULL; "
+                    f"uint64_t s1 = a + b; uint64_t co = (s1 < a); "
+                    f"uint64_t result = s1 + ca; co |= (result < s1); "
+                    f"ctx->xer = (ctx->xer & ~(1u << 29)) | ((uint32_t)co << 29); "
                     f"ctx->gpr[{rd}] = result; }}")
 
         if mn.startswith("subfme"):
             rd, ra = _reg_idx(ops[0]), _reg_idx(ops[1])
+            # subfme = ~RA + CA - 1 = ~RA + (~0) + CA; was MISSING the XER[CA] update.
             return (f"{{ uint64_t ca = (ctx->xer >> 29) & 1; "
-                    f"uint64_t result = ~ctx->gpr[{ra}] + ca - 1; "
+                    f"uint64_t a = ~ctx->gpr[{ra}], b = ~0ULL; "
+                    f"uint64_t s1 = a + b; uint64_t co = (s1 < a); "
+                    f"uint64_t result = s1 + ca; co |= (result < s1); "
+                    f"ctx->xer = (ctx->xer & ~(1u << 29)) | ((uint32_t)co << 29); "
                     f"ctx->gpr[{rd}] = result; }}")
 
         if mn.startswith("subfze"):
@@ -1707,6 +1791,30 @@ class PPULifter:
             return (f"{{ uint32_t* a=(uint32_t*)&ctx->vr[{va}]; uint32_t* b=(uint32_t*)&ctx->vr[{vb}]; "
                     f"uint32_t* d=(uint32_t*)&ctx->vr[{vd}]; "
                     f"for(int i=0;i<4;i++) d[i]=a[i]==b[i]?~0u:0; }}")
+
+        # Vector compare greater-than, signed/unsigned, byte/half/word.
+        # Previously unhandled (fell to the TODO catch-all = silently skipped
+        # stores, so vD kept stale data). Dot forms set CR6 per the AltiVec
+        # PEM: bit0 (value 8) = all lanes true, bit2 (value 2) = all lanes
+        # false, written to CR field 6 (bits 4-7 of our packed ctx->cr).
+        vcmpgt_family = {
+            "vcmpgtsb": ("int8_t",   16), "vcmpgtsh": ("int16_t",  8),
+            "vcmpgtsw": ("int32_t",   4),
+            "vcmpgtub": ("uint8_t",  16), "vcmpgtuh": ("uint16_t", 8),
+            "vcmpgtuw": ("uint32_t",  4),
+        }
+        base_mn = mn.rstrip(".")
+        if base_mn in vcmpgt_family:
+            ety, n = vcmpgt_family[base_mn]
+            uty = ety.replace("int", "uint") if not ety.startswith("u") else ety
+            vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
+            body = (f"{{ {ety}* a=({ety}*)&ctx->vr[{va}]; {ety}* b=({ety}*)&ctx->vr[{vb}]; "
+                    f"{uty}* d=({uty}*)&ctx->vr[{vd}]; int t=0; "
+                    f"for(int i=0;i<{n};i++){{ {uty} r=a[i]>b[i]?({uty})~({uty})0:0; d[i]=r; t+=r?1:0; }}")
+            if mn.endswith("."):
+                body += (f" uint32_t c6=(t=={n}?8u:0u)|(t==0?2u:0u); "
+                         f"ctx->cr=(ctx->cr & ~(0xFu<<4))|(c6<<4);")
+            return body + " }"
 
         # ------- VMX integer arithmetic (generated from disasm decode table) -------
         # These are simple per-element operations on vector registers.
@@ -2156,7 +2264,7 @@ class PPULifter:
         # Emit helper macros
         lines.append("/* Rotate helpers */")
         lines.append("static inline uint32_t ppc_rlwinm(uint32_t rs, int sh, int mb, int me) {")
-        lines.append("    uint32_t rotated = (rs << sh) | (rs >> (32 - sh));")
+        lines.append("    uint32_t rotated = sh ? ((rs << sh) | (rs >> (32 - sh))) : rs;")
         lines.append("    uint32_t mask;")
         lines.append("    if (mb <= me) {")
         lines.append("        mask = ((uint32_t)-1 >> mb) & ((uint32_t)-1 << (31 - me));")
@@ -2167,7 +2275,7 @@ class PPULifter:
         lines.append("}")
         lines.append("")
         lines.append("static inline uint32_t ppc_rlwimi(uint32_t ra, uint32_t rs, int sh, int mb, int me) {")
-        lines.append("    uint32_t rotated = (rs << sh) | (rs >> (32 - sh));")
+        lines.append("    uint32_t rotated = sh ? ((rs << sh) | (rs >> (32 - sh))) : rs;")
         lines.append("    uint32_t mask;")
         lines.append("    if (mb <= me) {")
         lines.append("        mask = ((uint32_t)-1 >> mb) & ((uint32_t)-1 << (31 - me));")
@@ -2181,7 +2289,7 @@ class PPULifter:
         lines.append("/* 64-bit rotate helpers */")
         lines.append("static inline uint64_t ppc_rotl64(uint64_t v, int n) {")
         lines.append("    n &= 63;")
-        lines.append("    return (v << n) | (v >> (64 - n));")
+        lines.append("    return n ? ((v << n) | (v >> (64 - n))) : v;")
         lines.append("}")
         lines.append("static inline uint64_t ppc_mask64(int mb, int me) {")
         lines.append("    uint64_t mask;")
@@ -2207,6 +2315,24 @@ class PPULifter:
         lines.append("    int me = 63 - sh;")
         lines.append("    uint64_t mask = ppc_mask64(mb, me);")
         lines.append("    return (ppc_rotl64(rs, sh) & mask) | (ra & ~mask);")
+        lines.append("}")
+        lines.append("")
+        # Shift-right-algebraic with XER[CA]. CA = rS<0 AND any 1-bits shifted out.
+        # Also clamps shift counts >= width (PPC yields all-sign; a raw C shift by
+        # >= the width is undefined). The carry feeds adde/addze/subfe consumers.
+        lines.append("static inline int64_t ppc_sraw(uint32_t* xer, int32_t rs, int n) {")
+        lines.append("    int sh = n & 0x3F;")
+        lines.append("    uint32_t so = (sh == 0) ? 0u : ((sh >= 32) ? (uint32_t)rs : ((uint32_t)rs & (((uint32_t)1u << sh) - 1u)));")
+        lines.append("    uint32_t ca = (rs < 0 && so != 0u) ? 1u : 0u;")
+        lines.append("    *xer = (*xer & ~(1u << 29)) | (ca << 29);")
+        lines.append("    return (int64_t)((sh >= 32) ? (rs >> 31) : (rs >> sh));")
+        lines.append("}")
+        lines.append("static inline int64_t ppc_srad(uint32_t* xer, int64_t rs, int n) {")
+        lines.append("    int sh = n & 0x7F;")
+        lines.append("    uint64_t so = (sh == 0) ? 0ull : ((sh >= 64) ? (uint64_t)rs : ((uint64_t)rs & (((uint64_t)1ull << sh) - 1ull)));")
+        lines.append("    uint32_t ca = (rs < 0 && so != 0ull) ? 1u : 0u;")
+        lines.append("    *xer = (*xer & ~(1u << 29)) | (ca << 29);")
+        lines.append("    return (sh >= 64) ? (rs >> 63) : (rs >> sh);")
         lines.append("}")
         lines.append("")
         return lines

--- a/tools/rpcs3_probe/bp_test.py
+++ b/tools/rpcs3_probe/bp_test.py
@@ -1,0 +1,22 @@
+from rsp import RSPClient
+import time
+c=RSPClient(port=2345); c.connect()
+def pc(): r=c.read_registers(); return (r.get("pc",r.get("cia",0)))&0xFFFFFFFF
+p0=pc(); print("connected; halted pc=0x%08X"%p0)
+# 1) step mechanism
+print("--- single-step x5 ---")
+ok_step=False
+for i in range(5):
+    c.step(); rep=c.wait_stop(deadline=time.time()+8)
+    p=pc(); print("  step%d -> pc=0x%08X stop=%s"%(i,p,rep[:6]))
+    if p!=p0: ok_step=True
+    p0=p
+print("STEP WORKS:", ok_step)
+# 2) breakpoint mechanism: bp a bit ahead, cont, see if it hits
+tgt=(p0+0x10)&0xFFFFFFFF
+print("--- bp @0x%08X, cont ---"%tgt)
+c.add_breakpoint(tgt)
+c.cont(); rep=c.wait_stop(deadline=time.time()+15)
+ph=pc(); print("  after cont: pc=0x%08X stop=%s  HIT=%s"%(ph,rep[:6], ph==tgt))
+c.remove_breakpoint(tgt)
+c._send_packet("D"); c._recv_packet(); c.close(); print("detached")

--- a/tools/rpcs3_probe/diag_oracle.py
+++ b/tools/rpcs3_probe/diag_oracle.py
@@ -1,0 +1,18 @@
+from rsp import RSPClient
+import struct
+c=RSPClient(port=2345); c.connect()
+r=c.read_registers()
+pc=r.get("pc",r.get("cia",0))&0xFFFFFFFF
+print("halted pc=0x%08X r1=0x%08X"%(pc, r.get("r1",0)&0xFFFFFFFF))
+try:
+    m=c.read_mem(0x006CEAA0,8)
+    print("mem[0x6CEAA0]=",m.hex(),"(expect f821ff817c0802a6)")
+except Exception as e: print("mem read err:",e)
+ok=c.add_breakpoint(0x006CEAA0); print("add_breakpoint(0x6CEAA0) ->",ok)
+# step 5 instructions to confirm interpreter executes
+for i in range(5):
+    c.step(); rep=c.wait_stop(deadline=__import__("time").time()+10)
+    rr=c.read_registers(); p=rr.get("pc",rr.get("cia",0))&0xFFFFFFFF
+    print("  step%d pc=0x%08X stop=%s"%(i,p,rep[:6]))
+c.remove_breakpoint(0x006CEAA0)
+c._send_packet("D"); c._recv_packet(); c.close(); print("detached")

--- a/tools/rpcs3_probe/diag_oracle2.py
+++ b/tools/rpcs3_probe/diag_oracle2.py
@@ -1,0 +1,17 @@
+from rsp import RSPClient
+import time
+c=RSPClient(port=2345); c.connect()
+r=c.read_registers()
+pc=r.get("pc",r.get("cia",0))&0xFFFFFFFF
+print("halted pc=0x%08X r1=0x%08X"%(pc, r.get("r1",0)&0xFFFFFFFF))
+try:
+    m=c.read_mem(0x006CEAA0,8)
+    print("mem[0x6CEAA0]=",m.hex(),"(expect f821ff817c0802a6)")
+except Exception as e: print("mem read err:",e)
+ok=c.add_breakpoint(0x006CEAA0); print("add_breakpoint(0x6CEAA0) ->",ok)
+for i in range(6):
+    c.step(); rep=c.wait_stop(deadline=time.time()+10)
+    rr=c.read_registers(); p=rr.get("pc",rr.get("cia",0))&0xFFFFFFFF
+    print("  step%d pc=0x%08X stop=%s"%(i,p,rep[:6]))
+c.remove_breakpoint(0x006CEAA0)
+c._send_packet("D"); c._recv_packet(); c.close(); print("detached")

--- a/tools/rpcs3_probe/oracle_006CEAA0.py
+++ b/tools/rpcs3_probe/oracle_006CEAA0.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Oracle probe: capture func_006CEAA0 calls on real-HW RPCS3 to resolve the flОw
+metaclass deserialization divergence. Question: does real HW ever call
+func_006CEAA0 with [r3+0]==0x10071038 && r4==5, and what does it return?
+"""
+import sys, time
+from rsp import RSPClient, RSPError
+
+BP = 0x006CEAA0
+TARGET_TABLE = 0x10071038
+MAX_HITS = int(sys.argv[1]) if len(sys.argv) > 1 else 400
+DEADLINE = time.time() + (int(sys.argv[2]) if len(sys.argv) > 2 else 240)
+
+c = RSPClient(port=2345)
+c.connect()
+print("connected; halted target")
+c.add_breakpoint(BP)
+print(f"bp @ 0x{BP:08X}; capturing up to {MAX_HITS} hits ...")
+
+dist = {}        # (r4, [r3+0]) -> count
+matches = []     # full captures where [r3+0]==TARGET_TABLE
+hits = 0
+first = True
+while hits < MAX_HITS and time.time() < DEADLINE:
+    c.cont()
+    # First hit may be MINUTES away (slow interpreter boot to deserialization). Wait up to the
+    # whole deadline for it; once deserialization starts, subsequent hits are fast.
+    wdl = DEADLINE if first else min(DEADLINE, time.time() + 60)
+    rep = c.wait_stop(deadline=wdl)
+    if rep[:1] in (b"W", b"X"):
+        print("target exited/terminated:", rep[:40]); break
+    if not rep:
+        print(f"  (no stop; hits so far={hits}, elapsed={int(time.time()-(DEADLINE-200))}s)")
+        if not first: break
+        continue
+    first = False
+    regs = c.read_registers()
+    pc = regs.get("pc", regs.get("cia", 0)) & 0xFFFFFFFF
+    if pc != BP:
+        # stopped somewhere else (signal); keep going
+        continue
+    hits += 1
+    r3 = regs["r3"] & 0xFFFFFFFF
+    r4 = regs["r4"] & 0xFFFFFFFF
+    try:
+        t0 = c.read_u32(r3) & 0xFFFFFFFF
+    except Exception:
+        t0 = 0xDEADBEEF
+    key = (r4, t0)
+    dist[key] = dist.get(key, 0) + 1
+    if t0 == TARGET_TABLE or (r4 == 5 and 0x10070000 <= t0 < 0x10080000):
+        lr = regs.get("lr", 0) & 0xFFFFFFFF
+        # get return value: bp at LR, continue, read r3
+        ret = None
+        try:
+            c.add_breakpoint(lr)
+            c.cont(); c.wait_stop(deadline=time.time() + 10)
+            rr = c.read_registers()
+            ret = rr["r3"] & 0xFFFFFFFF
+            c.remove_breakpoint(lr)
+        except Exception as e:
+            ret = f"err:{e}"
+        cap = {"hit": hits, "r3_key": f"0x{r3:08X}", "r4_index": r4,
+               "key[0]": f"0x{t0:08X}", "lr": f"0x{lr:08X}", "return": f"0x{ret:08X}" if isinstance(ret,int) else str(ret)}
+        matches.append(cap)
+        print("  MATCH:", cap)
+
+print(f"\n=== {hits} hits captured ===")
+print("distribution (r4_index, [r3+0]) -> count  [top 20]:")
+for k, v in sorted(dist.items(), key=lambda kv: -kv[1])[:20]:
+    print(f"  r4={k[0]:<4} [r3+0]=0x{k[1]:08X}  x{v}")
+print(f"\n{len(matches)} matches with target table / r4==5+class-range:")
+for m in matches:
+    print("  ", m)
+try:
+    c.remove_breakpoint(BP)
+    c._send_packet("D"); c._recv_packet()
+except Exception:
+    pass
+c.close()
+print("detached.")

--- a/tools/rpcs3_probe/snap_addrs.py
+++ b/tools/rpcs3_probe/snap_addrs.py
@@ -1,0 +1,17 @@
+from rsp import RSPClient
+import struct
+c=RSPClient(port=2345); c.connect()
+r=c.read_registers()
+print("halted pc=0x%08X r2(toc)=0x%08X"%((r.get("pc",r.get("cia",0)))&0xFFFFFFFF, r.get("r2",0)&0xFFFFFFFF))
+def dump(va,n,label):
+    try:
+        m=c.read_mem(va,n)
+        words=' '.join('%08X'%struct.unpack('>I',m[i:i+4])[0] for i in range(0,n,4))
+        print("  %-26s 0x%08X: %s"%(label,va,words))
+    except Exception as e:
+        print("  %-26s 0x%08X: ERR %s"%(label,va,e))
+dump(0x008969A8,32,"TOC-anchor/deref")          # past .data end (0x895CD4) in our model
+dump(0x00896900,32,"near TOC anchor")
+dump(0x0084E760,32,"OPD method table")          # static OPDs in our ELF
+dump(0x10071038,32,"class struct")              # vtable-of-vtables
+c._send_packet("D"); c._recv_packet(); c.close(); print("detached")

--- a/tools/rpcs3_probe/snap_singleton.py
+++ b/tools/rpcs3_probe/snap_singleton.py
@@ -1,0 +1,17 @@
+from rsp import RSPClient
+import struct
+c=RSPClient(port=2345); c.connect()
+def u32(va):
+    try: return struct.unpack('>I', c.read_mem(va,4))[0]
+    except Exception: return None
+TOC=0x008969A8
+sing = u32(TOC-0x4BFC)            # metaclass singleton = [r2-0x4BFC]
+print("REAL-HW metaclass singleton [0x%08X] = 0x%08X"%(TOC-0x4BFC, sing or 0))
+if sing:
+    for off in (-0x7DAC,-0x7DE8,-0x7DD4,-0x7CC0,-0x7FE8):
+        p=u32(sing+ (off & 0xFFFFFFFF) if off>=0 else sing+off)
+        print("  [sing%+#x] = 0x%08X"%(off, p or 0))
+    reg = u32(sing-0x7DAC)
+    if reg:
+        print("  registry [sing-0x7DAC]=0x%08X fields:"%reg, ' '.join('0x%08X'%(u32(reg+i*4) or 0) for i in range(6)))
+c._send_packet("D"); c._recv_packet(); c.close(); print("detached")

--- a/tools/spu_disasm.py
+++ b/tools/spu_disasm.py
@@ -349,7 +349,9 @@ def spu_decode(insn: int, addr: int = 0) -> SPUInstruction:
             target = i18 * 4
             result.operands = f"0x{target & 0xFFFFFFFF:X}"
         elif mne in ("brnz", "brz", "brhnz", "brhz"):
-            target = sign_extend(i16, 16) * 4 + addr
+            # (dead path -- these are RI16, not in RI18_TABLE -- but keep the
+            # arithmetic correct: i16 is already sign-extended, don't re-extend)
+            target = i16 * 4 + addr
             result.operands = f"$r{rt}, 0x{target & 0xFFFFFFFF:X}"
         elif mne == "ila":
             result.operands = f"$r{rt}, 0x{i18:X}"
@@ -377,7 +379,13 @@ def spu_decode(insn: int, addr: int = 0) -> SPUInstruction:
         elif mne in ("hbra", "hbrr"):
             result.operands = f"0x{i16 & 0xFFFF:X}, $r{rt}"
         elif mne == "il":
-            result.operands = f"$r{rt}, {sign_extend(i16, 16)}"
+            # i16 is ALREADY sign-extended (top of spu_decode). Extending it
+            # again mapped every NEGATIVE il immediate to (imm - 0x10000):
+            # Python's -4 & 0x8000 is truthy, so sign_extend(-4,16) = -65540.
+            # Found live in gs_task @LS 0x5008 (il $r17,-4 lifted as -65540 ->
+            # the free-list restock store landed at LS 0x3BDC0 instead of
+            # 0xBDC0 -> allocator popped NULL -> the LS-0x44 crash).
+            result.operands = f"$r{rt}, {i16}"
         elif mne in ("iohl", "ilh", "ilhu"):
             result.operands = f"$r{rt}, 0x{i16 & 0xFFFF:X}"
         elif mne in ("brz", "brnz", "brhz", "brhnz"):

--- a/tools/spu_disasm_audit.py
+++ b/tools/spu_disasm_audit.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""
+SPU decode cross-check: tools/spu_disasm.py vs RPCS3's SPUDisAsm used as an
+OUTPUT-ONLY oracle.
+
+Clean-room posture: RPCS3 is GPLv2. The oracle is a tiny standalone dump
+harness (see tools/spu_dump_tool.vcxproj, a thin main.cpp that links RPCS3's
+own SPUDisAsm class from a local RPCS3 source checkout) that you build
+against your own RPCS3 clone. No RPCS3 source is copied into this repo; this
+script only invokes that already-built .exe and diffs its plain-text stdout
+against our own decoder's output. See that harness's main.cpp for the build
+rationale and its vcxproj for the link recipe.
+
+Usage:
+    py -3 tools\\spu_disasm_audit.py <image1.elf> [image2.elf ...]
+        --oracle-exe PATH [--samples N]
+
+--oracle-exe defaults to the SPU_DUMP_TOOL_EXE environment variable if set;
+otherwise it is required.
+
+Each <imageN.elf> is one of the lifted SPU images in scratch\\spu_imgs\\ (an
+ELF-wrapped SPU binary produced by the lift pipeline). For each image:
+  1. Parse the ELF program headers (tools/elf_parser.py), find the PT_LOAD
+     segment with the executable flag (PF_X, bit 0x1) -- that is the SPU code
+     segment; other PT_LOAD segments are data (e.g. the 0x6 = R+W segment)
+     and are NOT code, so they are skipped.
+  2. Decode every 4-byte-aligned word of that segment with our
+     tools/spu_disasm.py (spu_decode) -> "ours" mnemonic per offset.
+  3. Write the SAME raw bytes to a temp file and invoke the oracle harness
+     (spu_dump_tool.exe <bytes> --base <vaddr>) -> "oracle" mnemonic per
+     offset, parsed back out of its stdout.
+  4. Normalize both to mnemonic-only (v1 scope; operand normalization is a
+     stretch goal, matching disasm_audit.py's precedent) via a whitelist
+     alias table (known made-up RPCS3 mnemonics: "mr" for ori/shlqbyi with a
+     zero immediate -- verified by reading SPUDisAsm.h's SHLQBYI/ORI bodies,
+     see the ALIAS_WHITELIST comment below -- plus the C-bit-conditional
+     sync/syncc and hbr/hbrp pairs, which our decoder does not model).
+  5. Diff per-offset; group residual (non-whitelisted) mismatches by
+     (ours_mnemonic, oracle_mnemonic) pair, descending count, with sample
+     addresses; report whitelisted pairs separately as INFO.
+
+Exit code: 0 always (this is a report tool, like disasm_audit.py); the
+CALLER (an acceptance run / a human) judges the residual count.
+"""
+
+import argparse
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+from collections import Counter, defaultdict
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from elf_parser import ELFFile, PT_LOAD  # noqa: E402
+from spu_disasm import spu_decode  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Oracle harness location: never shipped in this repo (built against your own
+# RPCS3 clone -- see tools/spu_dump_tool.vcxproj). Point --oracle-exe at your
+# build, or set the SPU_DUMP_TOOL_EXE environment variable.
+# ---------------------------------------------------------------------------
+DEFAULT_ORACLE_EXE = os.environ.get("SPU_DUMP_TOOL_EXE")
+
+PF_X = 0x1  # ELF program header "executable" flag bit
+
+# ---------------------------------------------------------------------------
+# Alias whitelist: (ours_mnemonic, oracle_mnemonic) pairs known to be the
+# SAME instruction under a different display name, confirmed by reading the
+# RPCS3 source (GPLv2, cited by file:line only -- no code copied):
+#   - SPUDisAsm.h ORI():      "if (!op.si10) DisAsm(\"mr\", ...)"       (~line 897)
+#   - SPUDisAsm.h SHLQBYI():  "if (!op.si7)  DisAsm(\"mr\", ...)"       (~line 553)
+#     Both are RPCS3's own "made-up mnemonic: as MR on PPU" comment --
+#     value-conditional (immediate == 0) aliasing our decoder does not do.
+#     v1 whitelists the mnemonic PAIR unconditionally (does not re-check the
+#     immediate); this is a deliberate v1 simplification, matching the
+#     "mnemonic-only in v1" scope used elsewhere in this audit family.
+#   - SPUDisAsm.h SYNC():     "DisAsm(op.c ? \"syncc\" : \"sync\")"      (~line 240)
+#   - SPUDisAsm.h HBR():      "DisAsm(op.c ? \"hbrp\" : \"hbr\", ...)"   (~line 419)
+#     Our decoder (tools/spu_disasm.py) always emits the C=0 name; these
+#     pairs are a REAL, reportable gap (not a bug -- SYNC/HBR are 1-bit
+#     variants we don't currently distinguish), whitelisted here so they
+#     don't drown out true decode-table-swap mismatches in the top-N report.
+# ---------------------------------------------------------------------------
+ALIAS_WHITELIST = {
+    ("ori", "mr"),
+    ("shlqbyi", "mr"),
+    ("sync", "syncc"),
+    ("hbr", "hbrp"),
+}
+
+
+def find_oracle_exe(explicit: str | None) -> str:
+    path = explicit or DEFAULT_ORACLE_EXE
+    if not path:
+        raise SystemExit(
+            "error: no oracle harness path given.\n"
+            "Pass --oracle-exe PATH or set the SPU_DUMP_TOOL_EXE environment "
+            "variable. Build the harness first: the project is "
+            "tools/spu_dump_tool.vcxproj, linked against your own local RPCS3 "
+            "source checkout; build with msbuild against that .vcxproj "
+            "(/p:SolutionDir=<path-to-your-rpcs3-checkout>\\)."
+        )
+    if not os.path.isfile(path):
+        raise SystemExit(
+            f"error: oracle harness not found at '{path}'.\n"
+            "Build it first: the harness project is "
+            "tools/spu_dump_tool.vcxproj, linked against your own local RPCS3 "
+            "source checkout; build with msbuild against that .vcxproj "
+            "(/p:SolutionDir=<path-to-your-rpcs3-checkout>\\)."
+        )
+    return path
+
+
+def extract_code_segment(elf_path: str) -> tuple[bytes, int]:
+    """Return (code_bytes, vaddr) for the executable PT_LOAD segment."""
+    ef = ELFFile(elf_path)
+    ef.load()
+
+    code_segs = [
+        ph for ph in ef.program_headers
+        if ph.p_type == PT_LOAD and (ph.p_flags & PF_X) and ph.p_filesz > 0
+    ]
+    if not code_segs:
+        raise SystemExit(f"error: no executable PT_LOAD segment found in '{elf_path}'")
+    if len(code_segs) > 1:
+        print(
+            f"warning: '{elf_path}' has {len(code_segs)} executable PT_LOAD "
+            "segments; using the first",
+            file=sys.stderr,
+        )
+
+    ph = code_segs[0]
+    data = ef.raw_data[ph.p_offset:ph.p_offset + ph.p_filesz]
+    return data, ph.p_vaddr
+
+
+def decode_ours(code: bytes, vaddr: int) -> dict[int, str]:
+    """offset -> mnemonic, decoding every 4-byte-aligned word."""
+    out = {}
+    n = len(code) - (len(code) % 4)
+    for off in range(0, n, 4):
+        word = struct.unpack_from(">I", code, off)[0]
+        insn = spu_decode(word, vaddr + off)
+        out[vaddr + off] = insn.mnemonic
+    return out
+
+
+def decode_oracle(oracle_exe: str, code: bytes, vaddr: int) -> dict[int, str]:
+    """offset -> mnemonic, by shelling out to the rpcs3clone harness."""
+    # SPU local store is 256 KiB (SPU_LS_SIZE); the harness requires
+    # base + len(code) <= 0x40000. Our lifted images' vaddrs (e.g. gs_task's
+    # 0x3000) already satisfy this -- if a future image doesn't, mask to the
+    # low 18 bits (LS-relative) the way real SPU addressing does.
+    base = vaddr
+    if base + len(code) > 0x40000:
+        base = vaddr & 0x3FFFF
+        if base + len(code) > 0x40000:
+            raise SystemExit(
+                f"error: code segment (vaddr=0x{vaddr:x} len=0x{len(code):x}) "
+                "does not fit in a 256 KiB SPU local store even after LS-masking"
+            )
+
+    with tempfile.NamedTemporaryFile(suffix=".spu.bin", delete=False) as tf:
+        tf.write(code)
+        tmp_path = tf.name
+
+    try:
+        proc = subprocess.run(
+            [oracle_exe, tmp_path, "--base", hex(base)],
+            capture_output=True, text=True, timeout=120,
+        )
+    finally:
+        os.unlink(tmp_path)
+
+    if proc.returncode != 0:
+        raise SystemExit(
+            f"error: oracle harness exited {proc.returncode}\n"
+            f"stdout: {proc.stdout[-2000:]}\nstderr: {proc.stderr[-2000:]}"
+        )
+
+    out = {}
+    delta = vaddr - base  # map harness-local offsets back to the real vaddr
+    for line in proc.stdout.splitlines():
+        # "00003000: ila r2,0x15ba4" (or "<disasm-out-of-range>")
+        colon = line.find(":")
+        if colon < 0:
+            continue
+        try:
+            off = int(line[:colon], 16)
+        except ValueError:
+            continue
+        rest = line[colon + 1:].strip()
+        if not rest or rest.startswith("<"):
+            continue
+        mnemonic = rest.split(None, 1)[0]
+        out[off + delta] = mnemonic
+    return out
+
+
+def audit_one(image_path: str, oracle_exe: str, samples: int) -> tuple[Counter, dict, int]:
+    """Returns (mismatch_pair_counts, sample_addrs_by_pair, total_words)."""
+    code, vaddr = extract_code_segment(image_path)
+    ours = decode_ours(code, vaddr)
+    oracle = decode_oracle(oracle_exe, code, vaddr)
+
+    pair_counts: Counter = Counter()
+    pair_samples: dict[tuple[str, str], list[int]] = defaultdict(list)
+
+    total = 0
+    for addr, our_mn in ours.items():
+        total += 1
+        oracle_mn = oracle.get(addr)
+        if oracle_mn is None:
+            continue  # oracle didn't cover this offset (shouldn't happen for aligned code)
+        if our_mn == oracle_mn:
+            continue
+        pair = (our_mn, oracle_mn)
+        pair_counts[pair] += 1
+        if len(pair_samples[pair]) < samples:
+            pair_samples[pair].append(addr)
+
+    return pair_counts, pair_samples, total
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("images", nargs="+", help="lifted SPU image ELF(s), e.g. scratch\\spu_imgs\\spu_0003_at_0126A580.elf")
+    ap.add_argument("--oracle-exe", default=None,
+                     help="path to your built spu_dump_tool.exe "
+                          "(default: $SPU_DUMP_TOOL_EXE if set)")
+    ap.add_argument("--samples", type=int, default=3, help="sample addresses per mismatch pair (default 3)")
+    args = ap.parse_args()
+
+    oracle_exe = find_oracle_exe(args.oracle_exe)
+    print(f"[spu_disasm_audit] oracle exe: {oracle_exe}")
+    print(f"[spu_disasm_audit] images: {len(args.images)}")
+
+    combined_counts: Counter = Counter()
+    combined_samples: dict[tuple[str, str], list[int]] = defaultdict(list)
+    grand_total = 0
+    per_image_totals = []
+
+    for img in args.images:
+        pair_counts, pair_samples, total = audit_one(img, oracle_exe, args.samples)
+        grand_total += total
+        per_image_totals.append((img, total, sum(pair_counts.values())))
+        combined_counts.update(pair_counts)
+        for pair, addrs in pair_samples.items():
+            for a in addrs:
+                if len(combined_samples[pair]) < args.samples:
+                    combined_samples[pair].append(a)
+
+    print()
+    print("=== Per-image summary ===")
+    for img, total, mism in per_image_totals:
+        print(f"  {os.path.basename(img)}: {total} words decoded, {mism} mismatches ({100.0 * mism / total if total else 0:.3f}%)")
+
+    whitelisted_pairs = {p: c for p, c in combined_counts.items() if p in ALIAS_WHITELIST}
+    residual_pairs = {p: c for p, c in combined_counts.items() if p not in ALIAS_WHITELIST}
+
+    print()
+    print(f"=== Total words decoded across {len(args.images)} image(s): {grand_total} ===")
+    print(f"=== Total mismatch pairs (distinct): {len(combined_counts)}  (whitelisted: {len(whitelisted_pairs)}, residual: {len(residual_pairs)}) ===")
+
+    print()
+    print("--- Residual (non-whitelisted) mismatches, grouped by (ours, oracle), descending count ---")
+    for pair, count in sorted(residual_pairs.items(), key=lambda kv: -kv[1]):
+        samples_str = ", ".join(f"0x{a:x}" for a in combined_samples[pair])
+        print(f"  ({pair[0]!r}, {pair[1]!r}): {count}  samples: {samples_str}")
+    if not residual_pairs:
+        print("  (none)")
+
+    print()
+    print("--- Whitelisted (known-alias) mismatches, INFO only ---")
+    for pair, count in sorted(whitelisted_pairs.items(), key=lambda kv: -kv[1]):
+        samples_str = ", ".join(f"0x{a:x}" for a in combined_samples[pair])
+        print(f"  ({pair[0]!r}, {pair[1]!r}): {count}  samples: {samples_str}")
+    if not whitelisted_pairs:
+        print("  (none)")
+
+    # Sanity gate: core ops must show zero NON-whitelisted mismatches.
+    core_ops = {"il", "ai", "lqd", "brsl", "shufb"}
+    core_residual = {p: c for p, c in residual_pairs.items() if p[0] in core_ops}
+    print()
+    if core_residual:
+        print(f"SANITY CHECK FAILED: core ops have residual mismatches: {core_residual}")
+    else:
+        print("SANITY CHECK OK: core ops (il, ai, lqd, brsl, shufb) show zero non-whitelisted mismatches.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/spu_disasm_audit_operands.py
+++ b/tools/spu_disasm_audit_operands.py
@@ -1,0 +1,497 @@
+#!/usr/bin/env python3
+"""
+SPU OPERAND-level decode cross-check: tools/spu_disasm.py vs RPCS3's SPUDisAsm
+oracle, restricted to words where the MNEMONIC already matches (v1's job,
+tools/spu_disasm_audit.py, covers mnemonic mismatches).
+
+This closes the blind spot where the historically most expensive SPU bug
+lived: the `il` negative-immediate double-sign-extension (see
+tools/spu_disasm.py's IL comment at ~line 387-394) decoded the right
+MNEMONIC but the wrong OPERAND VALUE. A mnemonic-only diff (v1) cannot catch
+that class at all -- this script can.
+
+Method
+------
+For each SPU image:
+  1. Reuse v1's ELF-segment extraction (extract_code_segment) to get the
+     same code bytes + vaddr both sides will decode.
+  2. Decode every 4-byte-aligned word with our spu_decode() -> (mnemonic,
+     operands string).
+  3. Shell out to the SAME oracle exe (spu_dump_tool.exe) used by v1 to get
+     its "offset: mnemonic operands" text per word.
+  4. Where mnemonics differ, skip (v1's job).
+  5. Where mnemonics match, CANONICALIZE both operand strings into an
+     ordered list of typed atoms (register-index int, immediate int, or a
+     literal string for channel/spr names) and compare atom-by-atom.
+  6. Divergences are grouped by mnemonic; each group carries sample
+     (addr, ours_raw, oracle_raw, ours_canon, oracle_canon) tuples.
+
+Canonicalization rules (derived from reading RPCS3's SPUDisAsm.h -- GPLv2,
+cited by file:line, NO code copied; only the black-box TEXT contract is
+reverse-derived):
+  - Registers: both sides name registers positionally; oracle uses
+    "lr"/"sp"/"r2".."r127" (SPUDisAsm.h spu_reg_name[128], line ~9-27) while
+    ours always uses "$rN". Canonical form = the integer index (lr->0,
+    sp->1, rN->N). This makes the "lr"/"sp" aliasing purely cosmetic.
+  - Immediates: oracle's SignedHex() helper (Emu/CPU/CPUDisAsm.h ~line 115)
+    prints abs(value) < 10 as plain decimal, otherwise as "0x.."/"-0x..".
+    Canonical form = the signed Python int the text denotes, regardless of
+    which base/sign notation was used. This is the crux of the "il" class:
+    a double-sign-extension bug changes which INTEGER is denoted, so this
+    canonicalization catches it even though both sides "look like hex".
+  - Displacement operands ("disp(reg)" for lqd/stqd/stqa/lqa/lqr/stqr):
+    split into (immediate, register) atoms in that order; the a-form/r-form
+    ops encode an absolute/pc-relative LOAD-STORE ADDRESS (not a signed
+    displacement) on the oracle side (DisAsmBranchTarget) -- canonicalize
+    both as the resolved absolute address integer.
+  - Branch targets (br/bra/brsl/brasl/brz/brnz/brhz/brhnz/hbra/hbrr): both
+    sides resolve to an absolute LS address; canonicalize as that integer,
+    NOT the raw immediate encoding.
+  - Channel operands (rdch/wrch/rchcnt): oracle prints a symbolic name
+    (SPUDisAsm.h spu_ch_name[128], line ~49-70); ours prints its own
+    CHANNEL_NAMES table (tools/spu_disasm.py line ~283) which is missing at
+    least channel 12 ("MFC_RdTagMask" on the oracle side, falls back to a
+    numeric "ch12" on ours per current CHANNEL_NAMES gaps). Canonical form
+    = the CHANNEL INDEX, not the name string, recovered by inverting each
+    side's own name table; a numeric fallback name ("ch12") is parsed back
+    to 12 directly. This avoids reporting a channel NAME gap as an operand
+    VALUE bug.
+  - Comment suffixes ("#GETL", "#0", "#i32[3]", "#0x1h", "#00" etc, emitted
+    by comment_constant()/spu_stop_syscall on the oracle side only) are
+    stripped before comparison -- ours never emits them and they are not
+    semantic operands.
+
+Whitelist: tools/spu_disasm_audit_operands_whitelist.txt, one
+"mnemonic:reason" per line, for KNOWN-benign canonicalization gaps (e.g. a
+channel name-table gap already understood and not a value bug). Never
+whitelist a raw register-index or immediate-VALUE mismatch.
+
+Usage:
+    py -3 tools\\spu_disasm_audit_operands.py <image1.elf> [image2.elf ...]
+        --oracle-exe PATH [--samples N] [--whitelist PATH]
+
+--oracle-exe defaults to the SPU_DUMP_TOOL_EXE environment variable if set;
+otherwise it is required. See tools/spu_disasm_audit.py's module docstring
+for how to build the oracle harness.
+"""
+
+import argparse
+import os
+import re
+import struct
+import subprocess
+import sys
+import tempfile
+from collections import Counter, defaultdict
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from elf_parser import ELFFile, PT_LOAD  # noqa: E402
+from spu_disasm import spu_decode  # noqa: E402
+
+# Never shipped in this repo -- see tools/spu_disasm_audit.py's module
+# docstring for the build recipe. Point --oracle-exe at your build, or set
+# the SPU_DUMP_TOOL_EXE environment variable.
+DEFAULT_ORACLE_EXE = os.environ.get("SPU_DUMP_TOOL_EXE")
+DEFAULT_WHITELIST = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "spu_disasm_audit_operands_whitelist.txt",
+)
+
+PF_X = 0x1
+
+# ---------------------------------------------------------------------------
+# Oracle's own register/channel name tables (SPUDisAsm.h, GPLv2 -- table
+# CONTENTS reproduced here as data only, not code/logic, purely so the
+# Python side can invert "lr"/"sp"/"r2"/"MFC_Cmd"/etc back to an index for
+# canonicalization; see SPUDisAsm.h line ~9 spu_reg_name[128] and line ~49
+# spu_ch_name[128]).
+# ---------------------------------------------------------------------------
+ORACLE_REG_NAMES = ["lr", "sp"] + [f"r{i}" for i in range(2, 128)]
+ORACLE_REG_INDEX = {name: i for i, name in enumerate(ORACLE_REG_NAMES)}
+
+ORACLE_CH_NAMES = [
+    "SPU_RdEventStat", "SPU_WrEventMask", "SPU_WrEventAck", "SPU_RdSigNotify1",
+    "SPU_RdSigNotify2", "ch5", "ch6", "SPU_WrDec", "SPU_RdDec",
+    "MFC_WrMSSyncReq", "ch10", "SPU_RdEventMask", "MFC_RdTagMask", "SPU_RdMachStat",
+    "SPU_WrSRR0", "SPU_RdSRR0", "MFC_LSA", "MFC_EAH", "MFC_EAL", "MFC_Size",
+    "MFC_TagID", "MFC_Cmd", "MFC_WrTagMask", "MFC_WrTagUpdate", "MFC_RdTagStat",
+    "MFC_RdListStallStat", "MFC_WrListStallAck", "MFC_RdAtomicStat",
+    "SPU_WrOutMbox", "SPU_RdInMbox", "SPU_WrOutIntrMbox", "ch31",
+]
+ORACLE_CH_INDEX = {name: i for i, name in enumerate(ORACLE_CH_NAMES)}
+
+# Ours: tools/spu_disasm.py CHANNEL_NAMES (addr -> name); invert it.
+from spu_disasm import CHANNEL_NAMES as OUR_CHANNEL_NAMES  # noqa: E402
+OUR_CH_INDEX = {name: i for i, name in OUR_CHANNEL_NAMES.items()}
+
+
+def canon_reg_token(tok: str):
+    """A register-like token -> integer index, or None if not a register."""
+    tok = tok.strip()
+    if tok.startswith("$r"):
+        try:
+            return int(tok[2:])
+        except ValueError:
+            return None
+    if tok in ORACLE_REG_INDEX:
+        return ORACLE_REG_INDEX[tok]
+    m = re.fullmatch(r"r(\d+)", tok)
+    if m:
+        return int(m.group(1))
+    return None
+
+
+def canon_channel_token(tok: str, ours: bool):
+    """A channel-name-or-fallback token -> channel index, or None."""
+    tok = tok.strip()
+    m = re.fullmatch(r"ch(\d+)", tok)
+    if m:
+        return int(m.group(1))
+    table = OUR_CH_INDEX if ours else ORACLE_CH_INDEX
+    if tok in table:
+        return table[tok]
+    return None
+
+
+def canon_spreg_token(tok: str):
+    tok = tok.strip()
+    m = re.fullmatch(r"spr(\d+)", tok)
+    if m:
+        return int(m.group(1))
+    return None
+
+
+def parse_int_token(tok: str):
+    """A hex/decimal/negative-immediate token -> Python int, or None."""
+    tok = tok.strip()
+    neg = False
+    if tok.startswith("-"):
+        neg = True
+        tok = tok[1:]
+    try:
+        if tok.lower().startswith("0x"):
+            v = int(tok, 16)
+        else:
+            v = int(tok, 10)
+    except ValueError:
+        return None
+    return -v if neg else v
+
+
+def strip_comment(text: str) -> str:
+    """Drop a trailing ' #...' comment (comment_constant()/stop-syscall
+    annotation on the oracle side; ours never emits one)."""
+    idx = text.find("#")
+    if idx < 0:
+        return text.strip()
+    return text[:idx].strip()
+
+
+def split_operands(mnemonic: str, operands: str, ours: bool):
+    """Return a list of canonical atoms for one side's operand string.
+
+    Atom = ("reg", idx) | ("imm", value) | ("spr", idx) | ("ch", idx) |
+           ("sym", raw_lowercased_string)   -- last resort, compared as text.
+
+    A disp(reg) operand (e.g. "0x10(sp)" or "-0x50(sp)") is split into two
+    atoms: ("imm", disp) then ("reg", idx), matching the register-then-
+    immediate-then-register token order used by both decoders for
+    lqd/stqd/lqa/stqa/lqr/stqr (ours already prints "rt, disp(ra)"; the
+    oracle prints "rt,disp(ra)" -- same order once tokenized).
+    """
+    operands = strip_comment(operands)
+    if not operands:
+        return []
+
+    atoms = []
+    # First split top-level commas (but not commas inside "(...)").
+    parts = []
+    depth = 0
+    cur = ""
+    for c in operands:
+        if c == "(":
+            depth += 1
+            cur += c
+        elif c == ")":
+            depth -= 1
+            cur += c
+        elif c == "," and depth == 0:
+            parts.append(cur)
+            cur = ""
+        else:
+            cur += c
+    parts.append(cur)
+
+    disp_re = re.compile(r"^\s*(-?(?:0x[0-9a-fA-F]+|\d+))\((\S+)\)\s*$")
+
+    for part in parts:
+        part = part.strip()
+        if not part:
+            continue
+
+        m = disp_re.match(part)
+        if m:
+            imm_val = parse_int_token(m.group(1))
+            atoms.append(("imm", imm_val))
+            reg_idx = canon_reg_token(m.group(2))
+            if reg_idx is not None:
+                atoms.append(("reg", reg_idx))
+            else:
+                atoms.append(("sym", m.group(2).lower()))
+            continue
+
+        reg_idx = canon_reg_token(part)
+        if reg_idx is not None and (part.startswith("$r") or part in ORACLE_REG_INDEX
+                                     or re.fullmatch(r"r\d+", part)):
+            atoms.append(("reg", reg_idx))
+            continue
+
+        spr_idx = canon_spreg_token(part)
+        if spr_idx is not None:
+            atoms.append(("spr", spr_idx))
+            continue
+
+        if mnemonic in ("rdch", "wrch", "rchcnt"):
+            ch_idx = canon_channel_token(part, ours)
+            if ch_idx is not None:
+                atoms.append(("ch", ch_idx))
+                continue
+
+        int_val = parse_int_token(part)
+        if int_val is not None:
+            atoms.append(("imm", int_val))
+            continue
+
+        atoms.append(("sym", part.lower()))
+
+    return atoms
+
+
+# ---------------------------------------------------------------------------
+# Whitelist: (mnemonic) -> reason, for KNOWN-benign canonicalization gaps.
+# Format: one "mnemonic:reason text" per line in the whitelist file, '#'
+# comments and blank lines ignored. A whitelisted mnemonic's residual
+# mismatches are still counted and reported (as INFO), just excluded from
+# the "residual real divergences" bucket that gates the acceptance check.
+# ---------------------------------------------------------------------------
+def load_whitelist(path: str) -> dict:
+    wl = {}
+    if not path or not os.path.isfile(path):
+        return wl
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if ":" in line:
+                mn, reason = line.split(":", 1)
+            else:
+                mn, reason = line, ""
+            wl[mn.strip()] = reason.strip()
+    return wl
+
+
+def find_oracle_exe(explicit):
+    path = explicit or DEFAULT_ORACLE_EXE
+    if not path:
+        raise SystemExit(
+            "error: no oracle harness path given. STOP -- cannot fake this.\n"
+            "Pass --oracle-exe PATH or set the SPU_DUMP_TOOL_EXE environment "
+            "variable (see tools/spu_disasm_audit.py's find_oracle_exe for the "
+            "build recipe)."
+        )
+    if not os.path.isfile(path):
+        raise SystemExit(
+            f"error: oracle harness not found at '{path}'. STOP -- cannot fake this."
+        )
+    return path
+
+
+def extract_code_segment(elf_path: str):
+    ef = ELFFile(elf_path)
+    ef.load()
+    code_segs = [
+        ph for ph in ef.program_headers
+        if ph.p_type == PT_LOAD and (ph.p_flags & PF_X) and ph.p_filesz > 0
+    ]
+    if not code_segs:
+        raise SystemExit(f"error: no executable PT_LOAD segment found in '{elf_path}'")
+    ph = code_segs[0]
+    data = ef.raw_data[ph.p_offset:ph.p_offset + ph.p_filesz]
+    return data, ph.p_vaddr
+
+
+def decode_ours(code: bytes, vaddr: int):
+    out = {}
+    n = len(code) - (len(code) % 4)
+    for off in range(0, n, 4):
+        word = struct.unpack_from(">I", code, off)[0]
+        insn = spu_decode(word, vaddr + off)
+        out[vaddr + off] = (insn.mnemonic, insn.operands, word)
+    return out
+
+
+def decode_oracle(oracle_exe: str, code: bytes, vaddr: int):
+    base = vaddr
+    if base + len(code) > 0x40000:
+        base = vaddr & 0x3FFFF
+        if base + len(code) > 0x40000:
+            raise SystemExit(
+                f"error: code segment (vaddr=0x{vaddr:x} len=0x{len(code):x}) "
+                "does not fit in a 256 KiB SPU local store even after LS-masking"
+            )
+
+    with tempfile.NamedTemporaryFile(suffix=".spu.bin", delete=False) as tf:
+        tf.write(code)
+        tmp_path = tf.name
+
+    try:
+        proc = subprocess.run(
+            [oracle_exe, tmp_path, "--base", hex(base)],
+            capture_output=True, text=True, timeout=120,
+        )
+    finally:
+        os.unlink(tmp_path)
+
+    if proc.returncode != 0:
+        raise SystemExit(
+            f"error: oracle harness exited {proc.returncode}\n"
+            f"stdout: {proc.stdout[-2000:]}\nstderr: {proc.stderr[-2000:]}"
+        )
+
+    out = {}
+    delta = vaddr - base
+    for line in proc.stdout.splitlines():
+        colon = line.find(":")
+        if colon < 0:
+            continue
+        try:
+            off = int(line[:colon], 16)
+        except ValueError:
+            continue
+        rest = line[colon + 1:].strip()
+        if not rest or rest.startswith("<"):
+            continue
+        sp = rest.split(None, 1)
+        mnemonic = sp[0]
+        operands = sp[1] if len(sp) > 1 else ""
+        out[off + delta] = (mnemonic, operands)
+    return out
+
+
+def audit_one(image_path: str, oracle_exe: str, samples: int, whitelist: dict):
+    code, vaddr = extract_code_segment(image_path)
+    ours = decode_ours(code, vaddr)
+    oracle = decode_oracle(oracle_exe, code, vaddr)
+
+    mnemonic_matched = 0
+    mismatch_counts = Counter()
+    mismatch_samples = defaultdict(list)
+    whitelisted_counts = Counter()
+
+    for addr, (our_mn, our_ops, word) in ours.items():
+        oracle_entry = oracle.get(addr)
+        if oracle_entry is None:
+            continue
+        oracle_mn, oracle_ops = oracle_entry
+        if our_mn != oracle_mn:
+            continue  # v1's job
+        mnemonic_matched += 1
+
+        our_atoms = split_operands(our_mn, our_ops, ours=True)
+        oracle_atoms = split_operands(oracle_mn, oracle_ops, ours=False)
+
+        if our_atoms == oracle_atoms:
+            continue
+
+        key = our_mn
+        entry = (addr, word, our_ops.strip(), oracle_ops.strip(),
+                 our_atoms, oracle_atoms)
+        if key in whitelist:
+            whitelisted_counts[key] += 1
+        else:
+            mismatch_counts[key] += 1
+            if len(mismatch_samples[key]) < samples:
+                mismatch_samples[key].append(entry)
+
+    return mnemonic_matched, mismatch_counts, mismatch_samples, whitelisted_counts, len(ours)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("images", nargs="+")
+    ap.add_argument("--oracle-exe", default=None,
+                     help="path to your built spu_dump_tool.exe "
+                          "(default: $SPU_DUMP_TOOL_EXE if set)")
+    ap.add_argument("--samples", type=int, default=5)
+    ap.add_argument("--whitelist", default=DEFAULT_WHITELIST)
+    args = ap.parse_args()
+
+    oracle_exe = find_oracle_exe(args.oracle_exe)
+    whitelist = load_whitelist(args.whitelist)
+    print(f"[spu_operand_audit] oracle exe: {oracle_exe}")
+    print(f"[spu_operand_audit] whitelist: {args.whitelist} ({len(whitelist)} entries)")
+    print(f"[spu_operand_audit] images: {len(args.images)}")
+
+    grand_words = 0
+    grand_matched = 0
+    combined_counts = Counter()
+    combined_samples = defaultdict(list)
+    combined_whitelisted = Counter()
+    per_image = []
+
+    for img in args.images:
+        matched, counts, samples_d, wl_counts, total_words = audit_one(
+            img, oracle_exe, args.samples, whitelist)
+        grand_words += total_words
+        grand_matched += matched
+        per_image.append((img, total_words, matched, sum(counts.values())))
+        combined_counts.update(counts)
+        combined_whitelisted.update(wl_counts)
+        for k, v in samples_d.items():
+            for e in v:
+                if len(combined_samples[k]) < args.samples:
+                    combined_samples[k].append(e)
+
+    print()
+    print("=== Per-image summary ===")
+    for img, total, matched, mism in per_image:
+        print(f"  {os.path.basename(img)}: {total} words, {matched} mnemonic-matched, {mism} operand divergences")
+
+    print()
+    print(f"=== Totals across {len(args.images)} image(s): {grand_words} words decoded, "
+          f"{grand_matched} mnemonic-matched (population for THIS audit) ===")
+    total_residual = sum(combined_counts.values())
+    total_whitelisted = sum(combined_whitelisted.values())
+    print(f"=== Residual (non-whitelisted) operand divergences: {total_residual}  "
+          f"(whitelisted: {total_whitelisted}) ===")
+
+    print()
+    print("--- Residual operand divergences, grouped by mnemonic, descending count (top 30) ---")
+    for mn, count in sorted(combined_counts.items(), key=lambda kv: -kv[1])[:30]:
+        print(f"  {mn}: {count} divergent word(s)")
+        for (addr, word, our_ops, oracle_ops, our_atoms, oracle_atoms) in combined_samples[mn]:
+            print(f"      0x{addr:08x}  word=0x{word:08x}  ours='{our_ops}' ({our_atoms})  "
+                  f"oracle='{oracle_ops}' ({oracle_atoms})")
+    if not combined_counts:
+        print("  (none)")
+
+    print()
+    print("--- Whitelisted mnemonics, INFO only ---")
+    for mn, count in sorted(combined_whitelisted.items(), key=lambda kv: -kv[1]):
+        print(f"  {mn}: {count}  reason: {whitelist.get(mn, '')}")
+    if not combined_whitelisted:
+        print("  (none)")
+
+    core_ops = {"il", "ai", "lqd", "ori", "shufb", "brsl"}
+    core_residual = {mn: c for mn, c in combined_counts.items() if mn in core_ops}
+    print()
+    if core_residual:
+        print(f"SANITY CHECK FAILED: core ops have residual OPERAND mismatches: {core_residual}")
+    else:
+        print("SANITY CHECK OK: core ops (il, ai, lqd, ori, shufb, brsl) show zero non-whitelisted operand divergences.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/spu_disasm_audit_operands_whitelist.txt
+++ b/tools/spu_disasm_audit_operands_whitelist.txt
@@ -1,0 +1,83 @@
+# Whitelist for tools/spu_disasm_audit_operands.py
+# One "mnemonic:reason" per line. '#' comments and blank lines ignored.
+# Conservative by design -- never whitelist a real register-index or
+# immediate-VALUE mismatch, especially on il/ila/ilh/ilhu/ai/ahi.
+#
+# Every entry below was individually traced through BOTH tools/spu_lifter.py
+# (which mnemonic dispatch table consumes the operand, and how) AND the
+# consuming runtime/spu/spu_helpers.h helper, to confirm the divergence is
+# format/display-only with PROVEN-ZERO codegen impact -- not merely "looks
+# benign". See the 2026-07-05 operand-audit session notes for the full
+# derivation; short form per entry below.
+
+# --- RI7 sign-extension (roti/rotmi/rotmai/rothi/rothmi/rotmahi/shli/shlhi/
+# rotqbii/rotqmbii/shlqbii/rotqbyi/rotqmbyi/shlqbyi/cbd/chd/cwd/cdd):
+# tools/spu_disasm.py's ri7_table (~line 493-520) extracts the 7-bit
+# immediate UNSIGNED (i7 = rb field, 0-127); RPCS3's SPUDisAsm.h uses
+# op.si7 (SIGNED, -64..63) for every one of these. This is a REAL,
+# class-wide decode bug (confirmed: the 7-bit unsigned value differs from
+# the signed one by exactly 128 whenever bit 6 is set) -- but PROVEN
+# codegen-inert: every runtime/spu/spu_helpers.h consumer masks the
+# resulting shift/rotate-amount or byte-position with a power-of-two <= 64
+# (0x1F, 0x3F, 0x0F, 0x07, or the cbd/chd/cwd/cdd `pos & 0xF` after a plain
+# `+i7` add) before use, and 128 is a multiple of every such mask -- so
+# ours(unsigned) and oracle(signed) always reduce to the identical
+# post-mask value (verified exhaustively for all 128 possible 7-bit
+# patterns against 0x1F/0x3F masks, session scratchpad). Reported as a
+# disassembler completeness/display bug in the operand-audit findings;
+# NOT whitelisted blanket-wide here since it IS a real value divergence --
+# left OUT of this file deliberately so the tool keeps reporting it
+# (matches "never whitelist a real value mismatch" instruction); this
+# comment documents the impact analysis for the report/reviewer instead.
+
+# --- andbi/xorbi/orbi (byte-immediate logic): tools/spu_disasm.py prints
+# the raw SIGNED 10-bit RI10 value (sign_extend, -512..511); RPCS3 prints
+# static_cast<u8>(op.si10) (unsigned byte, 0..255). tools/spu_lifter.py
+# passes the literal token straight through _imm() into
+# spu_andbi/spu_orbi/spu_xorbi(u128, int32_t imm), which immediately do
+# `(uint8_t)imm` internally (runtime/spu/spu_helpers.h ~line 453-456) --
+# any signed vs unsigned C integer literal that denotes the same 8-bit
+# two's-complement pattern truncates identically. PROVEN benign.
+andbi:byte-immediate truncates to uint8_t in spu_andbi() regardless of C literal sign; see runtime/spu/spu_helpers.h ~453
+xorbi:byte-immediate truncates to uint8_t in spu_xorbi() regardless of C literal sign; see runtime/spu/spu_helpers.h ~244
+orbi:byte-immediate truncates to uint8_t in spu_orbi() regardless of C literal sign; see runtime/spu/spu_helpers.h ~455
+
+# --- Unary RR ops missing from spu_disasm.py's "Single-operand" exception
+# list (~line 482): xsbh, xshw, xswd, frest, frsqest, gbb, fsmh, fesd,
+# frds, fscrwr all fall through to the generic 3-register RR default
+# (rt, ra, rb) and print a spurious extra "$r{rb}" operand that the real
+# ISA encoding does not have (verified against SPUDisAsm.h: each is
+# DisAsm(mnemonic, rt, ra) only, no rb). tools/spu_lifter.py's rr_un
+# dispatch table (~line 421-434) only ever calls rt()=ops[0] and
+# ra()=ops[1] for this class -- the bogus ops[2] token is never read.
+# fscrwr is handled separately as an unconditional FPSCR no-op (~line 342)
+# and never reads any operand. PROVEN benign (display-only).
+xsbh:spurious 3rd "$rb" operand never read by spu_lifter.py's rr_un dispatch (only rt=ops[0], ra=ops[1] used)
+xshw:spurious 3rd "$rb" operand never read by spu_lifter.py's rr_un dispatch (only rt=ops[0], ra=ops[1] used)
+xswd:spurious 3rd "$rb" operand never read by spu_lifter.py's rr_un dispatch (only rt=ops[0], ra=ops[1] used)
+frest:spurious 3rd "$rb" operand never read by spu_lifter.py's rr_un dispatch (only rt=ops[0], ra=ops[1] used)
+frsqest:spurious 3rd "$rb" operand never read by spu_lifter.py's rr_un dispatch (only rt=ops[0], ra=ops[1] used)
+gbb:spurious 3rd "$rb" operand never read by spu_lifter.py's rr_un dispatch (only rt=ops[0], ra=ops[1] used)
+fsmh:spurious 3rd "$rb" operand never read by spu_lifter.py's rr_un dispatch (only rt=ops[0], ra=ops[1] used)
+fesd:spurious 3rd "$rb" operand never read by spu_lifter.py's rr_un dispatch (only rt=ops[0], ra=ops[1] used)
+frds:spurious 3rd "$rb" operand never read by spu_lifter.py's rr_un dispatch (only rt=ops[0], ra=ops[1] used)
+fscrwr:fscrwr is an unconditional FPSCR no-op in spu_lifter.py (~line 342); no operand ever read
+fscrrd:spurious "ra" operand (real ISA has none; SPUDisAsm FSCRRD takes rt only) computed via spu_fscrrd(ra) but the arg is (void)-discarded and always returns zero (runtime/spu/spu_helpers.h ~286) -- read has no side effects, PROVEN benign
+iret:extra rt/rb operands never real (real ISA: iret takes no GPR operand, jumps to fixed SRR0); spu_lifter.py's iret codegen (~line 618) reads zero operands -- PROVEN benign
+
+# --- nop: SPU ISA's "rt" field on a NOP-class instruction is architecturally
+# a don't-care padding slot (RPCS3 prints it anyway as "r127"); ours prints
+# no operand. spu_lifter.py's nop handler (~line 338) is an unconditional
+# "/* nop */;" that reads nothing. PROVEN benign.
+nop:don't-care padding field; spu_lifter.py's nop handler reads no operand (~line 338)
+
+# NOTE: brsl/brasl/bisl (missing link-register operand) and stop (missing
+# 14-bit stop/signal code operand) and hbr/hbra/hbrr (wrong field layout
+# entirely) are DELIBERATELY NOT whitelisted here even though they are also
+# proven codegen-inert (spu_lifter.py recovers the link register from
+# insn.raw directly for brsl/brasl/bisl, ~line 549/622; stop's codegen
+# never reads the code, ~line 346; hbr/hbra/hbrr are unconditionally
+# dropped as a no-op, ~line 654) -- these are real disassembler
+# COMPLETENESS bugs worth fixing for readability/future-proofing even
+# though today's codegen doesn't depend on the missing operand, so they
+# stay visible in the residual report rather than being suppressed.

--- a/tools/spu_lifter.py
+++ b/tools/spu_lifter.py
@@ -80,6 +80,15 @@ extern "C" {
  * function and continues execution. Implemented by the SPU program glue. */
 void spu_indirect_branch(spu_context* ctx);
 
+/* stop/stopd hook (YDKJ): the runtime inspects the stop code, may deliver a
+ * stop-and-signal event to the PPU (SPURS bring-up handshake), and longjmps the
+ * host SPU thread back to spu_run_with_halt so the job does not spin past the
+ * stop. Complements ctx->status; harmless where the runtime handles status. */
+void spu_stop(spu_context* ctx);
+/* Lower-level longjmp helper: abort the host SPU thread back to spu_run_with_halt
+ * (used for the infinite no-op self-loop / idle halt idiom). */
+void spu_halt(spu_context* ctx);
+
 /* Channel access -- implemented by the runtime (MFC DMA engine, mailboxes,
  * signal notification, decrementer). See runtime/spu/spu_dma.h. */
 u128 spu_rdch(spu_context* ctx, uint32_t channel);
@@ -179,6 +188,56 @@ _NO_RT_WRITE = {
 }
 
 
+def _bi_target_reg(insn):
+    """Return the branch-target register of a bi/biz/binz/... insn, or None."""
+    ops = _ops(insn.operands)
+    if insn.mnemonic == "bi" and ops:
+        return _reg(ops[0])
+    if insn.mnemonic in ("biz", "binz", "bihz", "bihnz") and len(ops) >= 2:
+        return _reg(ops[1])
+    return None
+
+
+# RRR (4-operand) SPU ops write their destination in bits 21-27; the low 7 bits
+# (raw & 0x7F) are the RC *source* for these. Every other format writes bits 0-6.
+_RRR_DEST_OPS = {"selb", "shufb", "mpya", "fnms", "fma", "fms"}
+
+def _dest_reg(insn) -> int:
+    """The register an instruction writes (rt), accounting for RRR-format ops
+    whose destination is bits 21-27 rather than the low 7 bits."""
+    if insn.mnemonic in _RRR_DEST_OPS:
+        return (insn.raw >> 21) & 0x7F
+    return insn.raw & 0x7F
+
+
+def compute_bi_r0_jumps(insns, bounds) -> set:
+    """`bi $r0` (and conditional `biz/binz $r0`) is normally a function RETURN
+    (r0 = link register). But Sony's SPU code also uses it as a COMPUTED TAIL
+    JUMP after reloading r0 from memory -- e.g. the SPURS taskset launch
+    `lqa $r0, savedContextLr(0x2C80) ... bi $r0` jumps to the task entry
+    (0x3050), NOT back to the caller. Mistranslating that as `return;` makes
+    the launch fall through and the taskset dispatcher loop forever (same bug
+    class as the brsl mislifts). Detect it: within each function, a `bi $r0`
+    is a computed jump iff the NEAREST preceding write to r0 is an ABSOLUTE
+    load (lqa/lqr). A genuine return restores the link via a register/stack
+    load (lqd/lqx) or never rewrites r0 -- those stay returns. Returns the
+    set of such bi addrs."""
+    jumps = set()
+    for (s, e) in bounds:
+        fn = sorted((i for i in insns if s <= i.addr < e), key=lambda x: x.addr)
+        for idx, insn in enumerate(fn):
+            if _bi_target_reg(insn) != "0":
+                continue
+            # backward scan for the nearest instruction that writes r0
+            for j in range(idx - 1, -1, -1):
+                w = fn[j]
+                if w.mnemonic not in _NO_RT_WRITE and _dest_reg(w) == 0:
+                    if w.mnemonic in ("lqa", "lqr"):
+                        jumps.add(insn.addr)
+                    break  # nearest r0 writer found; classification decided
+    return jumps
+
+
 class SPULifter:
     def __init__(self, trace: bool = False, prefix: str = ""):
         self.functions: list[LiftedFunction] = []
@@ -190,6 +249,10 @@ class SPULifter:
         # Lets multiple lifted SPU images link into one binary without collisions
         # (every image otherwise exports spu_func_00000090 etc.). Empty = legacy.
         self.prefix = prefix
+        # Addresses of `bi/biz/... $r0` that are COMPUTED TAIL JUMPS (r0 reloaded
+        # via lqa/lqr), not function returns -- see compute_bi_r0_jumps(). Empty
+        # set => every `bi $r0` is a return (the prior behaviour).
+        self.bi_r0_jump: set = set()
 
     # ------------------------------------------------------------------ #
     def lift_function(self, insns: list[SPUInstruction],
@@ -288,7 +351,7 @@ class SPULifter:
         if mn == "fscrwr":
             return "/* fscrwr: FP status/control write (no-op in recomp) */;"
         if mn == "stop":
-            return "ctx->status = SPU_STATUS_STOPPED_BY_STOP; return;"
+            return "ctx->status = SPU_STATUS_STOPPED_BY_STOP; spu_stop(ctx); return;"
 
         # ---- immediate loaders ----
         if mn == "il":
@@ -315,7 +378,7 @@ class SPULifter:
         if mn in ("hgti", "hlgti", "heqi", "hgt", "hlgt", "heq"):
             return f"/* {mn}: halt-on-condition (no-op in recomp) */;"
         if mn == "stopd":
-            return "ctx->status = SPU_STATUS_STOPPED_BY_STOP; return;"
+            return "ctx->status = SPU_STATUS_STOPPED_BY_STOP; spu_stop(ctx); return;"
 
         # ---- integer arithmetic (register) ----
         rr_bin = {
@@ -331,8 +394,14 @@ class SPULifter:
             "fi": "spu_fi",   # floating interpolate (reciprocal refine)
             "fceq": "spu_fceq", "fcgt": "spu_fcgt",
             "fcmeq": "spu_fcmeq", "fcmgt": "spu_fcmgt",
+            # double-precision (2 doubles/reg) + double compares
+            "dfa": "spu_dfa", "dfs": "spu_dfs", "dfm": "spu_dfm",
+            "dfceq": "spu_dfceq", "dfcmeq": "spu_dfcmeq",
+            "dfcgt": "spu_dfcgt", "dfcmgt": "spu_dfcmgt",
+            "mpyhhu": "spu_mpyhhu",
+            "eqv": "spu_eqv", "absdb": "spu_absdb", "avgb": "spu_avgb",
             "cg": "spu_cg", "bg": "spu_bg",
-            "avgb": "spu_avgb",
+            "sumb": "spu_sumb",
             # double precision
             "dfa": "spu_dfa", "dfs": "spu_dfs", "dfm": "spu_dfm",
             # Phase 2: register-variable shifts/rotates
@@ -360,6 +429,7 @@ class SPULifter:
             "gb": "spu_gb", "gbh": "spu_gbh", "gbb": "spu_gbb",
             "fesd": "spu_fesd", "frds": "spu_frds",
             "frsqest": "spu_frsqest", "frest": "spu_frest",
+            "fesd": "spu_fesd", "frds": "spu_frds",   # single<->double convert
             # Phase 3
             "xsbh": "spu_xsbh", "xshw": "spu_xshw", "xswd": "spu_xswd",
             "orx": "spu_orx",
@@ -383,7 +453,8 @@ class SPULifter:
             # Phase 3: halfword/byte immediate logic
             "andhi": "spu_andhi", "andbi": "spu_andbi",
             "orhi":  "spu_orhi",  "orbi":  "spu_orbi",
-            "xorhi": "spu_xorhi",
+            "xorhi": "spu_xorhi", "xorbi": "spu_xorbi",
+            "dftsv": "spu_dftsv",
             # RI8 float<->int conversions with scale (i8 in ops[2])
             "cflts": "spu_cflts", "cfltu": "spu_cfltu",
             "csflt": "spu_csflt", "cuflt": "spu_cuflt",
@@ -431,6 +502,15 @@ class SPULifter:
         # sfx: extended subtract — RT is also a source (carry-in = low bit of old RT).
         if mn == "sfx":
             return f"{g(rt())} = spu_sfx({g(ra())}, {g(rb())}, {g(rt())});"
+        # cgx: extended carry-generate — RT is also a source (carry-in = low bit).
+        if mn == "cgx":
+            return f"{g(rt())} = spu_cgx({g(ra())}, {g(rb())}, {g(rt())});"
+        # double FMA (dfma/dfms/dfnms/dfnma): 3-register, RT is the accumulator (c).
+        if mn in ("dfma", "dfms", "dfnms", "dfnma"):
+            return f"{g(rt())} = spu_{mn}({g(ra())}, {g(rb())}, {g(rt())});"
+        # mpyhha/mpyhhau: high-half multiply accumulated into RT (3-register).
+        if mn in ("mpyhha", "mpyhhau"):
+            return f"{g(rt())} = spu_{mn}({g(ra())}, {g(rb())}, {g(rt())});"
 
         # ---- quadword loads / stores ----
         if mn == "lqd":
@@ -454,7 +534,9 @@ class SPULifter:
         if mn == "rdch":
             return f"{g(rt())} = spu_rdch(ctx, {_chan(ops[1])});"
         if mn == "rchcnt":
-            return f"{g(rt())} = spu_splat_u32(spu_rchcnt(ctx, {_chan(ops[1])}));"
+            # CBEA: the count lands in the PREFERRED word, remaining slots ZERO
+            # (splatting it is the spu_link bug class; RPCS3 = v128::from32r).
+            return f"{g(rt())} = spu_pref_u32(spu_rchcnt(ctx, {_chan(ops[1])}));"
         if mn == "wrch":
             # operands: channel, $rt
             return f"spu_wrch(ctx, {_chan(ops[0])}, {g(_reg(ops[1]))});"
@@ -462,13 +544,39 @@ class SPULifter:
         # ---- branches ----
         if mn in ("br", "bra"):
             tgt = self._branch_target(insn)
+            # SELF-LOOP TRAP: `br .` (target == this instruction) is an infinite
+            # hang on real SPU -- a deliberate trap, no forward progress. Emitting
+            # `goto loc_self` busy-spins the host thread forever; stop the SPU
+            # instead (same halt path the lifter emits for a `stop` instruction).
+            if tgt == addr:
+                return "ctx->status = SPU_STATUS_STOPPED_BY_HALT; return;"
             return self._uncond_branch(tgt, func)
         if mn in ("brsl", "brasl"):
             # The disassembler drops the link register from brsl operands, so
             # recover it from the raw encoding (rt = bits 25-31 = raw & 0x7F).
             link_rt = insn.raw & 0x7F
             tgt = self._branch_target(insn)
-            link = f"{g(link_rt)} = spu_splat_u32(0x{addr + 4:X});"
+            # Link register: preferred word only, other slots ZERO (real HW /
+            # RPCS3 v128::from32r) -- splatting corrupts full-quadword link use.
+            link = f"{g(link_rt)} = spu_link(0x{addr + 4:X});"
+            # SELF-LOOP TRAP: `brsl rX, .` (target == this instruction) is an
+            # infinite loop on real SPU (re-sets the link each pass, never
+            # advances) -- a trap, NOT a call. Emitting a host call recurses
+            # forever -> host stack overflow -> segfault (observed crashing the
+            # boot in cri_audio_00023C58). Set the link, then stop the SPU (same
+            # halt path the lifter emits for a `stop` instruction).
+            if tgt == addr:
+                return f"{link} ctx->status = SPU_STATUS_STOPPED_BY_HALT; return;"
+            # PC-GETTER IDIOM: `brsl rX, .+4` (target == next instruction) just
+            # loads PC+4 into rX for PC-relative addressing / computed jump tables;
+            # it is NOT a real call. Emitting a host call here imbalances the C
+            # call/return nesting -- the "callee" falls through into the rest of
+            # the function and a later `bi $r0` return unwinds to this brsl's frame
+            # instead of the real caller (observed: SPURS taskset LoadElf's return
+            # landed back inside its own clear loop, running it with a stale count).
+            # Treat it as: set the link, then fall through to addr+4.
+            if tgt == addr + 4:
+                return f"{link} {self._uncond_branch(addr + 4, func)}"
             if tgt is not None:
                 self.call_targets.add(tgt)
                 return f"{link} {self.prefix}spu_func_{tgt:08X}(ctx);"
@@ -488,26 +596,51 @@ class SPULifter:
             tgt_reg = _reg(ops[0])
             # SPU ABI: $r0 is the link register. `bi $r0` is the standard
             # function return — translate to a host return so call/return
-            # discipline matches the C function nesting from brsl.
-            if tgt_reg == "0":
+            # discipline matches the C function nesting from brsl. EXCEPTION:
+            # when r0 was reloaded from memory (lqa/lqr) it is a COMPUTED TAIL
+            # JUMP (e.g. the SPURS task launch `lqa $r0,savedContextLr; bi $r0`),
+            # flagged by compute_bi_r0_jumps() — emit the indirect dispatch.
+            if tgt_reg == "0" and addr not in self.bi_r0_jump:
                 return "return;"
             return (f"ctx->pc = {g(tgt_reg)}._u32[0]; "
                     f"spu_indirect_branch(ctx); return;")
+        # iret: interrupt return -> branch to the saved interrupt PC (SRR0).
+        if mn == "iret":
+            return ("ctx->pc = ctx->srr0; "
+                    "spu_indirect_branch(ctx); return;")
         if mn in ("bisl",):
             link_rt = insn.raw & 0x7F            # link reg dropped from operands
             tgt_reg = _reg(ops[0])
-            return (f"{g(link_rt)} = spu_splat_u32(0x{addr + 4:X}); "
+            return (f"{g(link_rt)} = spu_link(0x{addr + 4:X}); "
                     f"ctx->pc = {g(tgt_reg)}._u32[0]; spu_indirect_branch(ctx);")
+        # bisled: set link, branch to RA only if an external event is pending.
+        if mn in ("bisled",):
+            link_rt = insn.raw & 0x7F
+            tgt_reg = _reg(ops[0])
+            return (f"{g(link_rt)} = spu_splat_u32(0x{addr + 4:X}); "
+                    f"if ((ctx->event_status & ctx->event_mask) != 0) {{ "
+                    f"ctx->pc = {g(tgt_reg)}._u32[0]; "
+                    f"spu_indirect_branch(ctx); return; }}")
         # biz/binz/bihz/bihnz: ops[0] = condition reg, ops[1] = target reg.
         if mn in ("biz", "binz", "bihz", "bihnz"):
             cond = self._cond(mn[1:], _reg(ops[0]))   # strip leading 'b' -> iz/inz...
             tgt_reg = _reg(ops[1])
+            # $r0 is the link register: a conditional branch to it is a
+            # conditional function return — emit a host return so it composes
+            # with the brsl->C-call nesting (mirrors the `bi $r0` case above).
+            # Dispatching to the return address would miss the C frame and
+            # land on an unregistered mid-function PC.
+            if tgt_reg == "0" and addr not in self.bi_r0_jump:
+                return f"if ({cond}) return;"
             return (f"if ({cond}) {{ ctx->pc = {g(tgt_reg)}._u32[0]; "
                     f"spu_indirect_branch(ctx); return; }}")
 
         # hint-for-branch: pure performance hint, safe to drop
         if mn in ("hbr", "hbra", "hbrr"):
             return "/* branch hint (ignored) */;"
+        # mtspr: SPU special-purpose-register writes are ignored (RPCS3: SPRs unused)
+        if mn == "mtspr":
+            return "/* mtspr: SPR write ignored */;"
 
         # ---- fallthrough: unsupported ----
         self.unsupported[mn] = self.unsupported.get(mn, 0) + 1
@@ -626,6 +759,11 @@ def main() -> None:
                    help="Prefix for all emitted spu_func_* / spu_recomp_register "
                         "symbols, so multiple lifted SPU images can link into one "
                         "binary without colliding (e.g. flow_spu_00_). Default: none.")
+    p.add_argument("--extra-funcs", default="",
+                   help="Comma-separated extra function entry addresses (e.g. "
+                        "0x10F8,0x808) to add as boundaries -- for indirect-branch "
+                        "targets that --auto-functions can't detect statically. "
+                        "Splits the containing auto-detected function at each addr.")
     args = p.parse_args()
 
     if args.auto_functions:
@@ -654,9 +792,34 @@ def main() -> None:
             # No boundary info: treat the whole image as one function.
             bounds = [(base, base + len(data))]
 
+    # Add extra function entry points (indirect-branch targets auto-detect misses)
+    # by splitting whichever bound contains each address.
+    if args.extra_funcs:
+        extra = [int(x, 0) for x in args.extra_funcs.split(",") if x.strip()]
+        bset = sorted(set(bounds))
+        for a in extra:
+            newb = []
+            split = False
+            for (s, e) in bset:
+                if s < a < e:
+                    newb.append((s, a)); newb.append((a, e)); split = True
+                else:
+                    newb.append((s, e))
+            if not split and not any(s == a for s, _ in bset):
+                newb.append((a, base + len(data)))
+            bset = sorted(set(newb))
+        bounds = bset
+        sys.stderr.write("[spu_lifter] added extra funcs: %s\n" %
+                         ", ".join("0x%X" % a for a in extra))
+
     insns = disassemble_spu(data, base)
 
     lifter = SPULifter(trace=args.trace, prefix=args.symbol_prefix)
+    lifter.bi_r0_jump = compute_bi_r0_jumps(insns, bounds)
+    if lifter.bi_r0_jump:
+        print(f"  {len(lifter.bi_r0_jump)} `bi $r0` computed-jump site(s) "
+              f"(r0 reloaded via lqa/lqr): "
+              f"{', '.join(f'0x{a:X}' for a in sorted(lifter.bi_r0_jump))}")
     lifter.func_starts = {s for s, e in bounds}  # for fall-through tail-call chaining
     for s, e in bounds:
         lifter.lift_function(insns, s, e)

--- a/tools/test_ppu_lift.py
+++ b/tools/test_ppu_lift.py
@@ -1,0 +1,543 @@
+#!/usr/bin/env python3
+"""PPU lifter conformance suite.
+
+Tests the lifter's ACTUAL EMISSIONS (not a parallel implementation): each case
+encodes a real instruction word, round-trips it through ppu_disasm.decode
+(verifying the encoding), asks PPULifter for the C statement it would emit for
+that instruction, and wraps all statements in a generated C driver that runs
+them against edge-case register inputs and compares results with expectations
+computed here in Python straight from the PowerISA definitions.
+
+Why this exists: two multi-session silent-miscompile hunts (spu_disasm il
+double sign-extension; cntlzw(0) = raw __builtin_clz UB that dropped every
+SPURS-queue wakeup signal) were single-instruction semantics bugs that a suite
+like this catches in milliseconds. Sweep the class, don't spot-fix.
+
+Usage:
+    py -3 tools\\test_ppu_lift.py            # generate + compile + run
+    py -3 tools\\test_ppu_lift.py --emit     # just write the C file
+The compile step needs cl on PATH (the script self-launches vcvars64 like
+scratch\\dobuild2.bat when cl is absent).
+
+Scope (tranche 1): integer ALU/rotate/shift/carry/compare classes -- the
+proven silent-miscompile territory. Memory ops, FP, and VMX are follow-on
+tranches (VMX semantics already have manual-verified handling; loads/stores
+need a vm stub harness).
+"""
+
+import argparse
+import os
+import random
+import subprocess
+import sys
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(TOOLS)
+sys.path.insert(0, TOOLS)
+
+import ppu_disasm                    # noqa: E402
+from ppu_lifter import PPULifter, LiftedFunction   # noqa: E402
+
+MASK64 = (1 << 64) - 1
+MASK32 = (1 << 32) - 1
+
+# ---------------------------------------------------------------------------
+# Instruction encoders (big-endian words). Every encoded word is round-tripped
+# through ppu_disasm.decode and the mnemonic checked, so an encoding mistake
+# here is reported as ENCODING, never as a false lifter failure.
+# ---------------------------------------------------------------------------
+
+def xo_form(xo, rt, ra, rb, oe=0, rc=0):
+    return (31 << 26) | (rt << 21) | (ra << 16) | (rb << 11) | (oe << 10) | (xo << 1) | rc
+
+def x_logic(xo, rs, ra, rb, rc=0):   # and/or/... rs sits in the rt slot
+    return (31 << 26) | (rs << 21) | (ra << 16) | (rb << 11) | (xo << 1) | rc
+
+def d_form(op, rt, ra, imm):
+    return (op << 26) | (rt << 21) | (ra << 16) | (imm & 0xFFFF)
+
+def m_form(op, rs, ra, sh, mb, me, rc=0):
+    return (op << 26) | (rs << 21) | (ra << 16) | (sh << 11) | (mb << 6) | (me << 1) | rc
+
+def md_form(xo3, rs, ra, sh, mbe, rc=0):   # rldicl/rldicr/rldic/rldimi
+    return ((30 << 26) | (rs << 21) | (ra << 16) | ((sh & 31) << 11)
+            | ((mbe & 31) << 6) | ((mbe >> 5) << 5) | (xo3 << 2) | ((sh >> 5) << 1) | rc)
+
+def xs_sradi(rs, ra, sh, rc=0):
+    return ((31 << 26) | (rs << 21) | (ra << 16) | ((sh & 31) << 11)
+            | (413 << 2) | ((sh >> 5) << 1) | rc)
+
+def cmp_form(xo, bf, l, ra, rb):
+    return (31 << 26) | (bf << 23) | (l << 21) | (ra << 16) | (rb << 11) | (xo << 1)
+
+def cmpi_form(op, bf, l, ra, imm):
+    return (op << 26) | (bf << 23) | (l << 21) | (ra << 16) | (imm & 0xFFFF)
+
+# ---------------------------------------------------------------------------
+# PowerISA reference semantics (independent of the lifter). 64-bit registers;
+# CA per the 64-bit operation (PowerISA v2.03, the manual in the repo root).
+# ---------------------------------------------------------------------------
+
+def s64(v): v &= MASK64; return v - (1 << 64) if v >> 63 else v
+def s32(v): v &= MASK32; return v - (1 << 32) if v >> 31 else v
+def sxw(v): return s32(v) & MASK64          # sign-extend low word to 64
+
+def ref_add(a, b):        return (a + b) & MASK64, None
+def ref_addc(a, b):       s = a + b; return s & MASK64, s >> 64
+def ref_adde(a, b, ca):   s = a + b + ca; return s & MASK64, s >> 64
+def ref_addme(a, ca):     s = a + MASK64 + ca; return s & MASK64, s >> 64
+def ref_addze(a, ca):     s = a + ca; return s & MASK64, s >> 64
+def ref_subf(a, b):       return (b - a) & MASK64, None
+def ref_subfc(a, b):      s = ((~a) & MASK64) + b + 1; return s & MASK64, s >> 64
+def ref_subfe(a, b, ca):  s = ((~a) & MASK64) + b + ca; return s & MASK64, s >> 64
+def ref_subfme(a, ca):    s = ((~a) & MASK64) + MASK64 + ca; return s & MASK64, s >> 64
+def ref_subfze(a, ca):    s = ((~a) & MASK64) + ca; return s & MASK64, s >> 64
+def ref_neg(a):           return (-a) & MASK64, None
+def ref_cntlzw(a):        w = a & MASK32; return (32 if w == 0 else 31 - w.bit_length() + 1), None
+def ref_cntlzd(a):        return (64 if a == 0 else 64 - a.bit_length()), None
+def ref_extsb(a):         v = a & 0xFF; return (v - 0x100 if v >> 7 else v) & MASK64, None
+def ref_extsh(a):         v = a & 0xFFFF; return (v - 0x10000 if v >> 15 else v) & MASK64, None
+def ref_extsw(a):         return sxw(a), None
+def ref_mullw(a, b):      return (s32(a) * s32(b)) & MASK64, None
+def ref_mulhw(a, b):      return ((s32(a) * s32(b)) >> 32) & MASK32, None   # low32 defined; high undefined -> mask32 compare
+def ref_mulhwu(a, b):     return (((a & MASK32) * (b & MASK32)) >> 32) & MASK32, None
+def ref_mulld(a, b):      return (s64(a) * s64(b)) & MASK64, None
+def ref_mulhd(a, b):      return ((s64(a) * s64(b)) >> 64) & MASK64, None
+def ref_mulhdu(a, b):     return ((a * b) >> 64) & MASK64, None
+def ref_mulli(a, imm):    return (s64(a) * imm) & MASK64, None
+
+def rotl32(v, n): v &= MASK32; n &= 31; return ((v << n) | (v >> (32 - n))) & MASK32 if n else v
+def rotl64(v, n): v &= MASK64; n &= 63; return ((v << n) | (v >> (64 - n))) & MASK64 if n else v
+
+def mask32(mb, me):
+    if mb <= me:
+        return (MASK32 >> mb) & (MASK32 << (31 - me)) & MASK32
+    return ((MASK32 >> mb) | (MASK32 << (31 - me))) & MASK32
+
+def mask64(mb, me):
+    if mb <= me:
+        m = MASK64 if mb == 0 else (MASK64 >> mb)
+        return m & ((MASK64 << (63 - me)) & MASK64)
+    return ((MASK64 >> mb) | ((MASK64 << (63 - me)) & MASK64)) & MASK64
+
+def ref_rlwinm(a, sh, mb, me):   return rotl32(a, sh) & mask32(mb, me), None
+def ref_rlwimi(ra, rs, sh, mb, me):
+    m = mask32(mb, me)
+    return ((rotl32(rs, sh) & m) | (ra & MASK32 & ~m)) & MASK32, None   # low32 compare
+def ref_rldicl(a, sh, mb): return rotl64(a, sh) & mask64(mb, 63), None
+def ref_rldicr(a, sh, me): return rotl64(a, sh) & mask64(0, me), None
+def ref_rldimi(ra, rs, sh, mb):
+    m = mask64(mb, 63 - sh)
+    return ((rotl64(rs, sh) & m) | (ra & ~m)) & MASK64, None
+
+def ref_slw(a, b):
+    n = b & 0x3F
+    return 0 if n & 0x20 else ((a & MASK32) << n) & MASK32, None
+def ref_srw(a, b):
+    n = b & 0x3F
+    return 0 if n & 0x20 else (a & MASK32) >> n, None
+def ref_sld(a, b):
+    n = b & 0x7F
+    return 0 if n & 0x40 else (a << n) & MASK64, None
+def ref_srd(a, b):
+    n = b & 0x7F
+    return 0 if n & 0x40 else a >> n, None
+
+def ref_srawi(a, sh):
+    rs = s32(a)
+    if sh == 0:
+        return sxw(a), 0
+    out = (a & MASK32) & ((1 << sh) - 1)
+    return (rs >> sh) & MASK64, 1 if (rs < 0 and out) else 0
+def ref_sraw(a, b):
+    n = b & 0x3F
+    rs = s32(a)
+    if n == 0:
+        return sxw(a), 0
+    if n >= 32:
+        return (rs >> 31) & MASK64, 1 if (rs < 0) else 0
+    out = (a & MASK32) & ((1 << n) - 1)
+    return (rs >> n) & MASK64, 1 if (rs < 0 and out) else 0
+def ref_sradi(a, sh):
+    rs = s64(a)
+    if sh == 0:
+        return a & MASK64, 0
+    out = a & ((1 << sh) - 1)
+    return (rs >> sh) & MASK64, 1 if (rs < 0 and out) else 0
+
+def ref_logic(op, a, b):
+    f = {"and": a & b, "or": a | b, "xor": a ^ b, "nand": ~(a & b),
+         "nor": ~(a | b), "andc": a & ~b, "orc": a | ~b, "eqv": ~(a ^ b)}[op]
+    return f & MASK64, None
+
+def ref_addi(a, imm):  return (a + imm) & MASK64, None
+def ref_addic(a, imm): s = a + (imm & MASK64); return s & MASK64, s >> 64
+def ref_subfic(a, imm):
+    s = ((~a) & MASK64) + (imm & MASK64) + 1
+    return s & MASK64, s >> 64
+
+def ref_divw(a, b):
+    d, n = s32(a), s32(b)
+    if n == 0 or (d == -(1 << 31) and n == -1):
+        return None, None                        # UNDEFINED: assert no-crash only
+    return (int(d / n) if (d < 0) != (n < 0) else d // n) & MASK32, None
+def ref_divwu(a, b):
+    d, n = a & MASK32, b & MASK32
+    if n == 0:
+        return None, None
+    return (d // n) & MASK32, None
+def ref_divd(a, b):
+    d, n = s64(a), s64(b)
+    if n == 0 or (d == -(1 << 63) and n == -1):
+        return None, None
+    q = abs(d) // abs(n)
+    return (q if (d < 0) == (n < 0) else -q) & MASK64, None
+def ref_divdu(a, b):
+    if b == 0:
+        return None, None
+    return (a // b) & MASK64, None
+
+def cr_nibble_signed(a, b):
+    if s64(a) < s64(b): return 8
+    if s64(a) > s64(b): return 4
+    return 2
+def cr_nibble_signed32(a, b):
+    if s32(a) < s32(b): return 8
+    if s32(a) > s32(b): return 4
+    return 2
+def cr_nibble_unsigned(a, b, bits):
+    m = (1 << bits) - 1
+    if (a & m) < (b & m): return 8
+    if (a & m) > (b & m): return 4
+    return 2
+
+# ---------------------------------------------------------------------------
+# Test-case construction
+# ---------------------------------------------------------------------------
+
+E64 = [0, 1, 2, MASK64, 0x7FFFFFFFFFFFFFFF, 0x8000000000000000,
+       0xFFFFFFFF, 0x80000000, 0x7FFFFFFF, 0x100000000,
+       0x123456789ABCDEF0, 0xFEDCBA9876543210]
+rng = random.Random(0x59414B5A)   # deterministic
+E64 += [rng.getrandbits(64) for _ in range(4)]
+
+CASES = []   # dicts: name, word, in_regs {idx:val}, in_ca, expects [(reg, val, mask)], exp_ca, exp_cr(nibble,pos), may_trap
+
+def case(name, word, in_regs, expects, in_ca=None, exp_ca=None, exp_cr=None, may_trap=False):
+    CASES.append(dict(name=name, word=word, in_regs=in_regs, expects=expects,
+                      in_ca=in_ca, exp_ca=exp_ca, exp_cr=exp_cr, may_trap=may_trap))
+
+def pairs(n=6):
+    ps = []
+    for i in range(n):
+        ps.append((E64[i * 3 % len(E64)], E64[(i * 5 + 2) % len(E64)]))
+    ps += [(0, 0), (MASK64, 1), (0x7FFFFFFFFFFFFFFF, 1), (0x8000000000000000, MASK64),
+           (0xFFFFFFFF, 1), (0x80000000, 0x80000000)]
+    return ps
+
+def build_cases():
+    R = 3, 4, 5   # rt, ra, rb
+
+    # --- XO-form arithmetic + carry family -------------------------------
+    xo_ops = [
+        ("add",    266, lambda a, b, ca: ref_add(a, b)),
+        ("subf",    40, lambda a, b, ca: ref_subf(a, b)),
+        ("addc",    10, lambda a, b, ca: ref_addc(a, b)),
+        ("subfc",    8, lambda a, b, ca: ref_subfc(a, b)),
+        ("adde",   138, lambda a, b, ca: ref_adde(a, b, ca)),
+        ("subfe",  136, lambda a, b, ca: ref_subfe(a, b, ca)),
+        ("mullw",  235, lambda a, b, ca: ref_mullw(a, b)),
+        ("mulld",  233, lambda a, b, ca: ref_mulld(a, b)),
+        ("mulhw",   75, lambda a, b, ca: ref_mulhw(a, b)),
+        ("mulhwu",  11, lambda a, b, ca: ref_mulhwu(a, b)),
+        ("mulhd",   73, lambda a, b, ca: ref_mulhd(a, b)),
+        ("mulhdu",   9, lambda a, b, ca: ref_mulhdu(a, b)),
+    ]
+    for name, xo, ref in xo_ops:
+        uses_ca = name in ("adde", "subfe")
+        sets_ca = name in ("addc", "subfc", "adde", "subfe")
+        for a, b in pairs():
+            for ca in ((0, 1) if uses_ca else (None,)):
+                v, cout = ref(a, b, ca or 0)
+                mask = MASK32 if name in ("mulhw", "mulhwu") else MASK64
+                case(f"{name} a={a:#x} b={b:#x} ca={ca}",
+                     xo_form(xo, R[0], R[1], R[2]),
+                     {R[1]: a, R[2]: b}, [(R[0], v, mask)],
+                     in_ca=ca, exp_ca=(cout if sets_ca else None))
+
+    for name, xo, ref in [("addme", 234, ref_addme), ("addze", 202, ref_addze),
+                          ("subfme", 232, ref_subfme), ("subfze", 200, ref_subfze)]:
+        for a in E64[:8]:
+            for ca in (0, 1):
+                v, cout = ref(a, ca)
+                case(f"{name} a={a:#x} ca={ca}",
+                     xo_form(xo, R[0], R[1], 0),
+                     {R[1]: a}, [(R[0], v, MASK64)], in_ca=ca, exp_ca=cout)
+
+    for a in (0, 1, MASK64, 0x8000000000000000):
+        v, _ = ref_neg(a)
+        case(f"neg a={a:#x}", xo_form(104, R[0], R[1], 0), {R[1]: a}, [(R[0], v, MASK64)])
+
+    # divides: defined-result vectors + UNDEFINED vectors as no-crash probes
+    for name, xo, ref, m in [("divw", 491, ref_divw, MASK32), ("divwu", 459, ref_divwu, MASK32),
+                             ("divd", 489, ref_divd, MASK64), ("divdu", 457, ref_divdu, MASK64)]:
+        for a, b in [(100, 7), (MASK64, 3), (0x80000000, 0xFFFFFFFF),
+                     (0x7FFFFFFF, 2), (5, MASK64)]:
+            v, _ = ref(a, b)
+            if v is not None:
+                case(f"{name} a={a:#x} b={b:#x}", xo_form(xo, R[0], R[1], R[2]),
+                     {R[1]: a, R[2]: b}, [(R[0], v, m)])
+        for a, b in [(1, 0), (0x8000000000000000, MASK64), (0x80000000, 0xFFFFFFFF00000000 | MASK32)]:
+            case(f"{name} UNDEF a={a:#x} b={b:#x}", xo_form(xo, R[0], R[1], R[2]),
+                 {R[1]: a, R[2]: b}, [], may_trap=True)
+
+    # --- X-form logicals / extends / counts ------------------------------
+    for name, xo in [("and", 28), ("or", 444), ("xor", 316), ("nand", 476),
+                     ("nor", 124), ("andc", 60), ("orc", 412), ("eqv", 284)]:
+        for a, b in pairs(3):
+            v, _ = ref_logic(name, a, b)
+            case(f"{name} a={a:#x} b={b:#x}", x_logic(xo, R[0], R[1], R[2]),
+                 {R[0]: a, R[2]: b}, [(R[1], v, MASK64)])
+
+    for name, xo, ref in [("extsb", 954, ref_extsb), ("extsh", 922, ref_extsh),
+                          ("extsw", 986, ref_extsw),
+                          ("cntlzw", 26, ref_cntlzw), ("cntlzd", 58, ref_cntlzd)]:
+        for a in [0, 1, 0x80, 0x7F, 0xFF, 0x8000, 0xFFFF, 0x80000000, MASK32,
+                  0x8000000000000000, MASK64, 0x40000000, 0x0000000100000000]:
+            v, _ = ref(a)
+            case(f"{name} a={a:#x}", x_logic(xo, R[0], R[1], 0),
+                 {R[0]: a}, [(R[1], v, MASK64)])
+
+    # --- shifts -----------------------------------------------------------
+    for name, xo, ref in [("slw", 24, ref_slw), ("srw", 536, ref_srw),
+                          ("sld", 27, ref_sld), ("srd", 539, ref_srd)]:
+        for a in (0x1, 0x80000000, MASK32, 0x8000000000000000, MASK64):
+            for n in (0, 1, 31, 32, 33, 63, 64):
+                v, _ = ref(a, n)
+                case(f"{name} a={a:#x} n={n}", x_logic(xo, R[0], R[1], R[2]),
+                     {R[0]: a, R[2]: n}, [(R[1], v, MASK64)])
+
+    for a in (0x1, 0x80000000, 0xFFFFFFFF, 0x80000001, 0x7FFFFFFF, 0xFFFFFFFF80000000):
+        for sh in (0, 1, 4, 31):
+            v, ca = ref_srawi(a, sh)
+            case(f"srawi a={a:#x} sh={sh}",
+                 (31 << 26) | (R[0] << 21) | (R[1] << 16) | (sh << 11) | (824 << 1),
+                 {R[0]: a}, [(R[1], v, MASK64)], exp_ca=ca)
+        for n in (0, 1, 31, 32, 40):
+            v, ca = ref_sraw(a, n)
+            case(f"sraw a={a:#x} n={n}", x_logic(792, R[0], R[1], R[2]),
+                 {R[0]: a, R[2]: n}, [(R[1], v, MASK64)], exp_ca=ca)
+    for a in (0x1, 0x8000000000000000, MASK64, 0x8000000000000001):
+        for sh in (0, 1, 32, 63):
+            v, ca = ref_sradi(a, sh)
+            case(f"sradi a={a:#x} sh={sh}", xs_sradi(R[0], R[1], sh),
+                 {R[0]: a}, [(R[1], v, MASK64)], exp_ca=ca)
+
+    # --- rotates ----------------------------------------------------------
+    for a in (0x12345678, 0x80000001, MASK32, 0xFEDCBA9876543210):
+        for sh, mb, me in [(0, 0, 31), (1, 0, 31), (13, 5, 20), (16, 16, 31),
+                           (4, 28, 3), (31, 31, 0), (0, 31, 31)]:   # incl. mb>me wraps
+            v, _ = ref_rlwinm(a, sh, mb, me)
+            case(f"rlwinm a={a:#x} sh={sh} mb={mb} me={me}",
+                 m_form(21, R[0], R[1], sh, mb, me),
+                 {R[0]: a}, [(R[1], v, MASK32)])
+            r0 = 0xAAAAAAAABBBBBBBB
+            v2, _ = ref_rlwimi(r0, a, sh, mb, me)
+            case(f"rlwimi a={a:#x} sh={sh} mb={mb} me={me}",
+                 m_form(20, R[0], R[1], sh, mb, me),
+                 {R[0]: a, R[1]: r0}, [(R[1], v2, MASK32)])
+    for a in (0x123456789ABCDEF0, 0x8000000000000001, MASK64):
+        for sh, mbe in [(0, 0), (0, 63), (1, 0), (17, 5), (32, 31), (63, 1), (40, 63)]:
+            v, _ = ref_rldicl(a, sh, mbe)
+            case(f"rldicl a={a:#x} sh={sh} mb={mbe}", md_form(0, R[0], R[1], sh, mbe),
+                 {R[0]: a}, [(R[1], v, MASK64)])
+            v, _ = ref_rldicr(a, sh, mbe)
+            case(f"rldicr a={a:#x} sh={sh} me={mbe}", md_form(1, R[0], R[1], sh, mbe),
+                 {R[0]: a}, [(R[1], v, MASK64)])
+        for sh, mb in [(8, 4), (0, 0), (32, 16)]:
+            if mb <= 63 - sh:
+                r0 = 0xCCCCCCCCDDDDDDDD
+                v, _ = ref_rldimi(r0, a, sh, mb)
+                case(f"rldimi a={a:#x} sh={sh} mb={mb}", md_form(3, R[0], R[1], sh, mb),
+                     {R[0]: a, R[1]: r0}, [(R[1], v, MASK64)])
+
+    # --- D-form immediates (negative-immediate class) ---------------------
+    for a in (0, 5, MASK64, 0x7FFFFFFFFFFFFFFF):
+        for imm in (0, 1, -1, -4, 0x7FFF, -0x8000):
+            v, _ = ref_addi(a, imm)
+            case(f"addi a={a:#x} imm={imm}", d_form(14, R[0], R[1], imm),
+                 {R[1]: a}, [(R[0], v, MASK64)])
+            v, _ = ref_addi(a, imm << 16)
+            case(f"addis a={a:#x} imm={imm}", d_form(15, R[0], R[1], imm),
+                 {R[1]: a}, [(R[0], v, MASK64)])
+            v, ca = ref_addic(a, imm if imm >= 0 else (imm & MASK64))
+            case(f"addic a={a:#x} imm={imm}", d_form(12, R[0], R[1], imm),
+                 {R[1]: a}, [(R[0], v, MASK64)], exp_ca=ca)
+            v, ca = ref_subfic(a, imm if imm >= 0 else (imm & MASK64))
+            case(f"subfic a={a:#x} imm={imm}", d_form(8, R[0], R[1], imm),
+                 {R[1]: a}, [(R[0], v, MASK64)], exp_ca=ca)
+            v, _ = ref_mulli(a, imm)
+            case(f"mulli a={a:#x} imm={imm}", d_form(7, R[0], R[1], imm),
+                 {R[1]: a}, [(R[0], v, MASK64)])
+
+    # --- compares (CR field placement; cr0 and cr7) -----------------------
+    for a, b in [(0, 0), (1, 2), (2, 1), (MASK64, 1), (0x80000000, 0x7FFFFFFF),
+                 (0xFFFFFFFF80000000, 0x7FFFFFFF)]:
+        for bf in (0, 7):
+            shift = 28 - bf * 4
+            case(f"cmpd bf={bf} a={a:#x} b={b:#x}", cmp_form(0, bf, 1, R[1], R[2]),
+                 {R[1]: a, R[2]: b}, [], exp_cr=(cr_nibble_signed(a, b), shift))
+            case(f"cmpw bf={bf} a={a:#x} b={b:#x}", cmp_form(0, bf, 0, R[1], R[2]),
+                 {R[1]: a, R[2]: b}, [], exp_cr=(cr_nibble_signed32(a, b), shift))
+            case(f"cmpld bf={bf} a={a:#x} b={b:#x}", cmp_form(32, bf, 1, R[1], R[2]),
+                 {R[1]: a, R[2]: b}, [], exp_cr=(cr_nibble_unsigned(a, b, 64), shift))
+            case(f"cmplw bf={bf} a={a:#x} b={b:#x}", cmp_form(32, bf, 0, R[1], R[2]),
+                 {R[1]: a, R[2]: b}, [], exp_cr=(cr_nibble_unsigned(a, b, 32), shift))
+        case(f"cmpdi a={a:#x}", cmpi_form(11, 0, 1, R[1], 1),
+             {R[1]: a}, [], exp_cr=(cr_nibble_signed(a, 1), 28))
+        case(f"cmpwi a={a:#x}", cmpi_form(11, 0, 0, R[1], 1),
+             {R[1]: a}, [], exp_cr=(cr_nibble_signed32(a, 1), 28))
+
+    # --- Rc=1 CR0 recording ------------------------------------------------
+    for a, b in [(1, 1), (0, 0), (MASK64, 1), (0x8000000000000000, 0)]:
+        v, _ = ref_add(a, b)
+        nib = 8 if s64(v) < 0 else (4 if s64(v) > 0 else 2)
+        case(f"add. a={a:#x} b={b:#x}", xo_form(266, R[0], R[1], R[2], rc=1),
+             {R[1]: a, R[2]: b}, [(R[0], v, MASK64)], exp_cr=(nib, 28))
+
+build_cases()
+
+# ---------------------------------------------------------------------------
+# C driver generation
+# ---------------------------------------------------------------------------
+
+def emit_c(path):
+    lifter = PPULifter()
+    dummy = LiftedFunction(name="conf", start_addr=0, end_addr=0x10000)
+    pre = lifter._preamble_lines()
+    # replace the generated-header include with the real (small) context header
+    pre[0] = pre[0].replace('#include "ppu_recomp.h"',
+                            '#include "ppu_context.h"\n#include <stdint.h>')
+    out = ["/* Auto-generated by tools/test_ppu_lift.py -- conformance driver. */"]
+    out.append("#define _CRT_SECURE_NO_WARNINGS")
+    out.extend(pre)
+    out.append("""
+static int g_fail = 0, g_pass = 0, g_skip = 0;
+static ppu_context g_ctx;
+
+static void check_reg(const char* name, int reg, uint64_t got, uint64_t want, uint64_t mask) {
+    if ((got & mask) != (want & mask)) {
+        printf("FAIL %s: r%d = 0x%016llX want 0x%016llX (mask 0x%016llX)\\n",
+               name, reg, (unsigned long long)got, (unsigned long long)want,
+               (unsigned long long)mask);
+        g_fail++;
+    } else g_pass++;
+}
+static void check_ca(const char* name, uint32_t xer, int want) {
+    int got = (xer >> 29) & 1;
+    if (got != want) { printf("FAIL %s: XER[CA] = %d want %d\\n", name, got, want); g_fail++; }
+    else g_pass++;
+}
+static void check_cr(const char* name, uint32_t cr, int nib, int shift) {
+    int got = (cr >> shift) & 0xF;
+    /* only LT/GT/EQ (top 3 bits of the nibble); SO passthrough not asserted */
+    if ((got & 0xE) != (nib & 0xE)) {
+        printf("FAIL %s: CR nibble@%d = %X want %X\\n", name, shift, got, nib); g_fail++;
+    } else g_pass++;
+}
+""")
+    out.append("int main(void) {")
+    out.append("    ppu_context* ctx = &g_ctx;")
+    n_encoding_skipped = 0
+    for i, c in enumerate(CASES):
+        insn = ppu_disasm.decode(c["word"], 0x10000 + i * 4)
+        exp_mn = c["name"].split()[0].rstrip(".")
+        got_mn = insn.mnemonic.rstrip(".")
+        if got_mn != exp_mn:
+            print(f"ENCODING mismatch for {c['name']!r}: decoded as "
+                  f"{insn.mnemonic} {insn.operands} (word {c['word']:#010x}) -- case skipped")
+            n_encoding_skipped += 1
+            continue
+        code = lifter._translate(insn, dummy)
+        if code.startswith("/*"):
+            print(f"UNHANDLED by lifter: {c['name']!r} -> {code[:60]} -- case skipped")
+            n_encoding_skipped += 1
+            continue
+        nm = c["name"].replace('"', "'")
+        out.append(f'    {{ /* case {i}: {nm} | {insn.mnemonic} {insn.operands} */')
+        out.append("      memset(ctx, 0, sizeof(*ctx));")
+        for reg, val in c["in_regs"].items():
+            out.append(f"      ctx->gpr[{reg}] = 0x{val:016X}ULL;")
+        if c["in_ca"]:
+            out.append("      ctx->xer |= (1u << 29);")
+        body = [f"        {code}"]
+        for reg, val, mask in c["expects"]:
+            body.append(f'        check_reg("{nm}", {reg}, ctx->gpr[{reg}], '
+                        f"0x{val:016X}ULL, 0x{mask:016X}ULL);")
+        if c["exp_ca"] is not None:
+            body.append(f'        check_ca("{nm}", ctx->xer, {int(bool(c["exp_ca"]))});')
+        if c["exp_cr"] is not None:
+            nib, shift = c["exp_cr"]
+            body.append(f'        check_cr("{nm}", ctx->cr, {nib}, {shift});')
+        if c["may_trap"]:
+            out.append("      __try {")
+            out.extend(body)
+            out.append("        g_pass++;")
+            out.append("      } __except (1) {")
+            out.append(f'        printf("FAIL {nm}: HOST TRAP (div?) -- lifted code must not fault\\n");')
+            out.append("        g_fail++;")
+            out.append("      }")
+        else:
+            out.extend(body)
+        out.append("    }")
+    out.append("""
+    printf("\\n[ppu-conformance] %d checks passed, %d FAILED, %d skipped\\n",
+           g_pass, g_fail, g_skip);
+    return g_fail ? 1 : 0;
+}
+""")
+    with open(path, "w") as f:
+        f.write("\n".join(out))
+    print(f"wrote {path}: {len(CASES) - n_encoding_skipped} cases "
+          f"({n_encoding_skipped} skipped at generation)")
+
+# ---------------------------------------------------------------------------
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--emit", action="store_true", help="only write the C file")
+    args = ap.parse_args()
+
+    os.makedirs(os.path.join(ROOT, "scratch"), exist_ok=True)
+    cpath = os.path.join(ROOT, "scratch", "ppu_conformance.cpp")   # preamble is C++ (extern "C")
+    epath = os.path.join(ROOT, "scratch", "ppu_conformance.exe")
+    emit_c(cpath)
+    if args.emit:
+        return
+
+    vcvars = r"C:\Program Files\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build\vcvars64.bat"
+    bat = os.path.join(ROOT, "scratch", "ppu_conformance_run.bat")
+    log = os.path.join(ROOT, "scratch", "ppu_conformance.log")
+    with open(bat, "w") as f:
+        f.write("@echo off\n")
+        f.write(f'call "{vcvars}" >nul 2>nul\n')
+        f.write(f'cd /d "{ROOT}"\n')
+        f.write(f'cl /nologo /O1 /W3 /I runtime\\ppu /Fe:"{epath}" "{cpath}" > "{log}" 2>&1\n')
+        f.write("if errorlevel 1 exit /b 2\n")
+        f.write(f'"{epath}" >> "{log}" 2>&1\n')
+    r = subprocess.run(["cmd", "/c", bat], cwd=ROOT)
+    tail = open(log).read() if os.path.exists(log) else ""
+    fails = [ln for ln in tail.splitlines() if ln.startswith("FAIL")]
+    for ln in fails[:40]:
+        print(ln)
+    if len(fails) > 40:
+        print(f"... and {len(fails) - 40} more failures")
+    for ln in tail.splitlines():
+        if "[ppu-conformance]" in ln or "error C" in ln:
+            print(ln)
+    if r.returncode == 2:
+        print("COMPILE FAILED -- see", log)
+    sys.exit(0 if r.returncode == 0 else 1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This ships the differential audit tooling I used to find and confirm the lifter and HLE bugs that several of the other open PRs fix, generalized for any PPU ELF, HLE tree, or import-bridge convention rather than hardcoded to my port. The reason it exists: a decode-level swap, two opcodes trading mnemonics, survives every runtime and conformance test in the tree, because the lift stays internally self-consistent and only disagrees with the real architecture. A self-referential test suite cannot catch that, only an external oracle can. The crnor/crnand opcode swap, the SPU operand decode fixes, and the HLE ABI signature corrections in the companion PR were all found this way, so this is the reusable machinery behind that work, not a one-off.

disasm_audit.py and disasm_audit_operands.py cross-check tools/ppu_disasm.py against Capstone over an ELF's executable segments, first at the mnemonic level, then at the operand level for the words where the mnemonics already agree. Both carry seeded self-tests that deliberately introduce a swapped-opcode bug and confirm the harness flags it, so a clean run means the checker is actually working rather than silently passing.

spu_disasm_audit.py and spu_disasm_audit_operands.py do the same for tools/spu_disasm.py against RPCS3's SPUDisAsm. RPCS3 is used strictly as an output-only oracle you build yourself against your own RPCS3 clone and diff text against, so no GPL source is ever copied into this repo, the same clean-room posture the rest of the toolkit keeps.

endian_audit.py is an advisory heuristic scan of the HLE C sources for out-params that look like they may be missing a big-endian byte swap. hle_abi_audit.py diffs our HLE function signatures against RPCS3's real module implementations, and hle_dispatch_classify.py layers on top of it to say which of those mismatches are actually live at runtime versus shadowed by an LLE-dispatched or override-wrapped import slot, given a generated NID-to-function-pointer bridge table, so you triage the ones that matter instead of chasing dead stubs. lift_audit.py censuses a relift's structural health: unresolved lift markers by mnemonic, unresolved branch targets, and fallthrough-into-the-next-function hazards, with an optional baseline diff so regressions across relifts show up as a diff instead of a wall of text.

tests/sync_stress is a standalone lv2 sync-primitive stress suite (mutex, cond, semaphore, event queue) that links the real runtime sources directly and drives them from many host threads, to catch lost wakeups, timed-wait regressions, counting-invariant violations, and event-delivery ordering bugs under real concurrency, independent of the full game runner. Stated openly: it currently fails 2 of 5 cases against this repo's checked-in runtime, both real and narrow, a semaphore post that returns CELL_EINVAL instead of CELL_EBUSY when the post would exceed max_value, and an event-queue receive that never writes the dequeued event into gpr4 through gpr7 so it is silently lost. Both are exactly the class of bug this kit exists to surface, so I left them visible rather than whitelisting them away. Each whitelist file suppresses only known intentional divergences, so a clean run means zero unexpected findings.

Verified: all eight Python tools compile clean under Python 3.14 (py -3 -m py_compile) and are stdlib-only. The disasm cross-checks require an installed capstone and the SPU oracle requires a locally built RPCS3, both external to this repo and documented in each script's header. Not exercised here: a full corpus-wide audit run, since that needs the external oracles set up; the findings above came from running the kit against my own port's tree.
