### PR TITLE
lv2: real syscall numbers for the event flag, lwmutex, lwcond and SPU thread blocks

### DIFF
--- a/runtime/syscalls/lv2_syscall_table.h
+++ b/runtime/syscalls/lv2_syscall_table.h
@@ -88,27 +88,33 @@ extern "C" {
 #define SYS_EVENT_PORT_DISCONNECT       137
 #define SYS_EVENT_PORT_SEND             138
 
-#define SYS_EVENT_FLAG_CREATE           139
-#define SYS_EVENT_FLAG_DESTROY          140
-#define SYS_EVENT_FLAG_WAIT             141
-#define SYS_EVENT_FLAG_TRYWAIT          142
-#define SYS_EVENT_FLAG_SET              143
-#define SYS_EVENT_FLAG_CLEAR            144
-#define SYS_EVENT_FLAG_CANCEL           145
-#define SYS_EVENT_FLAG_GET              146
+/* Numbers verified against the real lv2 table (RPCS3 lv2.cpp). The old
+ * values (139-146) collided with sys_event_flag_get/sys_event_port_
+ * connect_ipc/sys_timer_usleep/sys_time_* — SPURS LLE calls usleep(141)
+ * and got the event-flag handler. */
+#define SYS_EVENT_FLAG_CREATE           82
+#define SYS_EVENT_FLAG_DESTROY          83
+#define SYS_EVENT_FLAG_WAIT             85
+#define SYS_EVENT_FLAG_TRYWAIT          86
+#define SYS_EVENT_FLAG_SET              87
+#define SYS_EVENT_FLAG_CLEAR            118
+#define SYS_EVENT_FLAG_CANCEL           132
+#define SYS_EVENT_FLAG_GET              139
 
-#define SYS_LWMUTEX_CREATE              150
-#define SYS_LWMUTEX_DESTROY             151
-#define SYS_LWMUTEX_LOCK               152
-#define SYS_LWMUTEX_TRYLOCK            153
-#define SYS_LWMUTEX_UNLOCK             154
+/* lv2 lightweight primitives are the _sys_lw* slow-path syscalls (95-99,
+ * 111-117); the old 150-160 values squatted on sys_raw_spu_* (150-154)
+ * and sys_spu_image_open/import (156/157). */
+#define SYS_LWMUTEX_CREATE              95
+#define SYS_LWMUTEX_DESTROY             96
+#define SYS_LWMUTEX_LOCK                97
+#define SYS_LWMUTEX_UNLOCK              98
+#define SYS_LWMUTEX_TRYLOCK             99
 
-#define SYS_LWCOND_CREATE               155
-#define SYS_LWCOND_DESTROY              156
-#define SYS_LWCOND_WAIT                 157
-#define SYS_LWCOND_SIGNAL               158
-#define SYS_LWCOND_SIGNAL_ALL           159
-#define SYS_LWCOND_SIGNAL_TO            160
+#define SYS_LWCOND_CREATE               111
+#define SYS_LWCOND_DESTROY              112
+#define SYS_LWCOND_WAIT                 113   /* _sys_lwcond_queue_wait */
+#define SYS_LWCOND_SIGNAL               115
+#define SYS_LWCOND_SIGNAL_ALL           116
 
 /* Timer */
 #define SYS_TIMER_CREATE                70
@@ -129,7 +135,7 @@ extern "C" {
 #define SYS_MEMORY_ALLOCATE             348
 #define SYS_MEMORY_FREE                 349
 #define SYS_MEMORY_ALLOCATE_FROM_CONTAINER 350
-#define SYS_MEMORY_GET_PAGE_ATTRIBUTE   351   /* 0x15F (was wrongly 358; verified vs RPCS3 lv2.cpp) */
+#define SYS_MEMORY_GET_PAGE_ATTRIBUTE   351   /* 0x15F (was wrongly 358; verified vs rpcs3/rpcs3/Emu/Cell/lv2/sys_memory.h) */
 #define SYS_MEMORY_GET_USER_MEMORY_SIZE 352
 #define SYS_MEMORY_CONTAINER_CREATE     353
 #define SYS_MEMORY_CONTAINER_DESTROY    354
@@ -143,12 +149,19 @@ extern "C" {
 #define SYS_MMAPPER_UNMAP_SHARED_MEMORY  335
 #define SYS_MMAPPER_SEARCH_AND_MAP      337
 
-/* SPU management — canonical PS3 lv2 syscall numbers. (Verified against a real
- * title: cellSpursInitialize calls 170=group_create, 172=thread_initialize,
- * 171=group_destroy on rollback. The previous table put GROUP_START at 172 and
- * THREAD_INITIALIZE at 181, so the title's thread_initialize(172) was misrouted
- * to group_start_handler -> "group not found" -> -1 -> cellSpurs init failed.) */
+/* SPU management — numbers verified against the real lv2 table (RPCS3
+ * lv2.cpp 155-252). The old block was wrong almost everywhere (e.g.
+ * THREAD_INITIALIZE was registered at 181 while the real 172 fell on
+ * GROUP_START — Sony's SPURS init failed silently on the id mismatch). */
+#define SYS_SPU_IMAGE_OPEN              156
+#define SYS_SPU_IMAGE_IMPORT            157   /* _sys_spu_image_import */
+#define SYS_SPU_IMAGE_CLOSE             158   /* _sys_spu_image_close */
+#define SYS_SPU_IMAGE_GET_SEGMENTS      159   /* _sys_spu_image_get_segments */
+
+#define SYS_SPU_THREAD_GET_EXIT_STATUS  165
+#define SYS_SPU_THREAD_SET_ARGUMENT     166
 #define SYS_SPU_INITIALIZE              169
+
 #define SYS_SPU_THREAD_GROUP_CREATE     170
 #define SYS_SPU_THREAD_GROUP_DESTROY    171
 #define SYS_SPU_THREAD_INITIALIZE       172
@@ -160,22 +173,20 @@ extern "C" {
 #define SYS_SPU_THREAD_GROUP_JOIN       178
 #define SYS_SPU_THREAD_GROUP_SET_PRIORITY 179
 #define SYS_SPU_THREAD_GROUP_GET_PRIORITY 180
-#define SYS_SPU_THREAD_GROUP_CONNECT_EVENT 181
-#define SYS_SPU_THREAD_GROUP_DISCONNECT_EVENT 182
-#define SYS_SPU_THREAD_SET_ARGUMENT     183
-#define SYS_SPU_THREAD_GET_EXIT_STATUS  184
+
+#define SYS_SPU_THREAD_WRITE_LS         181
+#define SYS_SPU_THREAD_READ_LS          182
+#define SYS_SPU_THREAD_WRITE_SNR        184
+#define SYS_SPU_THREAD_SET_SPU_CFG      187
+#define SYS_SPU_THREAD_GET_SPU_CFG      188
+#define SYS_SPU_THREAD_GROUP_CONNECT_EVENT    185
+#define SYS_SPU_THREAD_GROUP_DISCONNECT_EVENT 186
+#define SYS_SPU_THREAD_WRITE_SPU_MB     190
 #define SYS_SPU_THREAD_CONNECT_EVENT    191
 #define SYS_SPU_THREAD_DISCONNECT_EVENT 192
-
-#define SYS_SPU_THREAD_WRITE_LS         229
-#define SYS_SPU_THREAD_READ_LS          230
-#define SYS_SPU_THREAD_WRITE_SNR        231
-#define SYS_SPU_THREAD_BIND_QUEUE       235
-#define SYS_SPU_THREAD_UNBIND_QUEUE     236
-#define SYS_SPU_THREAD_GROUP_CONNECT_EVENT_ALL_THREADS 185
-
-#define SYS_SPU_IMAGE_OPEN              156
-#define SYS_SPU_IMAGE_CLOSE             157
+#define SYS_SPU_THREAD_BIND_QUEUE       193
+#define SYS_SPU_THREAD_UNBIND_QUEUE     194
+#define SYS_SPU_THREAD_GROUP_CONNECT_EVENT_ALL_THREADS 251
 
 /* PRX (module) management */
 #define SYS_PRX_LOAD_MODULE             480


### PR DESCRIPTION
The event flag block (139-146), the lwmutex block (150-154) and the lwcond block (155-160) in runtime/syscalls/lv2_syscall_table.h use made up numbers that collide with real lv2 syscalls, verified against RPCS3's lv2 syscall table (Emu/Cell/lv2, oracle only, no code copied). Concretely, five numbers on this tree are claimed twice: 141 is both SYS_EVENT_FLAG_WAIT and SYS_TIMER_USLEEP, 142 is both SYS_EVENT_FLAG_TRYWAIT and SYS_TIMER_SLEEP, 145 is both SYS_EVENT_FLAG_CANCEL and SYS_TIME_GET_CURRENT_TIME, and 156/157 hold SYS_LWCOND_DESTROY and SYS_LWCOND_WAIT on top of the SPU image family, which per the real lv2 numbering (open 156, import 157, close 158) owns exactly those numbers. A guest binary using the lightweight sync primitives alongside timers or SPU image calls gets routed to the wrong handler, and the failure looks like anything but a table bug.

This corrects the three blocks plus the SPU thread management range (165/166/169/181-194/251) to the real numbers. Only the numeric values move, handler registrations keep their macro names, so no other file changes.

Verified: a standalone checker over the header's SYS_* defines reports 5 colliding numbers before and 0 after across all 163 macros, and ps3recomp_runtime builds clean with the header as the only change (cmake and ninja, 112 of 112 objects).
