### PR TITLE
ppu: decode fpscr bit ops and vrsave as visible no ops

### DIFF
--- a/tools/ppu_disasm.py
+++ b/tools/ppu_disasm.py
@@ -27,6 +27,7 @@ SPR_NAMES = {
     19: "DAR",
     22: "DEC",
     25: "SDR1",
+    256: "VRSAVE",
     26: "SRR0",
     27: "SRR1",
     268: "TBL",
@@ -834,6 +835,10 @@ def decode(insn: int, addr: int = 0) -> Instruction:
             40: "fneg", 72: "fmr", 264: "fabs", 136: "fnabs",
             64: "mcrfs",
             583: "mffs", 711: "mtfsf",
+            # FPSCR bit ops. These previously fell through to the unknown-xo
+            # catch-all and emitted a raw .word, silently dropping the
+            # instruction from the lift.
+            70: "mtfsb0", 38: "mtfsb1", 134: "mtfsfi",
         }
         if xo_full in fp_x:
             mne = fp_x[xo_full]

--- a/tools/ppu_lifter.py
+++ b/tools/ppu_lifter.py
@@ -1083,6 +1083,16 @@ class PPULifter:
             rd_i = _reg_idx(ops[0])
             return f"ctx->gpr[{rd_i}] = ctx->cr;"
 
+        # VRSAVE is a hint register for AltiVec register allocation; nothing
+        # in the runtime models per-thread VRSAVE state, so treat the pair as
+        # a benign 0-read plus a discarded write rather than falling through
+        # to the unhandled-spr catch-all.
+        if mn == "mfspr" and ops and ops[-1].upper() == "VRSAVE":
+            rd_i = _reg_idx(ops[0])
+            return f"ctx->gpr[{rd_i}] = 0; /* VRSAVE unmodeled */"
+        if mn == "mtspr" and ops and ops[0].upper() == "VRSAVE":
+            return "/* mtspr VRSAVE: unmodeled */;"
+
         if mn == "mtcr":
             return f"ctx->cr = (uint32_t)ctx->gpr[{_reg_idx(ops[-1])}];"
         if mn == "mtcrf":
@@ -1389,6 +1399,12 @@ class PPULifter:
         # mtfsf — move to FPSCR fields
         if mn == "mtfsf":
             return f"/* mtfsf: FPSCR update — ignored for now */;"
+
+        # mtfsb0, mtfsb1, mtfsfi: FPSCR bit set/clear/immediate-field
+        # updates. FPSCR is unmodeled, so these become a named no-op comment
+        # instead of falling through to the unhandled-instruction catch-all.
+        if mn.rstrip(".") in ("mtfsb0", "mtfsb1", "mtfsfi"):
+            return f"/* {mn} {insn.operands}: FPSCR bit update — FPSCR unmodeled */;"
 
         # ------- Store/load with update indexed -------
         if mn == "stdux":

--- a/tools/test_ppu_lift.py
+++ b/tools/test_ppu_lift.py
@@ -77,6 +77,13 @@ def cmpi_form(op, bf, l, ra, imm):
 def vx_form(xo, vd, va, vb):
     return (4 << 26) | (vd << 21) | (va << 16) | (vb << 11) | xo
 
+def fp_x_form(xo, bt, rc=0):   # opcd-63 X-form FPSCR bit ops (mtfsb0/mtfsb1/mtfsfi); RA/RB unused
+    return (63 << 26) | (bt << 21) | (xo << 1) | rc
+
+def spr_form(xo, rt, spr_num):   # mfspr/mtspr; the 10-bit spr field is two 5-bit halves swapped
+    spr_raw = ((spr_num & 0x1F) << 5) | ((spr_num >> 5) & 0x1F)
+    return (31 << 26) | (rt << 21) | (spr_raw << 11) | (xo << 1)
+
 # ---------------------------------------------------------------------------
 # PowerISA reference semantics (independent of the lifter). 64-bit registers;
 # CA per the 64-bit operation (PowerISA v2.03, the manual in the repo root).
@@ -502,6 +509,56 @@ def build_vcases():
 build_vcases()
 
 # ---------------------------------------------------------------------------
+# Decode/lift-only checks: FPSCR bit ops (mtfsb0/mtfsb1/mtfsfi) and the
+# VRSAVE mfspr/mtspr pair. Their correct lift is a leading "/* ... */"
+# comment (a visible no-op, since FPSCR/VRSAVE are unmodeled), which is
+# indistinguishable from an unhandled instruction to the CASES driver above
+# (its "code.startswith('/*')" skip heuristic would drop them from the
+# generated C file either way), so verify them here directly against
+# ppu_disasm.decode and PPULifter._translate instead.
+# ---------------------------------------------------------------------------
+
+def check_decode_and_lift():
+    lifter = PPULifter()
+    dummy = LiftedFunction(name="conf", start_addr=0, end_addr=0x10000)
+    fails = [0]
+
+    def check(label, word, expect_mn, operand_substr=None, code_substr=None):
+        insn = ppu_disasm.decode(word, 0x30000)
+        mn = insn.mnemonic.rstrip(".")
+        if mn != expect_mn:
+            print(f"FAIL {label}: decoded as {insn.mnemonic} {insn.operands} "
+                  f"(word {word:#010x}), want {expect_mn}")
+            fails[0] += 1
+            return
+        if operand_substr and operand_substr not in insn.operands:
+            print(f"FAIL {label}: operands {insn.operands!r} missing {operand_substr!r}")
+            fails[0] += 1
+            return
+        code = lifter._translate(insn, dummy)
+        if code.startswith("/* TODO"):
+            print(f"FAIL {label}: lifter fell through to the unhandled catch-all: {code}")
+            fails[0] += 1
+            return
+        if code_substr and code_substr not in code:
+            print(f"FAIL {label}: lifted code {code!r} missing {code_substr!r}")
+            fails[0] += 1
+            return
+        print(f"[fpscr/vrsave] ok {label}: {insn.mnemonic} {insn.operands} -> {code}")
+
+    check("mtfsb0", fp_x_form(70, 5), "mtfsb0", code_substr="unmodeled")
+    check("mtfsb1", fp_x_form(38, 5), "mtfsb1", code_substr="unmodeled")
+    check("mtfsfi", fp_x_form(134, 5), "mtfsfi", code_substr="unmodeled")
+    check("mfspr VRSAVE", spr_form(339, 3, 256), "mfspr",
+          operand_substr="VRSAVE", code_substr="ctx->gpr[3] = 0")
+    check("mtspr VRSAVE", spr_form(467, 3, 256), "mtspr",
+          operand_substr="VRSAVE", code_substr="unmodeled")
+
+    n_ok = 5 - fails[0]
+    print(f"[fpscr/vrsave] {n_ok} checks passed, {fails[0]} FAILED")
+    return fails[0] == 0
+
+# ---------------------------------------------------------------------------
 # C driver generation
 # ---------------------------------------------------------------------------
 
@@ -639,6 +696,8 @@ def main():
     ap.add_argument("--emit", action="store_true", help="only write the C file")
     args = ap.parse_args()
 
+    decode_ok = check_decode_and_lift()
+
     os.makedirs(os.path.join(ROOT, "scratch"), exist_ok=True)
     cpath = os.path.join(ROOT, "scratch", "ppu_conformance.cpp")   # preamble is C++ (extern "C")
     epath = os.path.join(ROOT, "scratch", "ppu_conformance.exe")
@@ -668,7 +727,7 @@ def main():
             print(ln)
     if r.returncode == 2:
         print("COMPILE FAILED -- see", log)
-    sys.exit(0 if r.returncode == 0 else 1)
+    sys.exit(0 if (r.returncode == 0 and decode_ok) else 1)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
﻿mtfsb0 (xo 70), mtfsb1 (xo 38), and mtfsfi (xo 134) were undecoded, so they fell through to the unhandled catch all and were emitted as a raw .word, an invisible dropped instruction. mfspr/mtspr on spr 256 (VRSAVE) printed as a bare spr256 instead of a named register.

FPSCR is unmodeled by the runtime, so decode the three ops to their real mnemonics and have the lifter emit a named no op comment for them instead of the anonymous catch all, the same treatment already given to mtfsf. Add mfspr/mtspr no op arms for VRSAVE (a 0 read plus a discarded write) so that pair also stops hitting the catch all.

Verified: py -3 tools/test_ppu_lift.py, 1295 checks passed plus 5 new decode and lift only checks covering mtfsb0, mtfsb1, mtfsfi, mfspr VRSAVE, and mtspr VRSAVE, 0 failed, 0 skipped.
