### PR TITLE
lv2/sysprx: SPU image import — sys_spu_image_import (#57) + _sys_spu_image_import wrapper (0xEBE5F72F)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -136,6 +136,17 @@ Real-controller correctness surfaced by a DualShock-as-XInput bring-up
   of `255 - x`, which turned a centered stick into 127 (`0x7F`, aliasing
   SELECT+START self-exit + TRIANGLE).
 
+SPU/SPURS execution bring-up:
+- **`sys_spu_image_import` implemented + SPU-image syscall numbers fixed** —
+  import was mis-numbered 157 (that's `_sys_spu_image_import`) and collided with
+  `SYS_SPU_IMAGE_CLOSE`, so a title's import call dispatched to the close stub and
+  the image struct was left zeroed (entry=0 → matched no fallback → SPU threads
+  "instantly completed"). Renumbered 156/157/158 and replaced the zero-init stub
+  with a real SPU-ELF32 PT_LOAD → `sys_spu_segment[]` parser (#57). This is the
+  parser reused by the `_sys_spu_image_import` (sysPrxForUser 0xEBE5F72F) library
+  wrapper that finally loads the SPURS kernel image for the You Don't Know Jack
+  bring-up.
+
 ### Paulo Adriano Alves — [@pauloadrianoalves](https://github.com/pauloadrianoalves)
 Initial **PPU boot path** and supporting tooling (PR #3, partially incorporated
 in **v0.6.2** — the SPU portions were superseded by the v0.6.0 SPU subsystem and

--- a/README.md
+++ b/README.md
@@ -339,6 +339,13 @@ for who did what — thank you, everyone.
 
 ## Changelog
 
+### v0.6.8 — *"Load-Bearing"* (July 2026)
+*SPURS titles can't run any SPU work until their SPU kernel image is actually loaded. This release lands the image-import path: [@sagemono](https://github.com/sagemono)'s syscall implementation plus the sysPrxForUser library wrapper `libsre` actually calls during `cellSpursInitialize`.*
+
+**Runtime & lv2**
+- **`sys_spu_image_import` implemented + SPU-image syscall numbers fixed** — import was mis-numbered 157 (that's `_sys_spu_image_import`) and collided with `SYS_SPU_IMAGE_CLOSE`, so a title's import call dispatched to the close stub and the image struct was left zeroed (entry=0 → matched no fallback → the SPU thread "instantly completed"). Renumbered 156/157/158 and replaced the zero-init stub with a real SPU-ELF32 PT_LOAD → `sys_spu_segment[]` parser — *[@sagemono](https://github.com/sagemono)* (#57)
+- **`_sys_spu_image_import` (sysPrxForUser NID `0xEBE5F72F`) implemented** — the user-space wrapper `libsre` invokes during `cellSpursInitialize`; previously unresolved (returned 0), so the SPURS SPU kernel image was never parsed and the cellSpurs SPU threads came up at entry 0. Now parses the SPU ELF into the image struct (entry/segments), reusing the #57 segment layout, so the threads come up at the real kernel entry. (An experimental, env-gated `YDKJ_SPURSKERNEL` path routes that entry to an HLE kernel runner for the *You Don't Know Jack* bring-up.)
+
 ### v0.6.7 — *"Fine Print"* (July 2026)
 *The second half of the two-port review pass: [@canersaka](https://github.com/canersaka)'s remaining decode/ABI/timing fixes plus a lifter/HLE audit toolkit, and the title-agnostic robustness fixes from [@JonathanDC64](https://github.com/JonathanDC64)'s port that could be ported and build-verified cleanly.*
 

--- a/runtime/ppu/ppu_sysprx.cpp
+++ b/runtime/ppu/ppu_sysprx.cpp
@@ -241,9 +241,74 @@ static void hle_gcm_callback(ppu_context* ctx)
     ctx->gpr[3] = 0;                                   /* CELL_OK */
 }
 
+/* _sys_spu_image_import (sysPrxForUser NID 0xEBE5F72F) -- the user-space wrapper
+ * libsre calls during cellSpursInitialize to load the SPURS SPU kernel into the
+ * sys_spu_image struct. Previously UNRESOLVED -> returned 0 -> libsre proceeded
+ * with an EMPTY image (entry=0) -> the 5 SPURS SPU threads ran nothing -> PPU
+ * busy-waits on an SPU completion that never comes -> 0 GCM draws
+ * (prx/spu_kernel/README.txt step 1). Parses the SPU ELF at r4 into the image
+ * struct at r3.
+ *
+ * The ELF-parse (segment/entry layout below) is lifted directly from sagemono's
+ * sys_spu_image_import SYSCALL handler in PR #57 (fix/spu-image-import); this is
+ * the sysPrxForUser LIBRARY counterpart libsre actually calls. Credit: sagemono
+ * (PR #57) for the import implementation + SPU-image syscall-number fix.
+ * Self-verifying: no-op unless r4 points to an ELF (so a wrong NID guess is safe).
+ * sys_spu_image { u32 type; u32 entry; sys_spu_segment* segs; int nsegs; }
+ * sys_spu_segment{ int type; u32 ls_start; int size; u64 src_pa }  (0x18, src@0x10) */
+static void hle_sys_spu_image_import(ppu_context* ctx)
+{
+    uint32_t img_ea = (uint32_t)ctx->gpr[3];
+    uint32_t src_ea = (uint32_t)ctx->gpr[4];
+    fprintf(stderr, "[HLE] _sys_spu_image_import(img=0x%08X src=0x%08X r5=0x%08X r6=0x%08X)\n",
+            img_ea, src_ea, (uint32_t)ctx->gpr[5], (uint32_t)ctx->gpr[6]);
+    if (!img_ea || !src_ea || !vm_base) { ctx->gpr[3] = 0; return; }
+    const uint8_t* e = vm_base + src_ea;
+    if (!(e[0]==0x7F && e[1]=='E' && e[2]=='L' && e[3]=='F')) {
+        fprintf(stderr, "[HLE] _sys_spu_image_import: src not an ELF -> no-op\n");
+        fflush(stderr); ctx->gpr[3] = 0; return;
+    }
+    uint16_t machine = (uint16_t)((e[0x12] << 8) | e[0x13]);   /* 23 = SPU */
+    uint32_t entry   = vm_read32(src_ea + 0x18);
+    uint32_t phoff   = vm_read32(src_ea + 0x1C);
+    uint16_t phentsz = (uint16_t)((e[0x2A] << 8) | e[0x2B]); if (!phentsz) phentsz = 0x20;
+    uint16_t phnum   = (uint16_t)((e[0x2C] << 8) | e[0x2D]);
+    static uint32_t s_seg_bump = 0x0D000000u;
+    uint32_t segs_ea = s_seg_bump; int nsegs = 0;
+    for (uint16_t i = 0; i < phnum && nsegs < 32; i++) {
+        uint32_t ph = phoff + (uint32_t)i * phentsz;
+        if (vm_read32(src_ea + ph + 0x00) != 1) continue;      /* PT_LOAD */
+        uint32_t p_off = vm_read32(src_ea + ph + 0x04);
+        uint32_t p_va  = vm_read32(src_ea + ph + 0x08);
+        uint32_t p_fsz = vm_read32(src_ea + ph + 0x10);
+        uint32_t p_msz = vm_read32(src_ea + ph + 0x14);
+        uint32_t seg = segs_ea + (uint32_t)nsegs * 0x18;       /* COPY */
+        vm_write32(seg + 0x00, 1); vm_write32(seg + 0x04, p_va);
+        vm_write32(seg + 0x08, p_fsz); vm_write32(seg + 0x10, 0);
+        vm_write32(seg + 0x14, src_ea + p_off); nsegs++;
+        if (p_msz > p_fsz && nsegs < 32) {                     /* BSS tail -> FILL 0 */
+            seg = segs_ea + (uint32_t)nsegs * 0x18;
+            vm_write32(seg + 0x00, 2); vm_write32(seg + 0x04, p_va + p_fsz);
+            vm_write32(seg + 0x08, p_msz - p_fsz);
+            vm_write32(seg + 0x10, 0); vm_write32(seg + 0x14, 0); nsegs++;
+        }
+    }
+    s_seg_bump += (uint32_t)nsegs * 0x18;
+    if (s_seg_bump >= 0x0E000000u) s_seg_bump = 0x0D000000u;
+    vm_write32(img_ea + 0x00, 0);                              /* type = USER */
+    vm_write32(img_ea + 0x04, entry);
+    vm_write32(img_ea + 0x08, nsegs ? segs_ea : 0);
+    vm_write32(img_ea + 0x0C, (uint32_t)nsegs);
+    fprintf(stderr, "[HLE] _sys_spu_image_import -> entry=0x%05X nsegs=%d machine=%u (SPU=23)\n",
+            entry, nsegs, machine);
+    fflush(stderr);
+    ctx->gpr[3] = 0;
+}
+
 extern "C" void ppu_sysprx_register(void)
 {
     ps3_hle_register_ctx(0x15BAE46Bu, "_cellGcmInitBody", hle_cellGcmInitBody);
+    ps3_hle_register_ctx(0xEBE5F72Fu, "_sys_spu_image_import", hle_sys_spu_image_import);
     ppu_register_function(GCM_FIFO_CALLBACK_SENTINEL_EA, hle_gcm_callback);
     ps3_hle_register_ctx(ps3_compute_nid("sys_initialize_tls"),       "sys_initialize_tls",       sys_initialize_tls);
     ps3_hle_register_ctx(ps3_compute_nid("sys_time_get_system_time"), "sys_time_get_system_time", sys_time_get_system_time);

--- a/runtime/syscalls/lv2_register.c
+++ b/runtime/syscalls/lv2_register.c
@@ -402,10 +402,14 @@ static int64_t sys_spu_thread_initialize_handler(ppu_context* ctx)
     t->args_ea   = args_ea;
     t->args_size = 0;  /* not known until decoder reads it; sys_spu_thread_args is 32 B */
 
-    /* Empty image (entry=0) on a cellSpurs SPU thread -> route to the HLE SPURS
-     * kernel (YDKJ_SPURSKERNEL) so group_start runs a live SPU instead of an
-     * instant no-op. */
-    if (t->entry_point == 0 && getenv("YDKJ_SPURSKERNEL")) {
+    /* cellSpurs SPU kernel thread -> route to the HLE SPURS kernel runner so
+     * group_start runs a live SPU (the lifted sk_a) instead of an instant no-op.
+     * entry=0    : pre-image-import (empty image).
+     * entry=0x818: the REAL SPURS kernel-A entry, now that _sys_spu_image_import
+     *              (sysPrxForUser 0xEBE5F72F, ppu_sysprx.cpp) loads the kernel ELF. */
+    if ((t->entry_point == 0 || t->entry_point == 0x818) && getenv("YDKJ_SPURSKERNEL")) {
+        fprintf(stderr, "[SPU] SPURS kernel thread idx=%u entry=0x%X -> HLE kernel runner\n",
+                thread_num, t->entry_point);
         t->entry_point = YDKJ_SPURS_KERNEL_ENTRY;
         static int s_reg = 0;
         if (!s_reg) { s_reg = 1;

--- a/runtime/syscalls/lv2_register.c
+++ b/runtime/syscalls/lv2_register.c
@@ -952,20 +952,97 @@ uint8_t* spu_thread_get_local_store(uint32_t tid)
 
 uint32_t spu_thread_local_store_size(void) { return SPU_LS_SIZE; }
 
-/* sys_spu_image_import(*img, *source, type) — just log entry & return success.
- * We could parse the SPU ELF header and write entry into the image struct,
- * but no real use without SPU execution; zero-initialize so downstream
- * reads see a valid-looking image. */
+static uint16_t vm_read_be16(uint32_t a)
+{
+    extern uint8_t* vm_base;
+    if (!vm_base || !a) return 0;
+    const uint8_t* p = vm_base + a;
+    return (uint16_t)((p[0] << 8) | p[1]);
+}
+
+/* sys_spu_image_import(sys_spu_image_t* img, const void* src, uint32_t type)
+ * (Lv2 System Call & Library Reference, p.108). Parse the SPU ELF at `src`
+ * (guest memory) and fill the image-management struct so the entry point and
+ * segment table are real -- previously this zeroed the struct, so every SPU
+ * thread came up with entry=0, matched no fallback, and "instantly completed"
+ * (cellmark's SPU benchmarks read 0 as a result).
+ *
+ * sys_spu_image  { u32 type; u32 entry_point; sys_spu_segment* segs; int nsegs; }
+ * sys_spu_segment{ int type; u32 ls_start; int size; u64 src_pa; }  (0x18, src@0x10)
+ * PT_LOAD -> COPY segment (src_pa = src + p_offset); a memsz>filesz tail -> a
+ * FILL(0) segment, exactly as the SDK counts them. */
 static int64_t sys_spu_image_import_handler(ppu_context* ctx)
 {
     extern uint8_t* vm_base;
     uint32_t img_ea = (uint32_t)ctx->gpr[3];
     uint32_t src_ea = (uint32_t)ctx->gpr[4];
-    if (img_ea && vm_base) {
-        memset(vm_base + img_ea, 0, 16);
-        /* sys_spu_image.type = 0 (SYS_SPU_IMAGE_TYPE_KERNEL), entry=0, segs=0, nsegs=0 */
+    uint32_t itype  = (uint32_t)ctx->gpr[5];   /* PROTECT(0) / DIRECT(1) */
+    (void)itype;
+
+    if (!img_ea || !src_ea || !vm_base) {
+        if (img_ea && vm_base) memset(vm_base + img_ea, 0, 16);
+        ctx->gpr[3] = (uint64_t)(int64_t)-14;  /* EFAULT */
+        return -14;
     }
-    fprintf(stderr, "[SPU] image_import img=0x%08X src=0x%08X\n", img_ea, src_ea);
+
+    /* Validate SPU ELF32 (big-endian) magic. */
+    const uint8_t* e = vm_base + src_ea;
+    if (!(e[0] == 0x7F && e[1] == 'E' && e[2] == 'L' && e[3] == 'F')) {
+        memset(vm_base + img_ea, 0, 16);
+        fprintf(stderr, "[SPU] image_import img=0x%08X src=0x%08X -- not an ELF\n", img_ea, src_ea);
+        fflush(stderr);
+        ctx->gpr[3] = (uint64_t)(int64_t)-8;   /* ENOEXEC */
+        return -8;
+    }
+
+    uint32_t entry   = vm_read_be32(src_ea + 0x18);
+    uint32_t phoff   = vm_read_be32(src_ea + 0x1C);
+    uint16_t phentsz = vm_read_be16(src_ea + 0x2A);
+    uint16_t phnum   = vm_read_be16(src_ea + 0x2C);
+    if (phentsz == 0) phentsz = 0x20;
+
+    /* Build the segment array in a dedicated guest scratch region (below the
+     * TLS block at 0x0E000000). SPU images allow at most 32 segments. */
+    static uint32_t s_spu_seg_bump = 0x0D000000u;
+    uint32_t segs_ea = s_spu_seg_bump;
+    int nsegs = 0;
+
+    for (uint16_t i = 0; i < phnum && nsegs < 32; i++) {
+        uint32_t ph = phoff + (uint32_t)i * phentsz;
+        if (vm_read_be32(src_ea + ph + 0x00) != 1) continue;   /* PT_LOAD */
+        uint32_t p_off = vm_read_be32(src_ea + ph + 0x04);
+        uint32_t p_va  = vm_read_be32(src_ea + ph + 0x08);
+        uint32_t p_fsz = vm_read_be32(src_ea + ph + 0x10);
+        uint32_t p_msz = vm_read_be32(src_ea + ph + 0x14);
+
+        uint32_t seg = segs_ea + (uint32_t)nsegs * 0x18;        /* COPY */
+        vm_write_be32(seg + 0x00, 1);                           /* SYS_SPU_SEGMENT_TYPE_COPY */
+        vm_write_be32(seg + 0x04, p_va);                        /* ls_start   */
+        vm_write_be32(seg + 0x08, p_fsz);                       /* size       */
+        vm_write_be32(seg + 0x10, 0);                           /* src_pa hi  */
+        vm_write_be32(seg + 0x14, src_ea + p_off);              /* src_pa lo  */
+        nsegs++;
+
+        if (p_msz > p_fsz && nsegs < 32) {                      /* BSS tail -> FILL 0 */
+            seg = segs_ea + (uint32_t)nsegs * 0x18;
+            vm_write_be32(seg + 0x00, 2);                       /* SYS_SPU_SEGMENT_TYPE_FILL */
+            vm_write_be32(seg + 0x04, p_va + p_fsz);            /* ls_start */
+            vm_write_be32(seg + 0x08, p_msz - p_fsz);           /* size     */
+            vm_write_be32(seg + 0x10, 0);                       /* value    */
+            vm_write_be32(seg + 0x14, 0);
+            nsegs++;
+        }
+    }
+    s_spu_seg_bump += (uint32_t)nsegs * 0x18;
+    if (s_spu_seg_bump >= 0x0E000000u) s_spu_seg_bump = 0x0D000000u;  /* wrap */
+
+    vm_write_be32(img_ea + 0x00, 0);        /* type = SYS_SPU_IMAGE_TYPE_USER */
+    vm_write_be32(img_ea + 0x04, entry);    /* entry_point */
+    vm_write_be32(img_ea + 0x08, nsegs ? segs_ea : 0);  /* segs (guest EA) */
+    vm_write_be32(img_ea + 0x0C, (uint32_t)nsegs);
+
+    fprintf(stderr, "[SPU] image_import img=0x%08X src=0x%08X -> entry=0x%05X nsegs=%d\n",
+            img_ea, src_ea, entry, nsegs);
     fflush(stderr);
     ctx->gpr[3] = 0;
     return 0;
@@ -1097,6 +1174,7 @@ void lv2_register_all_syscalls(lv2_syscall_table* tbl)
     lv2_syscall_register(tbl, 169,                            sys_spu_thread_stub); /* deprecated */
     lv2_syscall_register(tbl, SYS_SPU_INITIALIZE,             sys_spu_initialize_handler);
     lv2_syscall_register(tbl, SYS_SPU_IMAGE_OPEN,             sys_spu_image_open_handler);
+    lv2_syscall_register(tbl, SYS_SPU_IMAGE_IMPORT,           sys_spu_image_import_handler);
     lv2_syscall_register(tbl, SYS_SPU_IMAGE_CLOSE,            sys_spu_thread_stub);
     lv2_syscall_register(tbl, SYS_SPU_THREAD_GROUP_CREATE,    sys_spu_thread_group_create_handler);
     lv2_syscall_register(tbl, SYS_SPU_THREAD_GROUP_DESTROY,   sys_spu_thread_group_destroy_handler);

--- a/runtime/syscalls/lv2_syscall_table.h
+++ b/runtime/syscalls/lv2_syscall_table.h
@@ -175,7 +175,8 @@ extern "C" {
 #define SYS_SPU_THREAD_GROUP_CONNECT_EVENT_ALL_THREADS 185
 
 #define SYS_SPU_IMAGE_OPEN              156
-#define SYS_SPU_IMAGE_CLOSE             157
+#define SYS_SPU_IMAGE_IMPORT            157   /* _sys_spu_image_import (RPCS3 lv2.cpp) */
+#define SYS_SPU_IMAGE_CLOSE             158   /* was mis-numbered 157 -> import hit the close stub */
 
 /* PRX (module) management */
 #define SYS_PRX_LOAD_MODULE             480


### PR DESCRIPTION
## What

Lands the SPU **image-import** path that SPURS titles need before any SPU work can run. Two pieces:

1. **`sys_spu_image_import` syscall + SPU-image syscall-number fix** — sagemono's **#57**, incorporated here with authorship preserved (cherry-picked, not squashed). Import was mis-numbered 157 (that's `_sys_spu_image_import`) and collided with `SYS_SPU_IMAGE_CLOSE`, so a title's import call dispatched to the close stub and the image struct was left zeroed (entry=0 → matched no fallback → the SPU thread "instantly completed"). Renumbered 156/157/158 and replaced the zero-init stub with a real SPU-ELF32 PT_LOAD → `sys_spu_segment[]` parser.

2. **`_sys_spu_image_import` (sysPrxForUser NID `0xEBE5F72F`)** — the user-space wrapper `libsre` actually invokes during `cellSpursInitialize`. It was unresolved (returned 0), so even with #57 the SPURS SPU kernel image was never parsed. This implements the wrapper, reusing #57's segment layout, so the cellSpurs SPU threads come up at the real kernel entry (verified: `entry=0x818`, `machine=23`) instead of 0.

## Verification

On the *You Don't Know Jack* bring-up, the 5 cellSpurs SPU threads now come up at `entry=0x818` (the SPURS kernel-A entry) instead of `0`. Self-verifying: the `0xEBE5F72F` handler is a no-op unless its source arg points at an ELF, so a wrong-NID guess is safe.

## Relationship to #57

This **supersedes / incorporates #57** — sagemono's commit is included verbatim (first commit in this branch, `sagemono <sewshee@tuta.io>`). Merging this can close #57; or merge #57 first and this rebases cleanly.

## Notes / scope

- The changelog (v0.6.8 "Load-Bearing") credits sagemono for #57; `CONTRIBUTORS.md` updated too.
- Includes a small **experimental, env-gated** (`YDKJ_SPURSKERNEL`) routing hook that sends the loaded kernel entry to an HLE runner for the YDKJ bring-up — inert for every other title. Happy to drop it from this PR if you'd rather keep master free of title-specific scaffolding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
