### PR TITLE
ppu: lmw and stmw load store multiple word

### DIFF
--- a/tools/ppu_lifter.py
+++ b/tools/ppu_lifter.py
@@ -822,6 +822,41 @@ class PPULifter:
                 return line
             return f"/* {mn} unhandled operands: {insn.operands} */;"
 
+        # ------- Load/Store Multiple Word -------
+        # PowerISA_V2.03_Final_Public.pdf p.72 (Book I, section 3.3.5):
+        #   lmw RT,D(RA):  b = (RA=0) ? 0 : GPR[RA]; EA = b + EXTS(D);
+        #                  for r = RT..31: GPR(r) = 0x0..0 || MEM(EA,4); EA += 4
+        #     (n = 32-RT words load into the LOW-order 32 bits of GPRs RT..31,
+        #     high-order 32 bits zeroed -- same zero-extending 32-bit guest
+        #     load as lwz/vm_read32, just repeated for each register.)
+        #   stmw RS,D(RA): same EA; for r = RS..31: MEM(EA,4) = GPR(r)[32:63]; EA += 4
+        #     (store the low-order 32 bits of each GPR, same as stw/vm_write32.)
+        # RA=0 denotes a literal zero base (not GPR[0]), unlike the plain
+        # loads/stores above -- explicit here since the ISA calls it out.
+        if mn == "lmw":
+            rd_i = int(_reg_idx(ops[0]))
+            disp, base = _disp_base(ops[1])
+            if disp is not None:
+                stmts = [f"{{ uint64_t _ea = (({base}) ? ctx->gpr[{base}] : 0) + {disp};"]
+                for i, r in enumerate(range(rd_i, 32)):
+                    off = f" + {i * 4}" if i else ""
+                    stmts.append(f" ctx->gpr[{r}] = vm_read32(_ea{off});")
+                stmts.append(" }")
+                return "".join(stmts)
+            return f"/* {mn} unhandled operands: {insn.operands} */;"
+
+        if mn == "stmw":
+            rs_i = int(_reg_idx(ops[0]))
+            disp, base = _disp_base(ops[1])
+            if disp is not None:
+                stmts = [f"{{ uint64_t _ea = (({base}) ? ctx->gpr[{base}] : 0) + {disp};"]
+                for i, r in enumerate(range(rs_i, 32)):
+                    off = f" + {i * 4}" if i else ""
+                    stmts.append(f" vm_write32(_ea{off}, (uint32_t)ctx->gpr[{r}]);")
+                stmts.append(" }")
+                return "".join(stmts)
+            return f"/* {mn} unhandled operands: {insn.operands} */;"
+
         # ------- Indexed Loads -------
         idx_load_map = {
             "lbzx": "vm_read8", "lhzx": "vm_read16", "lwzx": "vm_read32", "ldx": "vm_read64",

--- a/tools/test_ppu_lift.py
+++ b/tools/test_ppu_lift.py
@@ -22,7 +22,9 @@ scratch\\dobuild2.bat when cl is absent).
 Scope (tranche 1): integer ALU/rotate/shift/carry/compare classes -- the
 proven silent-miscompile territory. Memory ops, FP, and VMX are follow-on
 tranches (VMX semantics already have manual-verified handling; loads/stores
-need a vm stub harness).
+need a vm stub harness). A first slice of that vm stub harness now backs the
+lmw/stmw cases below (CASES gained optional in_mem/exp_mem fields); it is
+minimal on purpose and can grow with later memory-op tranches.
 """
 
 import argparse
@@ -251,10 +253,13 @@ rng = random.Random(0x59414B5A)   # deterministic
 E64 += [rng.getrandbits(64) for _ in range(4)]
 
 CASES = []   # dicts: name, word, in_regs {idx:val}, in_ca, expects [(reg, val, mask)], exp_ca, exp_cr(nibble,pos), may_trap
+             # in_mem/exp_mem {addr: bytes} back the lmw/stmw memory-op cases below.
 
-def case(name, word, in_regs, expects, in_ca=None, exp_ca=None, exp_cr=None, may_trap=False):
+def case(name, word, in_regs, expects, in_ca=None, exp_ca=None, exp_cr=None, may_trap=False,
+         in_mem=None, exp_mem=None):
     CASES.append(dict(name=name, word=word, in_regs=in_regs, expects=expects,
-                      in_ca=in_ca, exp_ca=exp_ca, exp_cr=exp_cr, may_trap=may_trap))
+                      in_ca=in_ca, exp_ca=exp_ca, exp_cr=exp_cr, may_trap=may_trap,
+                      in_mem=in_mem or {}, exp_mem=exp_mem or {}))
 
 # VMX/vector cases: unlike the GPR CASES above, a vupk-family op reads/writes
 # ctx->vr[] directly (no memory load/store instructions needed to exercise
@@ -476,6 +481,33 @@ def build_cases():
         case(f"add. a={a:#x} b={b:#x}", xo_form(266, R[0], R[1], R[2], rc=1),
              {R[1]: a, R[2]: b}, [(R[0], v, MASK64)], exp_cr=(nib, 28))
 
+    # --- lmw/stmw (load/store multiple word) -------------------------------
+    # PowerISA_V2.03_Final_Public.pdf p.72: EA = (RA=0 ? 0 : GPR[RA]) + D, then
+    # each word r..31 is loaded/stored 4 bytes at a time, big-endian, RA=0
+    # meaning a literal zero base rather than GPR[0]. Cover both a normal
+    # nonzero-base EA and the RA=0 literal-base rule, for both directions.
+    w29, w30, w31 = 0x11223344, 0xAABBCCDD, 0x00000001
+    ea = 0x2030
+    case("lmw r29..r31 base=r4", d_form(46, 29, R[1], 0x30), {R[1]: 0x2000},
+         [(29, w29, MASK64), (30, w30, MASK64), (31, w31, MASK64)],
+         in_mem={ea: struct.pack(">III", w29, w30, w31)})
+
+    w29b, w30b, w31b = 0xDEADBEEF, 0x00000001, 0xFFFFFFFF
+    ea = 0x3040
+    case("stmw r29..r31 base=r4", d_form(47, 29, R[1], 0x40), {R[1]: 0x3000, 29: w29b, 30: w30b, 31: w31b},
+         [], exp_mem={ea: struct.pack(">III", w29b, w30b, w31b)})
+
+    w29c, w30c, w31c = 0x55667788, 0x99AABBCC, 0x0000002A
+    ea = 0x100
+    case("lmw r29..r31 base=0", d_form(46, 29, 0, 0x100), {},
+         [(29, w29c, MASK64), (30, w30c, MASK64), (31, w31c, MASK64)],
+         in_mem={ea: struct.pack(">III", w29c, w30c, w31c)})
+
+    w29d, w30d, w31d = 0x01020304, 0xFFEEDDCC, 0x00000000
+    ea = 0x200
+    case("stmw r29..r31 base=0", d_form(47, 29, 0, 0x200), {29: w29d, 30: w30d, 31: w31d},
+         [], exp_mem={ea: struct.pack(">III", w29d, w30d, w31d)})
+
 build_cases()
 
 def build_vcases():
@@ -549,6 +581,25 @@ static void check_vr(const char* name, const uint8_t* got, const uint8_t* want) 
         g_fail++;
     } else g_pass++;
 }
+static void check_mem(const char* name, uint64_t addr, const uint8_t* got, const uint8_t* want, int n) {
+    for (int i = 0; i < n; i++) {
+        if (got[i] != want[i]) {
+            printf("FAIL %s: mem[0x%llX] byte %d = 0x%02X want 0x%02X\\n",
+                   name, (unsigned long long)addr, i, got[i], want[i]);
+            g_fail++;
+            return;
+        }
+    }
+    g_pass++;
+}
+/* vm stub over a 64 KB scratch page for the memory-op cases (lmw/stmw); EAs
+ * are masked into it. Only lmw/stmw exercise this today, so vm_read/write
+ * beyond 8/16/32 bits aren't provided yet -- add as later tranches need them. */
+#include <stdlib.h>   /* MSVC _byteswap_* */
+static uint8_t g_vm_stub[65536];
+#define VMOFF(a) ((uint32_t)(a) & 0xFFFFu)
+extern "C" uint32_t vm_read32(uint64_t a) { uint32_t v; memcpy(&v, g_vm_stub + VMOFF(a), 4); return _byteswap_ulong(v); }
+extern "C" void vm_write32(uint64_t a, uint32_t v) { v = _byteswap_ulong(v); memcpy(g_vm_stub + VMOFF(a), &v, 4); }
 """)
     out.append("int main(void) {")
     out.append("    ppu_context* ctx = &g_ctx;")
@@ -570,14 +621,24 @@ static void check_vr(const char* name, const uint8_t* got, const uint8_t* want) 
         nm = c["name"].replace('"', "'")
         out.append(f'    {{ /* case {i}: {nm} | {insn.mnemonic} {insn.operands} */')
         out.append("      memset(ctx, 0, sizeof(*ctx));")
+        if c["in_mem"] or c["exp_mem"]:
+            out.append("      memset(g_vm_stub, 0, sizeof(g_vm_stub));")
         for reg, val in c["in_regs"].items():
             out.append(f"      ctx->gpr[{reg}] = 0x{val:016X}ULL;")
         if c["in_ca"]:
             out.append("      ctx->xer |= (1u << 29);")
+        for addr, blob in c["in_mem"].items():
+            byts = ", ".join(f"0x{b:02X}" for b in blob)
+            out.append(f"      {{ static const uint8_t _m[{len(blob)}] = {{ {byts} }}; "
+                       f"memcpy(g_vm_stub + VMOFF(0x{addr:X}), _m, {len(blob)}); }}")
         body = [f"        {code}"]
         for reg, val, mask in c["expects"]:
             body.append(f'        check_reg("{nm}", {reg}, ctx->gpr[{reg}], '
                         f"0x{val:016X}ULL, 0x{mask:016X}ULL);")
+        for addr, blob in c["exp_mem"].items():
+            byts = ", ".join(f"0x{b:02X}" for b in blob)
+            body.append(f'        {{ static const uint8_t _want[{len(blob)}] = {{ {byts} }}; '
+                        f'check_mem("{nm}", 0x{addr:X}ULL, g_vm_stub + VMOFF(0x{addr:X}), _want, {len(blob)}); }}')
         if c["exp_ca"] is not None:
             body.append(f'        check_ca("{nm}", ctx->xer, {int(bool(c["exp_ca"]))});')
         if c["exp_cr"] is not None:


### PR DESCRIPTION
﻿lmw and stmw were already decoded by ppu_disasm but fell through to the lifter's TODO catch all, so any guest function using either instruction silently dropped the whole load or store instead of touching the registers or memory at all. This is a port from the Yakuza port's lifter. PowerISA_V2.03_Final_Public.pdf page 72, Book I section 3.3.5, gives EA as (RA=0 ? 0 : GPR[RA]) plus D, then each register from RT (or RS) through r31 is a plain four byte big endian word at EA, EA+4 and so on, RA=0 meaning a literal zero base rather than GPR[0], called out explicitly since the plain loads and stores just above this block do not handle rA=0 that way. These are the named lmw_last and stmw failure classes in the PR 64 torture suite.

Verified: 1303 of 1303 conformance checks green (993 cases, 0 skipped) including 4 new cases covering both directions of the transfer and both the normal and RA=0 addressing forms, backed by a small vm stub added to the conformance suite. Reverting the lifter change alone and keeping the new test cases makes all 4 of the new cases skip as unhandled by the lifter instead of running, since lmw and stmw fall back to the TODO stub without the fix, 989 cases run, 1295 checks passed, 0 failed, 4 skipped, so the suite discriminates old from new behavior.
