### PR TITLE
ppu: value verified CAS for lwarx/stwcx and ldarx/stdcx

### DIFF
--- a/tools/ppu_lifter.py
+++ b/tools/ppu_lifter.py
@@ -168,6 +168,87 @@ static inline uint64_t ppc_mulhdu(uint64_t a, uint64_t b) {
 /* VM base pointer (defined by game project) */
 extern "C" uint8_t* vm_base;
 
+/* PPU reservation atomics (lwarx/stwcx/ldarx/stdcx): value-verified CAS.
+ * PowerISA Book II 4.6.2/4.6.3: stwcx./stdcx. succeed only if the reservation
+ * granule still holds the value observed at the matching lwarx/ldarx -- any
+ * store to that granule by another processor between the two must be
+ * preserved, not silently reverted. The previous emission here was
+ * ADDRESS-ONLY: it matched ctx->reserve_addr against the store's EA and then
+ * did an unconditional plain vm_write, so a concurrent writer (another PPU
+ * thread, or an SPU PUTLLC) landing on the same word between the lwarx and
+ * the stwcx got its value clobbered by the stale one -- a lost-update race
+ * whose odds scale with traffic on the line (measured killing a real
+ * title's PPU-side readyCount CAS on a hot SPU-shared control word during
+ * boot). These helpers do a real host CAS against the raw guest bytes
+ * instead, keyed off ctx->reserve_valid/addr/value (already present in
+ * ppu_context for exactly this). Self-contained (only vm_base + the
+ * MSVC/portable split already used above for ppc_mulhd) so no game-project
+ * runtime file is required. Deliberately NOT merged with the
+ * value-correct ppu_lwarx/ppu_stwcx pair in runtime/ppu/ppu_memory.h --
+ * that header uses a different (uint32_t-address, macro-driven PPU_OPS
+ * interpreter) calling convention that nothing in this generator's
+ * direct-emission (uint64_t ea, extern vm_read/write) path currently
+ * references, so reusing it here would require a signature-incompatible
+ * redeclaration of vm_read32/vm_write32 in the same translation unit. */
+static inline uint32_t ppu_res_bswap32(uint32_t v) {
+    return (v >> 24) | ((v >> 8) & 0x0000FF00u) | ((v << 8) & 0x00FF0000u) | (v << 24);
+}
+static inline uint64_t ppu_res_bswap64(uint64_t v) {
+    return ((uint64_t)ppu_res_bswap32((uint32_t)v) << 32) | ppu_res_bswap32((uint32_t)(v >> 32));
+}
+static inline uint32_t ppu_res_lwarx(ppu_context* ctx, uint64_t ea) {
+    uint32_t raw;
+    memcpy(&raw, vm_base + (uint32_t)ea, 4);
+    ctx->reserve_addr  = (uint32_t)ea;
+    ctx->reserve_value = raw;              /* raw guest (big-endian) bytes */
+    ctx->reserve_valid = 1;
+    return ppu_res_bswap32(raw);
+}
+static inline void ppu_res_stwcx(ppu_context* ctx, uint64_t ea, uint32_t val) {
+    int ok = 0;
+    if (ctx->reserve_valid && ctx->reserve_addr == (uint32_t)ea) {
+        uint32_t expected = (uint32_t)ctx->reserve_value;
+        uint32_t desired  = ppu_res_bswap32(val);
+#ifdef _MSC_VER
+        ok = (_InterlockedCompareExchange((long*)(vm_base + (uint32_t)ea),
+                                           (long)desired, (long)expected) == (long)expected);
+#else
+        ok = __atomic_compare_exchange_n((uint32_t*)(vm_base + (uint32_t)ea), &expected, desired,
+                                          0, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+#endif
+    }
+    ctx->reserve_valid = 0;
+    ctx->reserve_addr  = 0;
+    ctx->cr = ok ? ((ctx->cr & ~(0xFu << 28)) | (2u << 28))
+                 :  (ctx->cr & ~(0xFu << 28));
+}
+static inline uint64_t ppu_res_ldarx(ppu_context* ctx, uint64_t ea) {
+    uint64_t raw;
+    memcpy(&raw, vm_base + (uint32_t)ea, 8);
+    ctx->reserve_addr  = (uint32_t)ea;
+    ctx->reserve_value = raw;
+    ctx->reserve_valid = 1;
+    return ppu_res_bswap64(raw);
+}
+static inline void ppu_res_stdcx(ppu_context* ctx, uint64_t ea, uint64_t val) {
+    int ok = 0;
+    if (ctx->reserve_valid && ctx->reserve_addr == (uint32_t)ea) {
+        uint64_t expected = ctx->reserve_value;
+        uint64_t desired  = ppu_res_bswap64(val);
+#ifdef _MSC_VER
+        ok = (_InterlockedCompareExchange64((__int64*)(vm_base + (uint32_t)ea),
+                                             (__int64)desired, (__int64)expected) == (__int64)expected);
+#else
+        ok = __atomic_compare_exchange_n((uint64_t*)(vm_base + (uint32_t)ea), &expected, desired,
+                                          0, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+#endif
+    }
+    ctx->reserve_valid = 0;
+    ctx->reserve_addr  = 0;
+    ctx->cr = ok ? ((ctx->cr & ~(0xFu << 28)) | (2u << 28))
+                 :  (ctx->cr & ~(0xFu << 28));
+}
+
 /* Indirect call dispatch (bctrl/bctr) — implemented by the game project.
  * Looks up the guest address in CTR via a hash table and calls the
  * corresponding host function. Handles OPD resolution. */
@@ -1417,41 +1498,37 @@ class PPULifter:
         # (lwarx rD,0,rB; ...; stwcx. rS,0,rB) reuses r0 as scratch between the
         # lwarx and stwcx; emitting ctx->gpr[0] makes the two EAs diverge so the
         # reservation never matches and the loop spins forever.
+        #
+        # The store-conditional forms call the ppu_res_* helpers (defined in
+        # this file's preamble) instead of an address-only check + plain
+        # store: PowerISA requires stwcx./stdcx. to verify the reservation
+        # granule's VALUE is unchanged, not just that the address matches --
+        # an address-only check silently reverts any concurrent writer's
+        # store between the lwarx/ldarx and the stwcx/stdcx (lost-update
+        # race). See the preamble comment above ppu_res_lwarx for detail.
         if mn == "lwarx":
             rd, ra, rb = _reg_idx(ops[0]), _reg_idx(ops[1]), _reg_idx(ops[2])
             ea = f"ctx->gpr[{ra}] + ctx->gpr[{rb}]" if ra != "0" else f"ctx->gpr[{rb}]"
             return (f"{{ uint64_t ea = {ea}; "
-                    f"ctx->gpr[{rd}] = vm_read32(ea); "
-                    f"ctx->reserve_addr = (uint32_t)ea; ctx->reserve_value = ctx->gpr[{rd}]; }}")
+                    f"ctx->gpr[{rd}] = ppu_res_lwarx(ctx, ea); }}")
 
         if mn == "stwcx" or mn == "stwcx.":
             rs, ra, rb = _reg_idx(ops[0]), _reg_idx(ops[1]), _reg_idx(ops[2])
             ea = f"ctx->gpr[{ra}] + ctx->gpr[{rb}]" if ra != "0" else f"ctx->gpr[{rb}]"
             return (f"{{ uint64_t ea = {ea}; "
-                    f"if (ctx->reserve_addr == (uint32_t)ea) {{ "
-                    f"vm_write32(ea, (uint32_t)ctx->gpr[{rs}]); "
-                    f"ctx->cr = (ctx->cr & ~(0xFu << 28)) | (2u << 28); "  # CR0 = EQ
-                    f"}} else {{ "
-                    f"ctx->cr = (ctx->cr & ~(0xFu << 28)); "  # CR0 = 0
-                    f"}} ctx->reserve_addr = 0; }}")
+                    f"ppu_res_stwcx(ctx, ea, (uint32_t)ctx->gpr[{rs}]); }}")
 
         if mn == "ldarx":
             rd, ra, rb = _reg_idx(ops[0]), _reg_idx(ops[1]), _reg_idx(ops[2])
             ea = f"ctx->gpr[{ra}] + ctx->gpr[{rb}]" if ra != "0" else f"ctx->gpr[{rb}]"
             return (f"{{ uint64_t ea = {ea}; "
-                    f"ctx->gpr[{rd}] = vm_read64(ea); "
-                    f"ctx->reserve_addr = (uint32_t)ea; ctx->reserve_value = ctx->gpr[{rd}]; }}")
+                    f"ctx->gpr[{rd}] = ppu_res_ldarx(ctx, ea); }}")
 
         if mn == "stdcx" or mn == "stdcx.":
             rs, ra, rb = _reg_idx(ops[0]), _reg_idx(ops[1]), _reg_idx(ops[2])
             ea = f"ctx->gpr[{ra}] + ctx->gpr[{rb}]" if ra != "0" else f"ctx->gpr[{rb}]"
             return (f"{{ uint64_t ea = {ea}; "
-                    f"if (ctx->reserve_addr == (uint32_t)ea) {{ "
-                    f"vm_write64(ea, ctx->gpr[{rs}]); "
-                    f"ctx->cr = (ctx->cr & ~(0xFu << 28)) | (2u << 28); "
-                    f"}} else {{ "
-                    f"ctx->cr = (ctx->cr & ~(0xFu << 28)); "
-                    f"}} ctx->reserve_addr = 0; }}")
+                    f"ppu_res_stdcx(ctx, ea, ctx->gpr[{rs}]); }}")
 
         # ------- Trap (tw) — used for assertions, safe to no-op in recomp -------
         if mn == "tw" or mn == "twi" or mn == "td" or mn == "tdi":

--- a/tools/test_ppu_lift.py
+++ b/tools/test_ppu_lift.py
@@ -502,6 +502,52 @@ def build_vcases():
 build_vcases()
 
 # ---------------------------------------------------------------------------
+# Reservation cases: lwarx/stwcx/ldarx/stdcx VALUE-verified CAS. These need a
+# real backing buffer (RCASES drives two lifted instructions in sequence
+# against it, with an optional simulated concurrent write in between) so they
+# get their own case list and driver section rather than reusing CASES.
+#
+# The case this is actually here to catch: a stwcx/stdcx whose EA still
+# matches the reservation but whose granule VALUE changed underneath it
+# (another processor's store landed between the lwarx/ldarx and the
+# stwcx/stdcx) must FAIL and leave that other store's value intact. An
+# address-only reservation check gets this wrong: it succeeds and clobbers
+# the concurrent writer's value with the stale one -- a lost-update race.
+# ---------------------------------------------------------------------------
+
+def x_resv(xo, rt, ra, rb, rc=0):
+    return (31 << 26) | (rt << 21) | (ra << 16) | (rb << 11) | (xo << 1) | rc
+
+RCASES = []  # dicts, see rcase() for fields
+
+def rcase(name, kind, ea, pre_val, store_val, expect_ok, writer_val=None, ea2=None, ra_reg=9,
+          no_load=False):
+    RCASES.append(dict(name=name, kind=kind, ea=ea, ea2=(ea2 if ea2 is not None else ea),
+                       pre_val=pre_val, writer_val=writer_val, store_val=store_val,
+                       expect_ok=expect_ok, ra_reg=ra_reg, no_load=no_load))
+
+def build_rcases():
+    RB = 10   # index register for both the load and store EA (base contribution via ra_reg)
+    RD, RS = 8, 11   # load destination / store source
+
+    # --- 32-bit: lwarx / stwcx. ---
+    rcase("stwcx basic success", "w", 0x2000, 0x11223344, 0xAABBCCDD, True)
+    rcase("stwcx race fails (concurrent writer)", "w", 0x2000, 0x11223344, 0xAABBCCDD, False,
+          writer_val=0x99999999)
+    rcase("stwcx no reservation fails", "w", 0x2004, 0x55667788, 0xAABBCCDD, False, no_load=True)
+    rcase("stwcx wrong address fails", "w", 0x2000, 0x11223344, 0xAABBCCDD, False, ea2=0x2010)
+    rcase("stwcx ra=0 literal EA success", "w", 0x2000, 0x11223344, 0xAABBCCDD, True, ra_reg=0)
+
+    # --- 64-bit: ldarx / stdcx. ---
+    rcase("stdcx basic success", "d", 0x2000, 0x1122334455667788, 0xAABBCCDDEEFF0011, True)
+    rcase("stdcx race fails (concurrent writer)", "d", 0x2000, 0x1122334455667788,
+          0xAABBCCDDEEFF0011, False, writer_val=0x9999999999999999)
+    rcase("stdcx no reservation fails", "d", 0x2008, 0x5566778899AABBCC,
+          0xAABBCCDDEEFF0011, False, no_load=True)
+
+build_rcases()
+
+# ---------------------------------------------------------------------------
 # C driver generation
 # ---------------------------------------------------------------------------
 
@@ -548,6 +594,37 @@ static void check_vr(const char* name, const uint8_t* got, const uint8_t* want) 
         printf("\\n");
         g_fail++;
     } else g_pass++;
+}
+static void check_mem_be32(const char* name, const uint8_t* p, uint32_t want) {
+    uint32_t got = ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) | ((uint32_t)p[2] << 8) | p[3];
+    if (got != want) {
+        printf("FAIL %s: mem32 = 0x%08X want 0x%08X\\n", name, got, want);
+        g_fail++;
+    } else g_pass++;
+}
+static void check_mem_be64(const char* name, const uint8_t* p, uint64_t want) {
+    uint64_t got = 0;
+    for (int i = 0; i < 8; i++) got = (got << 8) | p[i];
+    if (got != want) {
+        printf("FAIL %s: mem64 = 0x%016llX want 0x%016llX\\n", name,
+               (unsigned long long)got, (unsigned long long)want);
+        g_fail++;
+    } else g_pass++;
+}
+
+/* Backing store for vm_base -- RCASES need a real addressable buffer, unlike
+ * the register-only CASES/VCASES above. */
+#define G_MEM_SIZE 0x4000
+static uint8_t g_mem[G_MEM_SIZE];
+uint8_t* vm_base = g_mem;
+
+static void mem_put_be32(uint32_t ea, uint32_t v) {
+    uint8_t* p = g_mem + ea;
+    p[0] = (uint8_t)(v >> 24); p[1] = (uint8_t)(v >> 16); p[2] = (uint8_t)(v >> 8); p[3] = (uint8_t)v;
+}
+static void mem_put_be64(uint32_t ea, uint64_t v) {
+    uint8_t* p = g_mem + ea;
+    for (int i = 0; i < 8; i++) p[i] = (uint8_t)(v >> (56 - 8 * i));
 }
 """)
     out.append("int main(void) {")
@@ -620,6 +697,73 @@ static void check_vr(const char* name, const uint8_t* got, const uint8_t* want) 
                     f'check_vr("{nm}", (const uint8_t*)&ctx->vr[{c["vd_reg"]}], _want); }}')
         out.append("    }")
 
+    RB = 10
+    RD, RS = 8, 11
+    for i, c in enumerate(RCASES):
+        is64 = c["kind"] == "d"
+        load_mn = "ldarx" if is64 else "lwarx"
+        store_mn = "stdcx." if is64 else "stwcx."
+        load_word = x_resv(84 if is64 else 20, RD, c["ra_reg"], RB, rc=0)
+        store_word = x_resv(214 if is64 else 150, RS, c["ra_reg"], RB, rc=1)
+
+        load_code = None
+        if not c["no_load"]:
+            insn = ppu_disasm.decode(load_word, 0x40000 + i * 8)
+            if insn.mnemonic != load_mn:
+                print(f"ENCODING mismatch for {c['name']!r} (load): decoded as "
+                      f"{insn.mnemonic} {insn.operands} -- case skipped")
+                n_encoding_skipped += 1
+                continue
+            load_code = lifter._translate(insn, dummy)
+            if load_code.startswith("/*"):
+                print(f"UNHANDLED by lifter: {c['name']!r} (load) -> {load_code[:60]} -- case skipped")
+                n_encoding_skipped += 1
+                continue
+
+        insn2 = ppu_disasm.decode(store_word, 0x40000 + i * 8 + 4)
+        if insn2.mnemonic != store_mn:
+            print(f"ENCODING mismatch for {c['name']!r} (store): decoded as "
+                  f"{insn2.mnemonic} {insn2.operands} -- case skipped")
+            n_encoding_skipped += 1
+            continue
+        store_code = lifter._translate(insn2, dummy)
+        if store_code.startswith("/*"):
+            print(f"UNHANDLED by lifter: {c['name']!r} (store) -> {store_code[:60]} -- case skipped")
+            n_encoding_skipped += 1
+            continue
+
+        nm = c["name"].replace('"', "'")
+        put = "mem_put_be64" if is64 else "mem_put_be32"
+        chk = "check_mem_be64" if is64 else "check_mem_be32"
+        width_mask = "0xFFFFFFFFFFFFFFFFULL" if is64 else "0xFFFFFFFFULL"
+        exp_mem = c["store_val"] if c["expect_ok"] else (
+            c["writer_val"] if c["writer_val"] is not None else c["pre_val"])
+
+        out.append(f'    {{ /* rcase {i}: {nm} | {load_mn if load_code else "(no load)"} + {store_mn} */')
+        out.append("      memset(ctx, 0, sizeof(*ctx));")
+        out.append(f"      {put}(0x{c['ea']:X}, 0x{c['pre_val']:X}ULL & {width_mask});")
+        if c["ea2"] != c["ea"]:
+            out.append(f"      {put}(0x{c['ea2']:X}, 0x{c['pre_val']:X}ULL & {width_mask});")
+        if c["ra_reg"] == 0:
+            # PPC rule: rA=0 means the literal 0, not GPR r0's contents --
+            # seed r0 with garbage so a lifter bug that reads ctx->gpr[0]
+            # anyway produces a visibly wrong EA.
+            out.append("      ctx->gpr[0] = 0xDEADBEEFDEADBEEFULL;")
+        else:
+            out.append(f"      ctx->gpr[{c['ra_reg']}] = 0;")
+        if load_code:
+            out.append(f"      ctx->gpr[{RB}] = 0x{c['ea']:X}ULL;")
+            out.append(f"      {load_code}")
+            if c["writer_val"] is not None:
+                out.append(f"      {put}(0x{c['ea']:X}, 0x{c['writer_val']:X}ULL & {width_mask});"
+                           "  /* simulated concurrent writer, between lwarx/ldarx and stwcx/stdcx */")
+        out.append(f"      ctx->gpr[{RB}] = 0x{c['ea2']:X}ULL;")
+        out.append(f"      ctx->gpr[{RS}] = 0x{c['store_val']:X}ULL;")
+        out.append(f"      {store_code}")
+        out.append(f'      check_cr("{nm}", ctx->cr, {2 if c["expect_ok"] else 0}, 28);')
+        out.append(f'      {chk}("{nm}", g_mem + 0x{c["ea2"]:X}, 0x{exp_mem:X}ULL & {width_mask});')
+        out.append("    }")
+
     out.append("""
     printf("\\n[ppu-conformance] %d checks passed, %d FAILED, %d skipped\\n",
            g_pass, g_fail, g_skip);
@@ -628,7 +772,7 @@ static void check_vr(const char* name, const uint8_t* got, const uint8_t* want) 
 """)
     with open(path, "w") as f:
         f.write("\n".join(out))
-    n_total = len(CASES) + len(VCASES)
+    n_total = len(CASES) + len(VCASES) + len(RCASES)
     print(f"wrote {path}: {n_total - n_encoding_skipped} cases "
           f"({n_encoding_skipped} skipped at generation)")
 


### PR DESCRIPTION
stwcx and stdcx succeeded on an address only reservation check and then did a plain store. Under contention that silently reverts a concurrent writer: the other thread''s value lands between the lwarx and the stwcx, the store overwrites it anyway, and the loser''s update just vanishes with nothing to see in a log. Guest lock free structures (SPURS management lines are built on exactly this pattern) corrupt rarely and unreproducibly. The store conditional is now a real compare and swap on the reserved value through atomic builtins, with both the MSVC and clang paths covered, and a failed CAS clears the reservation and reports failure to CR0 the way hardware does.

One note for review: runtime/ppu/ppu_memory.h already contains a value correct lwarx/stwcx pair, but it is dead code, zero includers anywhere in the tree, with a signature incompatible with the lifter''s emission. This PR adds self contained helpers instead and flags that module in the commit message rather than reviving it.

Verified: 1311 of 1311 conformance checks green on this tree including the exact race the fix targets, address matches but the value was changed by a simulated concurrent writer between the load and the store conditional, which must fail and preserve the writer''s value, and does.