### PR TITLE
ppu: fp load and store update forms write back ra

### DIFF
--- a/tools/ppu_lifter.py
+++ b/tools/ppu_lifter.py
@@ -1105,7 +1105,7 @@ class PPULifter:
             return "lv2_syscall(ctx);"
 
         # ------- Floating-point loads/stores -------
-        if mn in ("lfs", "lfsu", "lfd", "lfdu"):
+        if mn in ("lfs", "lfd"):
             frd = _reg_idx(ops[0])
             disp, base = _disp_base(ops[1])
             if disp is not None:
@@ -1116,7 +1116,26 @@ class PPULifter:
                     return (f"{{ uint64_t tmp = vm_read64(ctx->gpr[{base}] + {disp}); "
                             f"memcpy(&ctx->fpr[{frd}], &tmp, 8); }}")
 
-        if mn in ("stfs", "stfsu", "stfd", "stfdu"):
+        # lfsu/lfdu sat in the plain lfs/lfd handling above (alongside their
+        # non-update counterparts), so the load happened but RA never got
+        # written back. PowerISA_V2.03_Final_Public.pdf p.129 (Load
+        # Floating-Point Single with Update) and p.130 (...Double with
+        # Update): EA is computed, the load goes through EA, then RA <- EA;
+        # both pages state RA=0 on these forms is itself an invalid
+        # instruction, so unlike the plain D-form loads there is no rA=0
+        # literal-zero-base case to guard here.
+        if mn in ("lfsu", "lfdu"):
+            frd = _reg_idx(ops[0])
+            disp, base = _disp_base(ops[1])
+            if disp is not None:
+                if mn == "lfsu":
+                    return (f"{{ uint64_t ea = ctx->gpr[{base}] + {disp}; uint32_t tmp = vm_read32(ea); "
+                            f"float ftmp; memcpy(&ftmp, &tmp, 4); ctx->fpr[{frd}] = ftmp; ctx->gpr[{base}] = ea; }}")
+                else:
+                    return (f"{{ uint64_t ea = ctx->gpr[{base}] + {disp}; uint64_t tmp = vm_read64(ea); "
+                            f"memcpy(&ctx->fpr[{frd}], &tmp, 8); ctx->gpr[{base}] = ea; }}")
+
+        if mn in ("stfs", "stfd"):
             frs = _reg_idx(ops[0])
             disp, base = _disp_base(ops[1])
             if disp is not None:
@@ -1125,12 +1144,30 @@ class PPULifter:
                 # mis-classified stfd/stfdu as single and emitted a lossy 4-byte
                 # store, corrupting the double (breaks fctidz+stfd+ld float->GPR
                 # idioms and any stored double). [ps3recomp fork JonathanDC64 eb5451b3]
-                if mn in ("stfs", "stfsu"):
+                if mn == "stfs":
                     return (f"{{ float ftmp = (float)ctx->fpr[{frs}]; uint32_t tmp; "
                             f"memcpy(&tmp, &ftmp, 4); vm_write32(ctx->gpr[{base}] + {disp}, tmp); }}")
                 else:
                     return (f"{{ uint64_t tmp; memcpy(&tmp, &ctx->fpr[{frs}], 8); "
                             f"vm_write64(ctx->gpr[{base}] + {disp}, tmp); }}")
+
+        # stfsu/stfdu: same RA<-EA update-form writeback fix as lfsu/lfdu
+        # above (they too sat in the plain stfs/stfd handling with no
+        # writeback). PowerISA_V2.03_Final_Public.pdf p.132 (Store
+        # Floating-Point Single with Update) and p.133 (...Double with
+        # Update) give the same RA <- EA rule and the same RA=0-invalid note;
+        # the single-vs-double explicit-mnemonic match above applies here for
+        # the same reason.
+        if mn in ("stfsu", "stfdu"):
+            frs = _reg_idx(ops[0])
+            disp, base = _disp_base(ops[1])
+            if disp is not None:
+                if mn == "stfsu":
+                    return (f"{{ uint64_t ea = ctx->gpr[{base}] + {disp}; float ftmp = (float)ctx->fpr[{frs}]; "
+                            f"uint32_t tmp; memcpy(&tmp, &ftmp, 4); vm_write32(ea, tmp); ctx->gpr[{base}] = ea; }}")
+                else:
+                    return (f"{{ uint64_t ea = ctx->gpr[{base}] + {disp}; uint64_t tmp; "
+                            f"memcpy(&tmp, &ctx->fpr[{frs}], 8); vm_write64(ea, tmp); ctx->gpr[{base}] = ea; }}")
 
         # ------- FP arithmetic -------
         fp_binary = {

--- a/tools/test_ppu_lift.py
+++ b/tools/test_ppu_lift.py
@@ -22,7 +22,10 @@ scratch\\dobuild2.bat when cl is absent).
 Scope (tranche 1): integer ALU/rotate/shift/carry/compare classes -- the
 proven silent-miscompile territory. Memory ops, FP, and VMX are follow-on
 tranches (VMX semantics already have manual-verified handling; loads/stores
-need a vm stub harness).
+need a vm stub harness). A minimal vm stub now backs the FP D-form
+load/store-with-update RA writeback cases below (CASES gained optional
+in_mem/exp_mem/in_fpr/exp_fpr fields); it is self-contained on purpose and
+can grow with later memory-op tranches.
 """
 
 import argparse
@@ -251,10 +254,17 @@ rng = random.Random(0x59414B5A)   # deterministic
 E64 += [rng.getrandbits(64) for _ in range(4)]
 
 CASES = []   # dicts: name, word, in_regs {idx:val}, in_ca, expects [(reg, val, mask)], exp_ca, exp_cr(nibble,pos), may_trap
+             # in_mem/exp_mem {addr: bytes} and in_fpr {freg: raw64 bits} /
+             # exp_fpr [(freg, raw64 bits)] back the FP update-form cases below
+             # (ctx->fpr is a double[32]; bits are compared as the raw
+             # IEEE-754 pattern via memcpy, not value).
 
-def case(name, word, in_regs, expects, in_ca=None, exp_ca=None, exp_cr=None, may_trap=False):
+def case(name, word, in_regs, expects, in_ca=None, exp_ca=None, exp_cr=None, may_trap=False,
+         in_mem=None, exp_mem=None, in_fpr=None, exp_fpr=None):
     CASES.append(dict(name=name, word=word, in_regs=in_regs, expects=expects,
-                      in_ca=in_ca, exp_ca=exp_ca, exp_cr=exp_cr, may_trap=may_trap))
+                      in_ca=in_ca, exp_ca=exp_ca, exp_cr=exp_cr, may_trap=may_trap,
+                      in_mem=in_mem or {}, exp_mem=exp_mem or {},
+                      in_fpr=in_fpr or {}, exp_fpr=exp_fpr or []))
 
 # VMX/vector cases: unlike the GPR CASES above, a vupk-family op reads/writes
 # ctx->vr[] directly (no memory load/store instructions needed to exercise
@@ -476,6 +486,52 @@ def build_cases():
         case(f"add. a={a:#x} b={b:#x}", xo_form(266, R[0], R[1], R[2], rc=1),
              {R[1]: a, R[2]: b}, [(R[0], v, MASK64)], exp_cr=(nib, 28))
 
+    # --- FP D-form load/store-with-update RA writeback ---------------------
+    # lfsu/lfdu/stfsu/stfdu (opcodes 49/51/53/55) sat in the plain lfs/lfd/
+    # stfs/stfd handling, so the access happened but RA never got EA written
+    # back. PowerISA_V2.03_Final_Public.pdf p.129 (Load Floating-Point Single
+    # with Update), p.130 (...Double with Update), p.132 (Store
+    # Floating-Point Single with Update) and p.133 (...Double with Update)
+    # all give RA <- EA as part of the update form and all four state RA=0
+    # is itself an invalid instruction on these forms, so no rA=0 guard
+    # belongs in the update handlers.
+    pi_bits = struct.unpack(">Q", struct.pack(">d", 3.14159265358979))[0]
+    fp_val = 2.5   # exactly representable in both float and double
+    fp_double_bits = struct.unpack(">Q", struct.pack(">d", fp_val))[0]
+    fp_float_bytes = struct.pack(">f", fp_val)
+
+    # lfsu f7,0x10(r3): single-load-with-update -- checks the widened double
+    # bits AND the updated RA.
+    case("lfsu loaded single widened and ra writeback", d_form(49, 7, 3, 0x10),
+         {3: 0x4000}, [(3, 0x4010, MASK64)],
+         in_mem={0x4010: fp_float_bytes},
+         exp_fpr=[(7, fp_double_bits)])
+
+    # lfdu f8,0x40(r4): checks BOTH the loaded double bits and the updated RA.
+    case("lfdu loaded double and ra writeback", d_form(51, 8, 4, 0x40),
+         {4: 0x5000}, [(4, 0x5040, MASK64)],
+         in_mem={0x5040: struct.pack(">Q", pi_bits)},
+         exp_fpr=[(8, pi_bits)])
+
+    # stfsu f9,0x30(r5): checks BOTH the stored float bytes and the updated RA.
+    case("stfsu stored float and ra writeback", d_form(53, 9, 5, 0x30),
+         {5: 0x6000}, [(5, 0x6030, MASK64)],
+         in_fpr={9: fp_double_bits},
+         exp_mem={0x6030: fp_float_bytes})
+
+    # stfdu f11,0x20(r12): double-store-with-update -- checks BOTH the stored
+    # double bytes and the updated RA.
+    case("stfdu stored double and ra writeback", d_form(55, 11, 12, 0x20),
+         {12: 0x8000}, [(12, 0x8020, MASK64)],
+         in_fpr={11: pi_bits},
+         exp_mem={0x8020: struct.pack(">Q", pi_bits)})
+
+    # lfd f10,0x20(r6): non-update regression check -- RA must be left alone.
+    case("lfd non-update leaves ra untouched", d_form(50, 10, 6, 0x20),
+         {6: 0x7000}, [(6, 0x7000, MASK64)],
+         in_mem={0x7020: struct.pack(">Q", pi_bits)},
+         exp_fpr=[(10, pi_bits)])
+
 build_cases()
 
 def build_vcases():
@@ -549,6 +605,35 @@ static void check_vr(const char* name, const uint8_t* got, const uint8_t* want) 
         g_fail++;
     } else g_pass++;
 }
+static void check_mem(const char* name, uint64_t addr, const uint8_t* got, const uint8_t* want, int n) {
+    for (int i = 0; i < n; i++) {
+        if (got[i] != want[i]) {
+            printf("FAIL %s: mem[0x%llX] byte %d = 0x%02X want 0x%02X\\n",
+                   name, (unsigned long long)addr, i, got[i], want[i]);
+            g_fail++;
+            return;
+        }
+    }
+    g_pass++;
+}
+static void check_fpr(const char* name, int reg, uint64_t got, uint64_t want) {
+    if (got != want) {
+        printf("FAIL %s: f%d raw bits = 0x%016llX want 0x%016llX\\n",
+               name, reg, (unsigned long long)got, (unsigned long long)want);
+        g_fail++;
+    } else g_pass++;
+}
+/* vm stub over a 64 KB scratch page for the FP update-form load/store cases
+ * (RA writeback needs a real access to write RA back after); EAs are masked
+ * into it. Widths beyond what these cases need aren't provided -- add as
+ * later memory-op tranches need them. */
+#include <stdlib.h>   /* MSVC _byteswap_* */
+static uint8_t g_vm_stub[65536];
+#define VMOFF(a) ((uint32_t)(a) & 0xFFFFu)
+extern "C" uint32_t vm_read32(uint64_t a) { uint32_t v; memcpy(&v, g_vm_stub + VMOFF(a), 4); return _byteswap_ulong(v); }
+extern "C" void vm_write32(uint64_t a, uint32_t v) { v = _byteswap_ulong(v); memcpy(g_vm_stub + VMOFF(a), &v, 4); }
+extern "C" uint64_t vm_read64(uint64_t a) { uint64_t v; memcpy(&v, g_vm_stub + VMOFF(a), 8); return _byteswap_uint64(v); }
+extern "C" void vm_write64(uint64_t a, uint64_t v) { v = _byteswap_uint64(v); memcpy(g_vm_stub + VMOFF(a), &v, 8); }
 """)
     out.append("int main(void) {")
     out.append("    ppu_context* ctx = &g_ctx;")
@@ -570,14 +655,29 @@ static void check_vr(const char* name, const uint8_t* got, const uint8_t* want) 
         nm = c["name"].replace('"', "'")
         out.append(f'    {{ /* case {i}: {nm} | {insn.mnemonic} {insn.operands} */')
         out.append("      memset(ctx, 0, sizeof(*ctx));")
+        if c["in_mem"] or c["exp_mem"]:
+            out.append("      memset(g_vm_stub, 0, sizeof(g_vm_stub));")
         for reg, val in c["in_regs"].items():
             out.append(f"      ctx->gpr[{reg}] = 0x{val:016X}ULL;")
         if c["in_ca"]:
             out.append("      ctx->xer |= (1u << 29);")
+        for addr, blob in c["in_mem"].items():
+            byts = ", ".join(f"0x{b:02X}" for b in blob)
+            out.append(f"      {{ static const uint8_t _m[{len(blob)}] = {{ {byts} }}; "
+                       f"memcpy(g_vm_stub + VMOFF(0x{addr:X}), _m, {len(blob)}); }}")
+        for reg, bits in c["in_fpr"].items():
+            out.append(f"      {{ uint64_t _b = 0x{bits:016X}ULL; memcpy(&ctx->fpr[{reg}], &_b, 8); }}")
         body = [f"        {code}"]
         for reg, val, mask in c["expects"]:
             body.append(f'        check_reg("{nm}", {reg}, ctx->gpr[{reg}], '
                         f"0x{val:016X}ULL, 0x{mask:016X}ULL);")
+        for addr, blob in c["exp_mem"].items():
+            byts = ", ".join(f"0x{b:02X}" for b in blob)
+            body.append(f'        {{ static const uint8_t _want[{len(blob)}] = {{ {byts} }}; '
+                        f'check_mem("{nm}", 0x{addr:X}ULL, g_vm_stub + VMOFF(0x{addr:X}), _want, {len(blob)}); }}')
+        for reg, bits in c["exp_fpr"]:
+            body.append(f'        {{ uint64_t _got; memcpy(&_got, &ctx->fpr[{reg}], 8); '
+                        f'check_fpr("{nm}", {reg}, _got, 0x{bits:016X}ULL); }}')
         if c["exp_ca"] is not None:
             body.append(f'        check_ca("{nm}", ctx->xer, {int(bool(c["exp_ca"]))});')
         if c["exp_cr"] is not None:


### PR DESCRIPTION
﻿lfsu, lfdu, stfsu and stfdu sat in the plain lfs/lfd/stfs/stfd handlers alongside their non update counterparts, so the access happened but RA never got EA written back. PowerISA_V2.03_Final_Public.pdf p.129 gives Load Floating Point Single with Update as EA computed then RA gets EA, p.130 gives the same rule for the double form, and p.132 and p.133 give the identical rule for the single and double stores with update, all four stating that RA=0 on these forms is itself an invalid instruction, so unlike the plain D form loads and stores there is no rA=0 literal zero base case to guard here. This is the FP sibling of the indexed integer fix on the ppu-store-update-writeback branch, same landmine class, the base pointer idiom that walks a struct of floats or doubles one field at a time never advances, so it re reads or re writes the same field forever instead of stepping through memory. I checked whether the X form update variants share the defect, lfsux, lfdux, stfsux and stfdux are decoded by ppu_disasm.py but have no handler at all in ppu_lifter.py, so they fall through to the unhandled catch all rather than silently miscompiling, a separate pre existing gap noted in tools/disasm_audit_operands_whitelist.txt and left alone here since the fix is scoped to the D form defect that was actually confirmed. The fix gives each of the four D form mnemonics its own handler that computes EA once, performs the load or store through it, then writes RA, leaving the non update lfs/lfd/stfs/stfd handlers untouched.

Verified: 994 of 994 conformance cases green, 1305 of 1305 checks passed, 0 skipped, including 5 new cases, lfsu, lfdu, stfsu and stfdu each checking both the memory access and the updated RA, plus an lfd regression check confirming the non update form leaves RA untouched. Reverting just the lifter hunk and keeping all five new cases turns exactly the 4 RA checks red while the memory access side of each case keeps passing, 1301 of 1305 checks passed, 4 failed, 0 skipped, so the suite discriminates the old behavior from the fixed one.
