### PR TITLE
ppu: vmx element wise ops read big endian lanes, values were byte reversed on x86

### DIFF
--- a/tools/ppu_lifter.py
+++ b/tools/ppu_lifter.py
@@ -1663,7 +1663,14 @@ class PPULifter:
                     f"tmp[i] = (sel < 16) ? a[sel] : b[sel - 16]; }} "
                     f"memcpy(d, tmp, 16); }}")
 
-        # VMX splat (vspltw, vsplth, vspltb) — duplicate one element across vector
+        # VMX splat (vspltw, vsplth, vspltb) — duplicate one element across
+        # vector. Left as native casts deliberately: a splat only ever COPIES
+        # an existing lane's raw bytes to other lane positions (no arithmetic
+        # on the value), so reading and writing with the same native
+        # reinterpretation cancels out and the transferred bytes are correct
+        # regardless of host endianness. (Unlike vspltisb/h/w two blocks
+        # above, which synthesize a NEW value from an immediate and do need
+        # the accessors.) See vsplth below for the halfword form.
         if mn == "vspltw":
             vd = int(ops[0][1:])
             vb = int(ops[1][1:])
@@ -1691,18 +1698,21 @@ class PPULifter:
                     f"d[0] = a[0] | b[0]; d[1] = a[1] | b[1]; }}")
 
         # ------- VMX floating-point arithmetic -------
+        # ctx->vr holds raw big-endian bytes; a native float* cast reinterprets
+        # each lane's 4 BE bytes as a host-endian (LE) float, which is a
+        # completely different bit pattern (e.g. 2.0's BE bytes 40 00 00 00
+        # read natively as a denormal near zero). Route every lane through
+        # vrf/vstf so the arithmetic sees/writes the correct value.
         if mn == "vmaddfp":
             # Vector Multiply-Add Floating-Point: vD = vA * vC + vB
             vd = int(ops[0][1:])
             va = int(ops[1][1:])
             vb = int(ops[2][1:])  # Note: vmaddfp operand order is vD, vA, vC, vB
             vc = int(ops[3][1:])
-            return (f"{{ float* d = (float*)&ctx->vr[{vd}]; "
-                    f"float* a = (float*)&ctx->vr[{va}]; "
-                    f"float* b = (float*)&ctx->vr[{vb}]; "
-                    f"float* c = (float*)&ctx->vr[{vc}]; "
-                    f"d[0]=a[0]*c[0]+b[0]; d[1]=a[1]*c[1]+b[1]; "
-                    f"d[2]=a[2]*c[2]+b[2]; d[3]=a[3]*c[3]+b[3]; }}")
+            return (f"{{ void* d=&ctx->vr[{vd}]; void* a=&ctx->vr[{va}]; "
+                    f"void* b=&ctx->vr[{vb}]; void* c=&ctx->vr[{vc}]; float r[4]; "
+                    f"for(int i=0;i<4;i++) r[i]=vrf(a,i)*vrf(c,i)+vrf(b,i); "
+                    f"for(int i=0;i<4;i++) vstf(d,i,r[i]); }}")
 
         if mn == "vnmsubfp":
             # Vector Negative Multiply-Subtract: vD = -(vA * vC - vB) = vB - vA*vC
@@ -1710,31 +1720,29 @@ class PPULifter:
             va = int(ops[1][1:])
             vb = int(ops[2][1:])
             vc = int(ops[3][1:])
-            return (f"{{ float* d = (float*)&ctx->vr[{vd}]; "
-                    f"float* a = (float*)&ctx->vr[{va}]; "
-                    f"float* b = (float*)&ctx->vr[{vb}]; "
-                    f"float* c = (float*)&ctx->vr[{vc}]; "
-                    f"d[0]=b[0]-a[0]*c[0]; d[1]=b[1]-a[1]*c[1]; "
-                    f"d[2]=b[2]-a[2]*c[2]; d[3]=b[3]-a[3]*c[3]; }}")
+            return (f"{{ void* d=&ctx->vr[{vd}]; void* a=&ctx->vr[{va}]; "
+                    f"void* b=&ctx->vr[{vb}]; void* c=&ctx->vr[{vc}]; float r[4]; "
+                    f"for(int i=0;i<4;i++) r[i]=vrf(b,i)-vrf(a,i)*vrf(c,i); "
+                    f"for(int i=0;i<4;i++) vstf(d,i,r[i]); }}")
 
         if mn == "vaddfp":
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
-            return (f"{{ float* d=(float*)&ctx->vr[{vd}]; float* a=(float*)&ctx->vr[{va}]; "
-                    f"float* b=(float*)&ctx->vr[{vb}]; "
-                    f"d[0]=a[0]+b[0]; d[1]=a[1]+b[1]; d[2]=a[2]+b[2]; d[3]=a[3]+b[3]; }}")
+            return (f"{{ void* d=&ctx->vr[{vd}]; void* a=&ctx->vr[{va}]; void* b=&ctx->vr[{vb}]; "
+                    f"float r[4]; for(int i=0;i<4;i++) r[i]=vrf(a,i)+vrf(b,i); "
+                    f"for(int i=0;i<4;i++) vstf(d,i,r[i]); }}")
 
         if mn == "vsubfp":
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
-            return (f"{{ float* d=(float*)&ctx->vr[{vd}]; float* a=(float*)&ctx->vr[{va}]; "
-                    f"float* b=(float*)&ctx->vr[{vb}]; "
-                    f"d[0]=a[0]-b[0]; d[1]=a[1]-b[1]; d[2]=a[2]-b[2]; d[3]=a[3]-b[3]; }}")
+            return (f"{{ void* d=&ctx->vr[{vd}]; void* a=&ctx->vr[{va}]; void* b=&ctx->vr[{vb}]; "
+                    f"float r[4]; for(int i=0;i<4;i++) r[i]=vrf(a,i)-vrf(b,i); "
+                    f"for(int i=0;i<4;i++) vstf(d,i,r[i]); }}")
 
         if mn == "vmulfp":
             # Not a real PPC instruction but some disassemblers emit it
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
-            return (f"{{ float* d=(float*)&ctx->vr[{vd}]; float* a=(float*)&ctx->vr[{va}]; "
-                    f"float* b=(float*)&ctx->vr[{vb}]; "
-                    f"d[0]=a[0]*b[0]; d[1]=a[1]*b[1]; d[2]=a[2]*b[2]; d[3]=a[3]*b[3]; }}")
+            return (f"{{ void* d=&ctx->vr[{vd}]; void* a=&ctx->vr[{va}]; void* b=&ctx->vr[{vb}]; "
+                    f"float r[4]; for(int i=0;i<4;i++) r[i]=vrf(a,i)*vrf(b,i); "
+                    f"for(int i=0;i<4;i++) vstf(d,i,r[i]); }}")
 
         # VMX select (vsel) — bitwise select: vD = (vA & ~vC) | (vB & vC)
         if mn == "vsel":
@@ -1748,27 +1756,25 @@ class PPULifter:
                     f"uint64_t* c=(uint64_t*)&ctx->vr[{vc}]; "
                     f"d[0]=(a[0]&~c[0])|(b[0]&c[0]); d[1]=(a[1]&~c[1])|(b[1]&c[1]); }}")
 
-        # VMX compare (vcmpequw, vcmpeqfp, vcmpgefp, vcmpgtfp)
+        # VMX compare (vcmpequw, vcmpeqfp, vcmpgefp, vcmpgtfp). Operands read
+        # via vrf (a native float* cast on raw-BE storage compares garbage
+        # bit patterns, not the guest's actual float values); the all-1s/
+        # all-0s mask result is byte-swap symmetric either way but is routed
+        # through vstw for consistency with every other lane accessor.
         if mn.startswith("vcmpeqfp"):
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
-            return (f"{{ float* a=(float*)&ctx->vr[{va}]; float* b=(float*)&ctx->vr[{vb}]; "
-                    f"uint32_t* d=(uint32_t*)&ctx->vr[{vd}]; "
-                    f"d[0]=a[0]==b[0]?~0u:0; d[1]=a[1]==b[1]?~0u:0; "
-                    f"d[2]=a[2]==b[2]?~0u:0; d[3]=a[3]==b[3]?~0u:0; }}")
+            return (f"{{ void* a=&ctx->vr[{va}]; void* b=&ctx->vr[{vb}]; void* d=&ctx->vr[{vd}]; "
+                    f"for(int i=0;i<4;i++) vstw(d,i,(vrf(a,i)==vrf(b,i))?~0u:0u); }}")
 
         if mn.startswith("vcmpgefp"):
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
-            return (f"{{ float* a=(float*)&ctx->vr[{va}]; float* b=(float*)&ctx->vr[{vb}]; "
-                    f"uint32_t* d=(uint32_t*)&ctx->vr[{vd}]; "
-                    f"d[0]=a[0]>=b[0]?~0u:0; d[1]=a[1]>=b[1]?~0u:0; "
-                    f"d[2]=a[2]>=b[2]?~0u:0; d[3]=a[3]>=b[3]?~0u:0; }}")
+            return (f"{{ void* a=&ctx->vr[{va}]; void* b=&ctx->vr[{vb}]; void* d=&ctx->vr[{vd}]; "
+                    f"for(int i=0;i<4;i++) vstw(d,i,(vrf(a,i)>=vrf(b,i))?~0u:0u); }}")
 
         if mn.startswith("vcmpgtfp"):
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
-            return (f"{{ float* a=(float*)&ctx->vr[{va}]; float* b=(float*)&ctx->vr[{vb}]; "
-                    f"uint32_t* d=(uint32_t*)&ctx->vr[{vd}]; "
-                    f"d[0]=a[0]>b[0]?~0u:0; d[1]=a[1]>b[1]?~0u:0; "
-                    f"d[2]=a[2]>b[2]?~0u:0; d[3]=a[3]>b[3]?~0u:0; }}")
+            return (f"{{ void* a=&ctx->vr[{va}]; void* b=&ctx->vr[{vb}]; void* d=&ctx->vr[{vd}]; "
+                    f"for(int i=0;i<4;i++) vstw(d,i,(vrf(a,i)>vrf(b,i))?~0u:0u); }}")
 
         # VMX shift (vsldoi) — shift left double by octet immediate
         if mn == "vsldoi":
@@ -1780,51 +1786,72 @@ class PPULifter:
                     f"memcpy(tmp, &ctx->vr[{va}], 16); memcpy(tmp+16, &ctx->vr[{vb}], 16); "
                     f"memcpy(&ctx->vr[{vd}], tmp + {sh}, 16); }}")
 
-        # VMX integer multiply-accumulate
+        # VMX integer multiply-accumulate. Halfword sources and the s32
+        # accumulator/result all reinterpret multi-byte lanes: route through
+        # vrh (a, b) and vrw/vstw (c, d).
         if mn == "vmsumshm":
             # vmsumshm vD, vA, vB, vC: multiply s16×s16 pairs, add to s32 accumulator
             vd = int(ops[0][1:])
             va = int(ops[1][1:])
             vb = int(ops[2][1:])
             vc = int(ops[3][1:])
-            return (f"{{ int16_t* a=(int16_t*)&ctx->vr[{va}]; "
-                    f"int16_t* b=(int16_t*)&ctx->vr[{vb}]; "
-                    f"int32_t* c=(int32_t*)&ctx->vr[{vc}]; "
-                    f"int32_t* d=(int32_t*)&ctx->vr[{vd}]; "
-                    f"for(int i=0;i<4;i++) d[i]=c[i]+(int32_t)a[i*2]*(int32_t)b[i*2]+(int32_t)a[i*2+1]*(int32_t)b[i*2+1]; }}")
+            return (f"{{ void* a=&ctx->vr[{va}]; void* b=&ctx->vr[{vb}]; "
+                    f"void* c=&ctx->vr[{vc}]; void* d=&ctx->vr[{vd}]; int32_t r[4]; "
+                    f"for(int i=0;i<4;i++) r[i]=(int32_t)vrw(c,i)"
+                    f"+(int32_t)(int16_t)vrh(a,i*2)*(int32_t)(int16_t)vrh(b,i*2)"
+                    f"+(int32_t)(int16_t)vrh(a,i*2+1)*(int32_t)(int16_t)vrh(b,i*2+1); "
+                    f"for(int i=0;i<4;i++) vstw(d,i,(uint32_t)r[i]); }}")
 
-        # VMX integer compare
+        # VMX integer compare. Equality is byte-swap symmetric (swap(a)==swap(b)
+        # iff a==b) and the all-1s/all-0s mask is too, so a native cast here
+        # is not actually a wrong-VALUE bug like vcmpgt/add below -- routed
+        # through vrh/vsth (resp. vrw/vstw) anyway for lane-accessor consistency.
         if mn.startswith("vcmpequh"):
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
-            return (f"{{ uint16_t* a=(uint16_t*)&ctx->vr[{va}]; uint16_t* b=(uint16_t*)&ctx->vr[{vb}]; "
-                    f"uint16_t* d=(uint16_t*)&ctx->vr[{vd}]; "
-                    f"for(int i=0;i<8;i++) d[i]=a[i]==b[i]?(uint16_t)~0:0; }}")
+            return (f"{{ void* a=&ctx->vr[{va}]; void* b=&ctx->vr[{vb}]; void* d=&ctx->vr[{vd}]; "
+                    f"for(int i=0;i<8;i++) vsth(d,i,(vrh(a,i)==vrh(b,i))?(uint16_t)~0:0); }}")
 
         if mn.startswith("vcmpequw"):
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
-            return (f"{{ uint32_t* a=(uint32_t*)&ctx->vr[{va}]; uint32_t* b=(uint32_t*)&ctx->vr[{vb}]; "
-                    f"uint32_t* d=(uint32_t*)&ctx->vr[{vd}]; "
-                    f"for(int i=0;i<4;i++) d[i]=a[i]==b[i]?~0u:0; }}")
+            return (f"{{ void* a=&ctx->vr[{va}]; void* b=&ctx->vr[{vb}]; void* d=&ctx->vr[{vd}]; "
+                    f"for(int i=0;i<4;i++) vstw(d,i,(vrw(a,i)==vrw(b,i))?~0u:0u); }}")
 
         # Vector compare greater-than, signed/unsigned, byte/half/word.
         # Previously unhandled (fell to the TODO catch-all = silently skipped
         # stores, so vD kept stale data). Dot forms set CR6 per the AltiVec
         # PEM: bit0 (value 8) = all lanes true, bit2 (value 2) = all lanes
         # false, written to CR field 6 (bits 4-7 of our packed ctx->cr).
+        # Order-sensitive: unlike equality, GT/LT does NOT survive a byte-swap
+        # (e.g. 256 vs 2: true 256>2, but the byte-reversed native reads give
+        # 0x00010000 vs 0x02000000 -- 65536 > 33554432 is false). Byte-width
+        # forms (vcmpgtsb/vcmpgtub) are unaffected (vr.b[] is already correct);
+        # half/word forms must read via vrh/vrw and write via vsth/vstw.
         vcmpgt_family = {
-            "vcmpgtsb": ("int8_t",   16), "vcmpgtsh": ("int16_t",  8),
-            "vcmpgtsw": ("int32_t",   4),
-            "vcmpgtub": ("uint8_t",  16), "vcmpgtuh": ("uint16_t", 8),
-            "vcmpgtuw": ("uint32_t",  4),
+            "vcmpgtsb": (16, 1, 1), "vcmpgtsh": (8, 2, 1), "vcmpgtsw": (4, 4, 1),
+            "vcmpgtub": (16, 1, 0), "vcmpgtuh": (8, 2, 0), "vcmpgtuw": (4, 4, 0),
         }
         base_mn = mn.rstrip(".")
         if base_mn in vcmpgt_family:
-            ety, n = vcmpgt_family[base_mn]
-            uty = ety.replace("int", "uint") if not ety.startswith("u") else ety
+            n, w, signed = vcmpgt_family[base_mn]
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
-            body = (f"{{ {ety}* a=({ety}*)&ctx->vr[{va}]; {ety}* b=({ety}*)&ctx->vr[{vb}]; "
-                    f"{uty}* d=({uty}*)&ctx->vr[{vd}]; int t=0; "
-                    f"for(int i=0;i<{n};i++){{ {uty} r=a[i]>b[i]?({uty})~({uty})0:0; d[i]=r; t+=r?1:0; }}")
+            if w == 1:
+                sty, uty = "int8_t", "uint8_t"
+                get_a = f"(({sty})((const uint8_t*)a)[i])" if signed else f"((const uint8_t*)a)[i]"
+                get_b = f"(({sty})((const uint8_t*)b)[i])" if signed else f"((const uint8_t*)b)[i]"
+                setd = "((uint8_t*)d)[i]=r"
+            elif w == 2:
+                sty, uty = "int16_t", "uint16_t"
+                get_a = f"(({sty})vrh(a,i))" if signed else f"vrh(a,i)"
+                get_b = f"(({sty})vrh(b,i))" if signed else f"vrh(b,i)"
+                setd = "vsth(d,i,r)"
+            else:
+                sty, uty = "int32_t", "uint32_t"
+                get_a = f"(({sty})vrw(a,i))" if signed else f"vrw(a,i)"
+                get_b = f"(({sty})vrw(b,i))" if signed else f"vrw(b,i)"
+                setd = "vstw(d,i,r)"
+            body = (f"{{ void* a=&ctx->vr[{va}]; void* b=&ctx->vr[{vb}]; void* d=&ctx->vr[{vd}]; "
+                    f"int t=0; for(int i=0;i<{n};i++){{ {uty} r={get_a}>{get_b}?({uty})~({uty})0:0; "
+                    f"{setd}; t+=r?1:0; }}")
             if mn.endswith("."):
                 body += (f" uint32_t c6=(t=={n}?8u:0u)|(t==0?2u:0u); "
                          f"ctx->cr=(ctx->cr & ~(0xFu<<4))|(c6<<4);")
@@ -1847,12 +1874,26 @@ class PPULifter:
             "vminsb":  None, "vminsh": None, "vminsw": None,
         }
 
-        if mn in ("vaddubm", "vadduhm", "vadduwm", "vsububm", "vsubuhm", "vsubuwm", "vand"):
+        # Byte add/sub and the 64-bit-wide vand are lane-order-agnostic (raw
+        # bytes / bitwise, invariant to a byte-swap) so the storage cast is
+        # correct as-is. The halfword/word add/sub forms reinterpret
+        # multi-byte lanes and carries do NOT commute with a byte-swap (e.g.
+        # true 0xFF+0x01=0x100, but the byte-reversed native reads overflow
+        # entirely differently and give 0) -- route those through vrh/vsth
+        # (resp. vrw/vstw).
+        if mn in ("vaddubm", "vsububm", "vand"):
             ty, cnt, op = vmx_int_binop[mn]
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
             return (f"{{ {ty}* d=({ty}*)&ctx->vr[{vd}]; {ty}* a=({ty}*)&ctx->vr[{va}]; "
                     f"{ty}* b=({ty}*)&ctx->vr[{vb}]; "
                     f"for(int i=0;i<{cnt};i++) d[i]=a[i]{op}b[i]; }}")
+
+        if mn in ("vadduhm", "vsubuhm", "vadduwm", "vsubuwm"):
+            _, cnt, op = vmx_int_binop[mn]
+            vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
+            g, s = ("vrh", "vsth") if cnt == 8 else ("vrw", "vstw")
+            return (f"{{ void* d=&ctx->vr[{vd}]; void* a=&ctx->vr[{va}]; void* b=&ctx->vr[{vb}]; "
+                    f"for(int i=0;i<{cnt};i++) {s}(d,i,(uint32_t)({g}(a,i){op}{g}(b,i))); }}")
 
         if mn == "vandc":
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
@@ -1868,7 +1909,9 @@ class PPULifter:
                     f"uint64_t* b=(uint64_t*)&ctx->vr[{vb}]; "
                     f"d[0]=~(a[0]|b[0]); d[1]=~(a[1]|b[1]); }}")
 
-        # Integer min/max
+        # Integer min/max. Byte lanes are order-agnostic (raw vr.b[]); the
+        # halfword/word forms compare/select on the reinterpreted multi-byte
+        # value and must read/write through vrh/vsth (resp. vrw/vstw).
         for prefix in ("vmax", "vmin"):
             for suffix, ty, cnt, signed in [("ub","uint8_t",16,0),("uh","uint16_t",8,0),
                                              ("uw","uint32_t",4,0),("sb","int8_t",16,1),
@@ -1877,32 +1920,45 @@ class PPULifter:
                 if mn == iname:
                     vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
                     cmp = ">" if prefix == "vmax" else "<"
-                    return (f"{{ {ty}* d=({ty}*)&ctx->vr[{vd}]; {ty}* a=({ty}*)&ctx->vr[{va}]; "
-                            f"{ty}* b=({ty}*)&ctx->vr[{vb}]; "
-                            f"for(int i=0;i<{cnt};i++) d[i]=a[i]{cmp}b[i]?a[i]:b[i]; }}")
+                    if cnt == 16:
+                        return (f"{{ {ty}* d=({ty}*)&ctx->vr[{vd}]; {ty}* a=({ty}*)&ctx->vr[{va}]; "
+                                f"{ty}* b=({ty}*)&ctx->vr[{vb}]; "
+                                f"for(int i=0;i<{cnt};i++) d[i]=a[i]{cmp}b[i]?a[i]:b[i]; }}")
+                    g, s = ("vrh", "vsth") if cnt == 8 else ("vrw", "vstw")
+                    cast = ty
+                    return (f"{{ void* d=&ctx->vr[{vd}]; void* a=&ctx->vr[{va}]; void* b=&ctx->vr[{vb}]; "
+                            f"for(int i=0;i<{cnt};i++){{ {cast} av=({cast}){g}(a,i); {cast} bv=({cast}){g}(b,i); "
+                            f"{s}(d,i,(uint32_t)(av{cmp}bv?av:bv)); }} }}")
 
-        # Float min/max
+        # Float min/max (lane values reinterpreted; route through vrf/vstf)
         if mn == "vmaxfp" or mn == "vminfp":
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
             cmp = ">" if mn == "vmaxfp" else "<"
-            return (f"{{ float* d=(float*)&ctx->vr[{vd}]; float* a=(float*)&ctx->vr[{va}]; "
-                    f"float* b=(float*)&ctx->vr[{vb}]; "
-                    f"for(int i=0;i<4;i++) d[i]=a[i]{cmp}b[i]?a[i]:b[i]; }}")
+            return (f"{{ void* d=&ctx->vr[{vd}]; void* a=&ctx->vr[{va}]; void* b=&ctx->vr[{vb}]; "
+                    f"float r[4]; for(int i=0;i<4;i++){{ float av=vrf(a,i),bv=vrf(b,i); r[i]=av{cmp}bv?av:bv; }} "
+                    f"for(int i=0;i<4;i++) vstf(d,i,r[i]); }}")
 
-        # Splat immediate (vspltisb/h/w) — splat a 5-bit signed immediate
+        # Splat immediate (vspltisb/h/w) — splat a 5-bit signed immediate.
+        # vspltisb is a byte memset (unaffected). vspltish/vspltisw synthesize
+        # a computed constant and WRITE it into each lane; a native int16_t*/
+        # int32_t* store there writes the value in host (LE) byte order into
+        # storage that every other lane accessor treats as raw big-endian, so
+        # (unlike vspltw/vsplth, which just copy an existing lane's bytes
+        # verbatim and are correct as-is) this is a genuine write-side bug.
+        # Route through vsth/vstw.
         if mn in ("vspltisb", "vspltish", "vspltisw"):
             vd = int(ops[0][1:])
             simm = int(ops[1]) if not ops[1].startswith("v") else int(ops[1][1:])
             # Sign extend 5-bit to appropriate type
             if simm > 15: simm -= 32
             if mn == "vspltisb":
-                return (f"{{ memset(&ctx->vr[{vd}], (uint8_t){simm}, 16); }}")
+                return (f"{{ memset(&ctx->vr[{vd}], (uint8_t)(int8_t){simm}, 16); }}")
             elif mn == "vspltish":
-                return (f"{{ int16_t* d=(int16_t*)&ctx->vr[{vd}]; "
-                        f"for(int i=0;i<8;i++) d[i]={simm}; }}")
+                return (f"{{ void* d=&ctx->vr[{vd}]; "
+                        f"for(int i=0;i<8;i++) vsth(d,i,(uint16_t)(int16_t)({simm})); }}")
             else:
-                return (f"{{ int32_t* d=(int32_t*)&ctx->vr[{vd}]; "
-                        f"for(int i=0;i<4;i++) d[i]={simm}; }}")
+                return (f"{{ void* d=&ctx->vr[{vd}]; "
+                        f"for(int i=0;i<4;i++) vstw(d,i,(uint32_t)(int32_t)({simm})); }}")
 
         # Merge (vmrghb/h/w, vmrglb/h/w) — interleave elements
         if mn.startswith("vmrg"):
@@ -1920,46 +1976,55 @@ class PPULifter:
                     f"for(int i=0;i<{half};i++) {{ tmp[i*2]=a[{off}+i]; tmp[i*2+1]=b[{off}+i]; }} "
                     f"memcpy(&ctx->vr[{vd}], tmp, 16); }}")
 
-        # Float reciprocal estimate / reciprocal sqrt estimate
+        # Float reciprocal estimate / reciprocal sqrt estimate / round-to-int.
+        # Route through vrf/vstf like the rest of the float arithmetic.
         if mn == "vrefp":
             vd, vb = int(ops[0][1:]), int(ops[-1][1:])  # vB = last operand (vmx_vx emits vD, vA, vB)
-            return (f"{{ float* d=(float*)&ctx->vr[{vd}]; float* b=(float*)&ctx->vr[{vb}]; "
-                    f"for(int i=0;i<4;i++) d[i]=1.0f/b[i]; }}")
+            return (f"{{ void* d=&ctx->vr[{vd}]; void* b=&ctx->vr[{vb}]; "
+                    f"float r[4]; for(int i=0;i<4;i++) r[i]=1.0f/vrf(b,i); "
+                    f"for(int i=0;i<4;i++) vstf(d,i,r[i]); }}")
 
         if mn == "vrsqrtefp":
             vd, vb = int(ops[0][1:]), int(ops[-1][1:])  # vB = last operand (vmx_vx emits vD, vA, vB)
-            return (f"{{ float* d=(float*)&ctx->vr[{vd}]; float* b=(float*)&ctx->vr[{vb}]; "
-                    f"for(int i=0;i<4;i++) d[i]=1.0f/sqrtf(b[i]); }}")
+            return (f"{{ void* d=&ctx->vr[{vd}]; void* b=&ctx->vr[{vb}]; "
+                    f"float r[4]; for(int i=0;i<4;i++) r[i]=1.0f/sqrtf(vrf(b,i)); "
+                    f"for(int i=0;i<4;i++) vstf(d,i,r[i]); }}")
 
         if mn == "vrfim":  # round to FP integer toward -inf (floor); vrfim is vD,vB
             vd, vb = int(ops[0][1:]), int(ops[-1][1:])
-            return (f"{{ float* d=(float*)&ctx->vr[{vd}]; float* b=(float*)&ctx->vr[{vb}]; "
-                    f"for(int i=0;i<4;i++) d[i]=floorf(b[i]); }}")
+            return (f"{{ void* d=&ctx->vr[{vd}]; void* b=&ctx->vr[{vb}]; "
+                    f"float r[4]; for(int i=0;i<4;i++) r[i]=floorf(vrf(b,i)); "
+                    f"for(int i=0;i<4;i++) vstf(d,i,r[i]); }}")
 
-        # Float/int convert (operand form "vD, vB, UIMM" — UIMM is a bare int)
+        # Float/int convert (operand form "vD, vB, UIMM" — UIMM is a bare int).
+        # Word/float lanes are reinterpreted on both sides: read via vrw
+        # (vcfsx/vcfux) or vrf (vctsxs/vctuxs), write via vstf/vstw.
         if mn == "vcfsx" or mn == "vcfux":
             vd, vb = int(ops[0][1:]), int(ops[1][1:])
             uimm = int(ops[2]) if len(ops) > 2 and not ops[2].startswith("v") else 0
-            src_ty = "int32_t" if mn == "vcfsx" else "uint32_t"
+            cast = "(int32_t)" if mn == "vcfsx" else ""
             scale = f" / {1 << uimm}.0f" if uimm > 0 else ""
-            return (f"{{ float* d=(float*)&ctx->vr[{vd}]; {src_ty}* b=({src_ty}*)&ctx->vr[{vb}]; "
-                    f"for(int i=0;i<4;i++) d[i]=(float)b[i]{scale}; }}")
+            return (f"{{ void* d=&ctx->vr[{vd}]; void* b=&ctx->vr[{vb}]; float r[4]; "
+                    f"for(int i=0;i<4;i++) r[i]=(float)({cast}vrw(b,i)){scale}; "
+                    f"for(int i=0;i<4;i++) vstf(d,i,r[i]); }}")
 
         if mn == "vctsxs" or mn == "vctuxs":
             vd, vb = int(ops[0][1:]), int(ops[1][1:])
             uimm = int(ops[2]) if len(ops) > 2 and not ops[2].startswith("v") else 0
             dst_ty = "int32_t" if mn == "vctsxs" else "uint32_t"
             scale = f" * {1 << uimm}.0f" if uimm > 0 else ""
-            return (f"{{ {dst_ty}* d=({dst_ty}*)&ctx->vr[{vd}]; float* b=(float*)&ctx->vr[{vb}]; "
-                    f"for(int i=0;i<4;i++) d[i]=({dst_ty})(b[i]{scale}); }}")
+            return (f"{{ void* d=&ctx->vr[{vd}]; void* b=&ctx->vr[{vb}]; "
+                    f"for(int i=0;i<4;i++) vstw(d,i,(uint32_t)({dst_ty})(vrf(b,i){scale})); }}")
 
-        # Compare with Rc (vcmpeqfp., vcmpgefp., etc.)
+        # Compare with Rc (vcmpeqfp., vcmpgefp., etc.). Unlike the boolean
+        # all-1s/all-0s masks above, vcmpbfp's result bits (0x80000000u /
+        # 0x40000000u) are NOT byte-swap symmetric, so both the float reads
+        # and the word write genuinely need the accessors.
         if mn.startswith("vcmpbfp"):
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
-            return (f"{{ float* a=(float*)&ctx->vr[{va}]; float* b=(float*)&ctx->vr[{vb}]; "
-                    f"uint32_t* d=(uint32_t*)&ctx->vr[{vd}]; "
-                    f"for(int i=0;i<4;i++) {{ uint32_t r=0; "
-                    f"if(a[i]>b[i]) r|=0x80000000u; if(a[i]<-b[i]) r|=0x40000000u; d[i]=r; }} }}")
+            return (f"{{ void* a=&ctx->vr[{va}]; void* b=&ctx->vr[{vb}]; void* d=&ctx->vr[{vd}]; "
+                    f"for(int i=0;i<4;i++) {{ float av=vrf(a,i),bv=vrf(b,i); uint32_t r=0; "
+                    f"if(av>bv) r|=0x80000000u; if(av<-bv) r|=0x40000000u; vstw(d,i,r); }} }}")
 
         # ------- Additional VMX integer instructions -------
         # Byte compare equal
@@ -1969,7 +2034,10 @@ class PPULifter:
                     f"uint8_t* b=(uint8_t*)&ctx->vr[{vb}]; "
                     f"for(int i=0;i<16;i++) d[i]=a[i]==b[i]?0xFFu:0u; }}")
 
-        # Saturating add
+        # Saturating add. Byte forms (vaddsbs/vsububs) are unaffected (byte
+        # lanes, no swap). Halfword/word forms reinterpret multi-byte lanes
+        # for both the arithmetic and the saturation bound: route through
+        # vrh/vsth (resp. vrw/vstw).
         if mn == "vaddsbs":
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
             return (f"{{ int8_t* d=(int8_t*)&ctx->vr[{vd}]; int8_t* a=(int8_t*)&ctx->vr[{va}]; "
@@ -1977,28 +2045,24 @@ class PPULifter:
                     f"for(int i=0;i<16;i++){{int32_t r=(int32_t)a[i]+(int32_t)b[i]; d[i]=(int8_t)(r>127?127:r<-128?-128:r);}} }}")
         if mn == "vadduhs":
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
-            return (f"{{ uint16_t* d=(uint16_t*)&ctx->vr[{vd}]; uint16_t* a=(uint16_t*)&ctx->vr[{va}]; "
-                    f"uint16_t* b=(uint16_t*)&ctx->vr[{vb}]; "
-                    f"for(int i=0;i<8;i++){{uint32_t r=(uint32_t)a[i]+(uint32_t)b[i]; d[i]=(uint16_t)(r>65535u?65535u:r);}} }}")
+            return (f"{{ void* d=&ctx->vr[{vd}]; void* a=&ctx->vr[{va}]; void* b=&ctx->vr[{vb}]; "
+                    f"for(int i=0;i<8;i++){{uint32_t r=(uint32_t)vrh(a,i)+(uint32_t)vrh(b,i); vsth(d,i,(uint16_t)(r>65535u?65535u:r));}} }}")
         if mn == "vaddshs":
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
-            return (f"{{ int16_t* d=(int16_t*)&ctx->vr[{vd}]; int16_t* a=(int16_t*)&ctx->vr[{va}]; "
-                    f"int16_t* b=(int16_t*)&ctx->vr[{vb}]; "
-                    f"for(int i=0;i<8;i++){{int32_t r=(int32_t)a[i]+(int32_t)b[i]; d[i]=(int16_t)(r>32767?32767:r<-32768?-32768:r);}} }}")
+            return (f"{{ void* d=&ctx->vr[{vd}]; void* a=&ctx->vr[{va}]; void* b=&ctx->vr[{vb}]; "
+                    f"for(int i=0;i<8;i++){{int32_t r=(int32_t)(int16_t)vrh(a,i)+(int32_t)(int16_t)vrh(b,i); vsth(d,i,(uint16_t)(int16_t)(r>32767?32767:r<-32768?-32768:r));}} }}")
         if mn == "vadduws":
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
-            return (f"{{ uint32_t* d=(uint32_t*)&ctx->vr[{vd}]; uint32_t* a=(uint32_t*)&ctx->vr[{va}]; "
-                    f"uint32_t* b=(uint32_t*)&ctx->vr[{vb}]; "
-                    f"for(int i=0;i<4;i++){{uint64_t r=(uint64_t)a[i]+(uint64_t)b[i]; d[i]=(uint32_t)(r>0xFFFFFFFFu?0xFFFFFFFFu:r);}} }}")
+            return (f"{{ void* d=&ctx->vr[{vd}]; void* a=&ctx->vr[{va}]; void* b=&ctx->vr[{vb}]; "
+                    f"for(int i=0;i<4;i++){{uint64_t r=(uint64_t)vrw(a,i)+(uint64_t)vrw(b,i); vstw(d,i,(uint32_t)(r>0xFFFFFFFFu?0xFFFFFFFFu:r));}} }}")
 
         # Subtract saturate
         if mn == "vsubsws":
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
-            return (f"{{ int32_t* d=(int32_t*)&ctx->vr[{vd}]; int32_t* a=(int32_t*)&ctx->vr[{va}]; "
-                    f"int32_t* b=(int32_t*)&ctx->vr[{vb}]; "
-                    f"for(int i=0;i<4;i++){{int64_t r=(int64_t)a[i]-(int64_t)b[i]; d[i]=(int32_t)(r>0x7FFFFFFFLL?0x7FFFFFFFLL:r<-0x80000000LL?-0x80000000LL:r);}} }}")
+            return (f"{{ void* d=&ctx->vr[{vd}]; void* a=&ctx->vr[{va}]; void* b=&ctx->vr[{vb}]; "
+                    f"for(int i=0;i<4;i++){{int64_t r=(int64_t)(int32_t)vrw(a,i)-(int64_t)(int32_t)vrw(b,i); vstw(d,i,(uint32_t)(int32_t)(r>0x7FFFFFFFLL?0x7FFFFFFFLL:r<-0x80000000LL?-0x80000000LL:r));}} }}")
 
-        if mn == "vsububs":  # subtract unsigned byte, saturate to [0,255]
+        if mn == "vsububs":  # subtract unsigned byte, saturate to [0,255] (byte lanes, no swap)
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
             return (f"{{ uint8_t* d=(uint8_t*)&ctx->vr[{vd}]; uint8_t* a=(uint8_t*)&ctx->vr[{va}]; "
                     f"uint8_t* b=(uint8_t*)&ctx->vr[{vb}]; "
@@ -2007,53 +2071,61 @@ class PPULifter:
         if mn == "vsum2sws":
             # AltiVec PEM: d.word1 = SAT_s32(a.w0 + a.w1 + b.w1);
             #              d.word3 = SAT_s32(a.w2 + a.w3 + b.w3); d.word0 = d.word2 = 0.
-            # (word index = BE element, matching the VMX handlers above.) temp
-            # buffer so vD may alias vA/vB.
+            # (word index = BE element, matching the VMX handlers above.)
+            # Word lanes reinterpreted -- read/write via vrw/vstw.
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
-            return (f"{{ int32_t* a=(int32_t*)&ctx->vr[{va}]; int32_t* b=(int32_t*)&ctx->vr[{vb}]; "
-                    f"int64_t s0=(int64_t)a[0]+a[1]+b[1]; int64_t s1=(int64_t)a[2]+a[3]+b[3]; "
+            return (f"{{ void* a=&ctx->vr[{va}]; void* b=&ctx->vr[{vb}]; void* d=&ctx->vr[{vd}]; "
+                    f"int64_t s0=(int64_t)(int32_t)vrw(a,0)+(int32_t)vrw(a,1)+(int32_t)vrw(b,1); "
+                    f"int64_t s1=(int64_t)(int32_t)vrw(a,2)+(int32_t)vrw(a,3)+(int32_t)vrw(b,3); "
                     f"int32_t r[4]={{0,0,0,0}}; "
                     f"r[1]=(int32_t)(s0>0x7FFFFFFFLL?0x7FFFFFFFLL:s0<-0x80000000LL?-0x80000000LL:s0); "
                     f"r[3]=(int32_t)(s1>0x7FFFFFFFLL?0x7FFFFFFFLL:s1<-0x80000000LL?-0x80000000LL:s1); "
-                    f"memcpy(&ctx->vr[{vd}], r, 16); }}")
+                    f"for(int i=0;i<4;i++) vstw(d,i,(uint32_t)r[i]); }}")
 
+        # Unpacks: the halfword SOURCE reinterprets a multi-byte lane on read
+        # (vupkhsh/vupklsh via vrh) and the word RESULT is written through
+        # vstw; vupkhsb/vupklsb read raw bytes (unaffected) but still WRITE a
+        # halfword result, so the write needs vsth even though the source
+        # doesn't need a read fix.
         if mn == "vupkhsh":
             # Unpack high signed halfword: sign-extend the high 4 halfwords
-            # (BE elements 0-3) to 4 words. temp so vD may alias vB.
+            # (BE elements 0-3) to 4 words.
             vd = int(ops[0][1:]); vb = int(ops[-1][1:])
-            return (f"{{ int16_t* b=(int16_t*)&ctx->vr[{vb}]; int32_t r[4]; "
-                    f"for(int i=0;i<4;i++) r[i]=(int32_t)b[i]; "
-                    f"memcpy(&ctx->vr[{vd}], r, 16); }}")
+            return (f"{{ void* b=&ctx->vr[{vb}]; void* d=&ctx->vr[{vd}]; int32_t r[4]; "
+                    f"for(int i=0;i<4;i++) r[i]=(int32_t)(int16_t)vrh(b,i); "
+                    f"for(int i=0;i<4;i++) vstw(d,i,(uint32_t)r[i]); }}")
 
         if mn == "vupklsh":
             # Unpack low signed halfword (AltiVec PEM 6-176, Fig 6-147):
             # sign-extend the LOW 4 halfwords (BE elements 4-7) to 4 words in
-            # vD. Mirror of vupkhsh over the low half. temp so vD may alias
-            # vB. ops[-1] for vB (matches the vupkhsh convention above).
+            # vD. Mirror of vupkhsh over the low half. ops[-1] for vB (matches
+            # the vupkhsh convention above).
             vd = int(ops[0][1:]); vb = int(ops[-1][1:])
-            return (f"{{ int16_t* b=(int16_t*)&ctx->vr[{vb}]; int32_t r[4]; "
-                    f"for(int i=0;i<4;i++) r[i]=(int32_t)b[4+i]; "
-                    f"memcpy(&ctx->vr[{vd}], r, 16); }}")
+            return (f"{{ void* b=&ctx->vr[{vb}]; void* d=&ctx->vr[{vd}]; int32_t r[4]; "
+                    f"for(int i=0;i<4;i++) r[i]=(int32_t)(int16_t)vrh(b,4+i); "
+                    f"for(int i=0;i<4;i++) vstw(d,i,(uint32_t)r[i]); }}")
 
         if mn == "vupkhsb":
             # Unpack high signed byte (AltiVec PEM 6-172, Fig 6-143):
             # sign-extend the HIGH 8 signed bytes (elements 0-7) to 8 signed
-            # halfwords in vD. temp so vD may alias vB.
+            # halfwords in vD.
             vd = int(ops[0][1:]); vb = int(ops[-1][1:])
-            return (f"{{ int8_t* b=(int8_t*)&ctx->vr[{vb}]; int16_t r[8]; "
-                    f"for(int i=0;i<8;i++) r[i]=(int16_t)b[i]; "
-                    f"memcpy(&ctx->vr[{vd}], r, 16); }}")
+            return (f"{{ uint8_t* b=(uint8_t*)&ctx->vr[{vb}]; void* d=&ctx->vr[{vd}]; int16_t r[8]; "
+                    f"for(int i=0;i<8;i++) r[i]=(int16_t)(int8_t)b[i]; "
+                    f"for(int i=0;i<8;i++) vsth(d,i,(uint16_t)r[i]); }}")
 
         if mn == "vupklsb":
             # Unpack low signed byte (AltiVec PEM 6-175, Fig 6-146):
             # sign-extend the LOW 8 signed bytes (elements 8-15) to 8 signed
             # halfwords in vD. Mirror of vupkhsb over the low half.
             vd = int(ops[0][1:]); vb = int(ops[-1][1:])
-            return (f"{{ int8_t* b=(int8_t*)&ctx->vr[{vb}]; int16_t r[8]; "
-                    f"for(int i=0;i<8;i++) r[i]=(int16_t)b[8+i]; "
-                    f"memcpy(&ctx->vr[{vd}], r, 16); }}")
+            return (f"{{ uint8_t* b=(uint8_t*)&ctx->vr[{vb}]; void* d=&ctx->vr[{vd}]; int16_t r[8]; "
+                    f"for(int i=0;i<8;i++) r[i]=(int16_t)(int8_t)b[8+i]; "
+                    f"for(int i=0;i<8;i++) vsth(d,i,(uint16_t)r[i]); }}")
 
-        # Shifts and rotates
+        # Shifts and rotates. Byte lanes (vslb/vrlb) are order-agnostic (raw
+        # vr.b[]). Word forms reinterpret both the operand AND the per-lane
+        # shift/rotate count read from vB -- route everything through vrw/vstw.
         if mn == "vslb":
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
             return (f"{{ uint8_t* d=(uint8_t*)&ctx->vr[{vd}]; uint8_t* a=(uint8_t*)&ctx->vr[{va}]; "
@@ -2061,14 +2133,14 @@ class PPULifter:
                     f"for(int i=0;i<16;i++) d[i]=(uint8_t)(a[i]<<(b[i]&7u)); }}")
         if mn == "vslw":
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
-            return (f"{{ uint32_t* d=(uint32_t*)&ctx->vr[{vd}]; uint32_t* a=(uint32_t*)&ctx->vr[{va}]; "
-                    f"uint32_t* b=(uint32_t*)&ctx->vr[{vb}]; "
-                    f"for(int i=0;i<4;i++) d[i]=a[i]<<(b[i]&31u); }}")
-        if mn == "vsrw":  # vector shift right word (logical), per-element count = b[i] & 31
+            return (f"{{ void* d=&ctx->vr[{vd}]; void* a=&ctx->vr[{va}]; void* b=&ctx->vr[{vb}]; "
+                    f"uint32_t r[4]; for(int i=0;i<4;i++) r[i]=vrw(a,i)<<(vrw(b,i)&31u); "
+                    f"for(int i=0;i<4;i++) vstw(d,i,r[i]); }}")
+        if mn == "vsrw":  # vector shift right word (logical), per-element count = vB word & 31
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
-            return (f"{{ uint32_t* d=(uint32_t*)&ctx->vr[{vd}]; uint32_t* a=(uint32_t*)&ctx->vr[{va}]; "
-                    f"uint32_t* b=(uint32_t*)&ctx->vr[{vb}]; "
-                    f"for(int i=0;i<4;i++) d[i]=a[i]>>(b[i]&31u); }}")
+            return (f"{{ void* d=&ctx->vr[{vd}]; void* a=&ctx->vr[{va}]; void* b=&ctx->vr[{vb}]; "
+                    f"uint32_t r[4]; for(int i=0;i<4;i++) r[i]=vrw(a,i)>>(vrw(b,i)&31u); "
+                    f"for(int i=0;i<4;i++) vstw(d,i,r[i]); }}")
         if mn == "vrlb":
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
             return (f"{{ uint8_t* d=(uint8_t*)&ctx->vr[{vd}]; uint8_t* a=(uint8_t*)&ctx->vr[{va}]; "
@@ -2076,36 +2148,32 @@ class PPULifter:
                     f"for(int i=0;i<16;i++){{uint8_t s=b[i]&7u; d[i]=(a[i]<<s)|(a[i]>>(8u-s));}} }}")
         if mn == "vrlw":
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
-            return (f"{{ uint32_t* d=(uint32_t*)&ctx->vr[{vd}]; uint32_t* a=(uint32_t*)&ctx->vr[{va}]; "
-                    f"uint32_t* b=(uint32_t*)&ctx->vr[{vb}]; "
-                    f"for(int i=0;i<4;i++){{uint32_t s=b[i]&31u; d[i]=(a[i]<<s)|(a[i]>>(32u-s));}} }}")
+            return (f"{{ void* d=&ctx->vr[{vd}]; void* a=&ctx->vr[{va}]; void* b=&ctx->vr[{vb}]; "
+                    f"uint32_t r[4]; for(int i=0;i<4;i++){{uint32_t av=vrw(a,i),s=vrw(b,i)&31u; r[i]=(av<<s)|(av>>(32u-s));}} "
+                    f"for(int i=0;i<4;i++) vstw(d,i,r[i]); }}")
         if mn == "vsraw":
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
-            return (f"{{ int32_t* d=(int32_t*)&ctx->vr[{vd}]; int32_t* a=(int32_t*)&ctx->vr[{va}]; "
-                    f"uint32_t* b=(uint32_t*)&ctx->vr[{vb}]; "
-                    f"for(int i=0;i<4;i++) d[i]=a[i]>>(b[i]&31u); }}")
+            return (f"{{ void* d=&ctx->vr[{vd}]; void* a=&ctx->vr[{va}]; void* b=&ctx->vr[{vb}]; "
+                    f"uint32_t r[4]; for(int i=0;i<4;i++) r[i]=(uint32_t)((int32_t)vrw(a,i)>>(vrw(b,i)&31u)); "
+                    f"for(int i=0;i<4;i++) vstw(d,i,r[i]); }}")
 
         # (vmaxsw handled above by the generic vmax/vmin loop)
 
-        # Integer multiply (odd/even halfword)
+        # Integer multiply (odd/even halfword). Even = BE halfword elements
+        # 0,2,4,6; odd = 1,3,5,7 (= storage indices). Halfword sources read
+        # via vrh, word result written via vstw.
         if mn == "vmulouh":
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
-            return (f"{{ uint32_t* d=(uint32_t*)&ctx->vr[{vd}]; uint16_t* a=(uint16_t*)&ctx->vr[{va}]; "
-                    f"uint16_t* b=(uint16_t*)&ctx->vr[{vb}]; "
-                    f"d[0]=(uint32_t)a[1]*(uint32_t)b[1]; d[1]=(uint32_t)a[3]*(uint32_t)b[3]; "
-                    f"d[2]=(uint32_t)a[5]*(uint32_t)b[5]; d[3]=(uint32_t)a[7]*(uint32_t)b[7]; }}")
+            return (f"{{ void* d=&ctx->vr[{vd}]; void* a=&ctx->vr[{va}]; void* b=&ctx->vr[{vb}]; "
+                    f"for(int i=0;i<4;i++) vstw(d,i,(uint32_t)vrh(a,2*i+1)*(uint32_t)vrh(b,2*i+1)); }}")
         if mn == "vmuleuh":
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
-            return (f"{{ uint32_t* d=(uint32_t*)&ctx->vr[{vd}]; uint16_t* a=(uint16_t*)&ctx->vr[{va}]; "
-                    f"uint16_t* b=(uint16_t*)&ctx->vr[{vb}]; "
-                    f"d[0]=(uint32_t)a[0]*(uint32_t)b[0]; d[1]=(uint32_t)a[2]*(uint32_t)b[2]; "
-                    f"d[2]=(uint32_t)a[4]*(uint32_t)b[4]; d[3]=(uint32_t)a[6]*(uint32_t)b[6]; }}")
+            return (f"{{ void* d=&ctx->vr[{vd}]; void* a=&ctx->vr[{va}]; void* b=&ctx->vr[{vb}]; "
+                    f"for(int i=0;i<4;i++) vstw(d,i,(uint32_t)vrh(a,2*i)*(uint32_t)vrh(b,2*i)); }}")
         if mn == "vmulosh":
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
-            return (f"{{ int32_t* d=(int32_t*)&ctx->vr[{vd}]; int16_t* a=(int16_t*)&ctx->vr[{va}]; "
-                    f"int16_t* b=(int16_t*)&ctx->vr[{vb}]; "
-                    f"d[0]=(int32_t)a[1]*(int32_t)b[1]; d[1]=(int32_t)a[3]*(int32_t)b[3]; "
-                    f"d[2]=(int32_t)a[5]*(int32_t)b[5]; d[3]=(int32_t)a[7]*(int32_t)b[7]; }}")
+            return (f"{{ void* d=&ctx->vr[{vd}]; void* a=&ctx->vr[{va}]; void* b=&ctx->vr[{vb}]; "
+                    f"for(int i=0;i<4;i++) vstw(d,i,(uint32_t)((int32_t)(int16_t)vrh(a,2*i+1)*(int32_t)(int16_t)vrh(b,2*i+1))); }}")
 
         # Average unsigned byte
         if mn == "vavgub":
@@ -2127,21 +2195,27 @@ class PPULifter:
             return (f"{{ uint16_t* d=(uint16_t*)&ctx->vr[{vd}]; uint16_t* b=(uint16_t*)&ctx->vr[{vb}]; "
                     f"uint16_t v=b[{uimm}]; for(int i=0;i<8;i++) d[i]=v; }}")
 
-        # Pack signed halfword signed saturate
+        # Pack signed halfword signed saturate. Source halfword lanes reread
+        # via vrh (a real read-side bug despite the byte-width output: the
+        # saturation math needs the true halfword value); the packed result
+        # is a plain byte array, no write-side swap needed.
         if mn == "vpkshss":
             vd, va, vb = int(ops[0][1:]), int(ops[1][1:]), int(ops[2][1:])
-            return (f"{{ int8_t* d=(int8_t*)&ctx->vr[{vd}]; int16_t* a=(int16_t*)&ctx->vr[{va}]; "
-                    f"int16_t* b=(int16_t*)&ctx->vr[{vb}]; "
-                    f"for(int i=0;i<8;i++){{int32_t v=a[i]; d[i]=(int8_t)(v>127?127:v<-128?-128:v);}} "
-                    f"for(int i=0;i<8;i++){{int32_t v=b[i]; d[8+i]=(int8_t)(v>127?127:v<-128?-128:v);}} }}")
+            return (f"{{ void* a=&ctx->vr[{va}]; void* b=&ctx->vr[{vb}]; uint8_t r[16]; "
+                    f"for(int i=0;i<8;i++){{int32_t v=(int16_t)vrh(a,i); r[i]=(uint8_t)(int8_t)(v>127?127:v<-128?-128:v);}} "
+                    f"for(int i=0;i<8;i++){{int32_t v=(int16_t)vrh(b,i); r[8+i]=(uint8_t)(int8_t)(v>127?127:v<-128?-128:v);}} "
+                    f"memcpy(&ctx->vr[{vd}], r, 16); }}")
 
-        # vmsummbm (VA-form, 4 operands)
+        # vmsummbm (VA-form, 4 operands). Source bytes are order-agnostic; the
+        # s32 accumulator (vC) and s32 result reinterpret a multi-byte lane
+        # and go through vrw/vstw.
         if mn == "vmsummbm":
             vd = int(ops[0][1:]); va = int(ops[1][1:]); vb = int(ops[2][1:]); vc = int(ops[3][1:])
-            return (f"{{ int32_t* d=(int32_t*)&ctx->vr[{vd}]; int8_t* a=(int8_t*)&ctx->vr[{va}]; "
-                    f"uint8_t* ub=(uint8_t*)&ctx->vr[{vb}]; int32_t* cc=(int32_t*)&ctx->vr[{vc}]; "
-                    f"for(int i=0;i<4;i++) d[i]=(int32_t)a[4*i]*(int32_t)ub[4*i]+(int32_t)a[4*i+1]*(int32_t)ub[4*i+1]"
-                    f"+(int32_t)a[4*i+2]*(int32_t)ub[4*i+2]+(int32_t)a[4*i+3]*(int32_t)ub[4*i+3]+cc[i]; }}")
+            return (f"{{ void* d=&ctx->vr[{vd}]; int8_t* a=(int8_t*)&ctx->vr[{va}]; "
+                    f"uint8_t* ub=(uint8_t*)&ctx->vr[{vb}]; void* c=&ctx->vr[{vc}]; int32_t r[4]; "
+                    f"for(int i=0;i<4;i++) r[i]=(int32_t)a[4*i]*(int32_t)ub[4*i]+(int32_t)a[4*i+1]*(int32_t)ub[4*i+1]"
+                    f"+(int32_t)a[4*i+2]*(int32_t)ub[4*i+2]+(int32_t)a[4*i+3]*(int32_t)ub[4*i+3]+(int32_t)vrw(c,i); "
+                    f"for(int i=0;i<4;i++) vstw(d,i,(uint32_t)r[i]); }}")
 
         # Merge high halfword / low halfword (vmrghh, vmrglh — already in vmrg* handler above)
 
@@ -2399,6 +2473,43 @@ class PPULifter:
         lines.append("    *xer = (*xer & ~(1u << 29)) | (ca << 29);")
         lines.append("    return (sh >= 64) ? (rs >> 63) : (rs >> sh);")
         lines.append("}")
+        lines.append("")
+        # ---- VMX lane-endianness accessors ----
+        # ctx->vr holds RAW big-endian bytes (lvx/stvx do a plain memcpy: guest
+        # memory byte 0 == vr.b[0], the MSB, matching AltiVec PEM Fig. 1-3 and
+        # 1.3.2.1: an aligned quadword load places EA's byte into byte element 0).
+        # BE element k of a typed view therefore lives at STORAGE INDEX k, but a
+        # little-endian host reads the multi-byte value byte-reversed. These
+        # accessors read/write element k (index k) with the per-width byte swap,
+        # so a handler's lane math sees the correct BE-ordered scalar value while
+        # byte-granular ops (vperm/lvsl/vsldoi/lvlx/merge/pack) keep using vr.b[]
+        # untouched. Bytes need no swap. Convention: "element k at index k".
+        lines.append("/* VMX big-endian lane accessors (raw-BE storage; element k at index k) */")
+        lines.append("#if defined(_MSC_VER)")
+        lines.append("#define VR_BSWAP16(x) _byteswap_ushort(x)")
+        lines.append("#define VR_BSWAP32(x) _byteswap_ulong(x)")
+        lines.append("#define VR_BSWAP64(x) _byteswap_uint64(x)")
+        lines.append("#elif defined(__GNUC__) || defined(__clang__)")
+        lines.append("#define VR_BSWAP16(x) __builtin_bswap16(x)")
+        lines.append("#define VR_BSWAP32(x) __builtin_bswap32(x)")
+        lines.append("#define VR_BSWAP64(x) __builtin_bswap64(x)")
+        lines.append("#else")
+        lines.append("static inline uint16_t VR_BSWAP16(uint16_t v){return (uint16_t)((v>>8)|(v<<8));}")
+        lines.append("static inline uint32_t VR_BSWAP32(uint32_t v){v=((v&0x00FF00FFu)<<8)|((v&0xFF00FF00u)>>8);return (v<<16)|(v>>16);}")
+        lines.append("static inline uint64_t VR_BSWAP64(uint64_t v){v=((v&0x00FF00FF00FF00FFull)<<8)|((v&0xFF00FF00FF00FF00ull)>>8);v=((v&0x0000FFFF0000FFFFull)<<16)|((v&0xFFFF0000FFFF0000ull)>>16);return (v<<32)|(v>>32);}")
+        lines.append("#endif")
+        # Accessors take a raw pointer to the 16-byte lane storage (void*), so
+        # they are agnostic to whether ctx->vr is typed ppu_vr (generated header)
+        # or u128 (runtime ppu_context.h) -- both are the same 16 raw BE bytes.
+        # BE element k of width W lives at byte offset k*W (= storage index k).
+        lines.append("static inline uint16_t vrh(const void* v, int i) { uint16_t r; memcpy(&r,(const uint8_t*)v+i*2,2); return VR_BSWAP16(r); }")
+        lines.append("static inline uint32_t vrw(const void* v, int i) { uint32_t r; memcpy(&r,(const uint8_t*)v+i*4,4); return VR_BSWAP32(r); }")
+        lines.append("static inline uint64_t vrd(const void* v, int i) { uint64_t r; memcpy(&r,(const uint8_t*)v+i*8,8); return VR_BSWAP64(r); }")
+        lines.append("static inline void vsth(void* v, int i, uint16_t x) { uint16_t r=VR_BSWAP16(x); memcpy((uint8_t*)v+i*2,&r,2); }")
+        lines.append("static inline void vstw(void* v, int i, uint32_t x) { uint32_t r=VR_BSWAP32(x); memcpy((uint8_t*)v+i*4,&r,4); }")
+        lines.append("static inline void vstd(void* v, int i, uint64_t x) { uint64_t r=VR_BSWAP64(x); memcpy((uint8_t*)v+i*8,&r,8); }")
+        lines.append("static inline float vrf(const void* v, int i) { uint32_t u=vrw(v,i); float f; memcpy(&f,&u,4); return f; }")
+        lines.append("static inline void vstf(void* v, int i, float f) { uint32_t u; memcpy(&u,&f,4); vstw(v,i,u); }")
         lines.append("")
         return lines
 

--- a/tools/test_ppu_lift.py
+++ b/tools/test_ppu_lift.py
@@ -203,28 +203,27 @@ def ref_divdu(a, b):
 
 # --- vupk*: AltiVec sign-extend unpacks. Element SELECTION (which half of
 # the 16 input bytes feeds the op) follows the AltiVec PEM (6-172..6-176):
-# high = storage bytes 0-7, low = storage bytes 8-15. But ppu_lifter.py's
-# vupk* handlers read/write vr[] through native (host, little-endian x86)
-# int16_t*/int32_t* casts rather than an explicit big-endian unpack -- e.g.
-# vupkhsh does `int16_t* b=(int16_t*)&ctx->vr[vb]; r[i]=(int32_t)b[i];
-# memcpy(vd, r, 16)`, so a 16-bit lane's bytes are read AND written in host
-# (LE) order, not swapped to/from the guest's big-endian element order. That
-# is this file's existing, already-upstream vupkhsh convention (matched here
-# for vupklsh/vupkhsb/vupklsb, not something this change invents), so these
-# references model that native-endian read/write exactly, using '<' (host
-# LE) struct formats -- NOT '>' -- to predict the lifter's actual output.
+# high = storage bytes 0-7, low = storage bytes 8-15. ppu_lifter.py's vupk*
+# handlers now route every multi-byte lane through the vrh/vsth (halfword
+# source of vupkhsh/vupklsh) and vsth (halfword result of vupkhsb/vupklsb)
+# big-endian accessors, matching every other multi-byte-lane VMX handler
+# (ppu: vmx element wise ops read big endian lanes fix). These references
+# therefore use '>' (true big-endian) struct formats to predict the lifter's
+# corrected output -- this used to be '<' (host LE), which modeled the
+# pre-fix byte-reversed behavior as "correct"; it wasn't, it was the same
+# class of bug this change fixes everywhere else.
 def ref_vupkhsh(vb16):
-    halfs = struct.unpack("<4h", vb16[0:8])          # high 4 halfwords, host order
-    return struct.pack("<4i", *halfs)
+    halfs = struct.unpack(">4h", vb16[0:8])          # high 4 halfwords, big-endian
+    return struct.pack(">4i", *halfs)
 def ref_vupklsh(vb16):
-    halfs = struct.unpack("<4h", vb16[8:16])         # low 4 halfwords, host order
-    return struct.pack("<4i", *halfs)
+    halfs = struct.unpack(">4h", vb16[8:16])         # low 4 halfwords, big-endian
+    return struct.pack(">4i", *halfs)
 def ref_vupkhsb(vb16):
-    bytes8 = struct.unpack("<8b", vb16[0:8])         # high 8 bytes
-    return struct.pack("<8h", *bytes8)
+    bytes8 = struct.unpack(">8b", vb16[0:8])         # high 8 bytes (byte lanes: order-agnostic)
+    return struct.pack(">8h", *bytes8)
 def ref_vupklsb(vb16):
-    bytes8 = struct.unpack("<8b", vb16[8:16])        # low 8 bytes
-    return struct.pack("<8h", *bytes8)
+    bytes8 = struct.unpack(">8b", vb16[8:16])        # low 8 bytes (byte lanes: order-agnostic)
+    return struct.pack(">8h", *bytes8)
 
 def cr_nibble_signed(a, b):
     if s64(a) < s64(b): return 8
@@ -262,12 +261,30 @@ def case(name, word, in_regs, expects, in_ca=None, exp_ca=None, exp_cr=None, may
 # and checks one output vector register's 16 raw bytes. The byte contents
 # are opaque here (chosen only to span sign/lane patterns); the ref_vupk*
 # functions above are what predict the lifter's actual output for a given
-# input, including its native-endian element read/write convention.
-VCASES = []   # dicts: name, word, vb_reg, vb_bytes, vd_reg, exp_bytes
+# input, including its big-endian element read/write convention.
+#
+# va_reg/va_bytes and vc_reg/vc_bytes are optional: the original harness only
+# covered unary vupk* (one input, vB); binary ops (vcmpgtsw, vadduwm, ...)
+# also seed vA, and the VA-form vmaddfp also seeds vC. Kept at the end of the
+# signature so the existing unary vcase(...) call sites above are untouched.
+VCASES = []   # dicts: name, word, vb_reg, vb_bytes, vd_reg, exp_bytes, va_reg, va_bytes, vc_reg, vc_bytes
 
-def vcase(name, word, vb_reg, vb_bytes, vd_reg, exp_bytes):
+def vcase(name, word, vb_reg, vb_bytes, vd_reg, exp_bytes,
+          va_reg=None, va_bytes=None, vc_reg=None, vc_bytes=None):
     VCASES.append(dict(name=name, word=word, vb_reg=vb_reg, vb_bytes=vb_bytes,
-                       vd_reg=vd_reg, exp_bytes=exp_bytes))
+                       vd_reg=vd_reg, exp_bytes=exp_bytes,
+                       va_reg=va_reg, va_bytes=va_bytes,
+                       vc_reg=vc_reg, vc_bytes=vc_bytes))
+
+def be_w(vals):    # N x uint32 (big-endian lane values) -> 4N raw bytes
+    return struct.pack(f">{len(vals)}I", *(v & 0xFFFFFFFF for v in vals))
+def be_h(vals):    # N x uint16 (big-endian lane values) -> 2N raw bytes
+    return struct.pack(f">{len(vals)}H", *(v & 0xFFFF for v in vals))
+def be_f(vals):    # N x float (big-endian lane values) -> 4N raw bytes
+    return struct.pack(f">{len(vals)}f", *vals)
+
+def va_form(xo6, vd, va, vb, vc):   # VA-form (vmaddfp/vnmsubfp/vsel/vperm/vsldoi/...)
+    return (4 << 26) | (vd << 21) | (va << 16) | (vb << 11) | (vc << 6) | xo6
 
 def pairs(n=6):
     ps = []
@@ -499,6 +516,68 @@ def build_vcases():
         vcase(f"vupkhsb {label}", vx_form(526, VD, 0, VB), VB, vb, VD, ref_vupkhsb(vb))
         vcase(f"vupklsb {label}", vx_form(654, VD, 0, VB), VB, vb, VD, ref_vupklsb(vb))
 
+    # --- VMX per-lane byte-order discrimination cases -----------------------
+    # (ppu: vmx element wise ops read big endian lanes fix). Each pair below
+    # is chosen so the PRE-FIX (native-cast) lifter and the POST-FIX
+    # (vrh/vrw/vrf accessor) lifter compute DIFFERENT results -- i.e. these
+    # fail on a revert of just the lifter change (see the discrimination
+    # count in the PR description), unlike an equality compare or a splat,
+    # where a byte-swap is either invariant or cancels out.
+
+    # vcmpgtsw: true 256 > 2, but a native (unswapped) 32-bit read sees BE
+    # bytes 00 00 01 00 / 00 00 00 02 as 0x00010000 / 0x02000000 -- 65536 >
+    # 33554432 is false. This is the exact audit example. Lanes 1-3 are a
+    # sanity/equal-value check (not part of the discriminating lane). xo=902
+    # with Rc=0 (bit 10 of the 11-bit xo field clear) decodes as "vcmpgtsw"
+    # with no dot -- the case name below must match exactly.
+    vcase("vcmpgtsw mixed", vx_form(902, 2, 0, 1),
+          1, be_w([2, 10, 1, 7]), 2, be_w([0xFFFFFFFF, 0, 0, 0]),
+          va_reg=0, va_bytes=be_w([256, 10, 0, 7]))
+
+    # vcmpgtsh: same 256-vs-2 audit example at halfword width (native 16-bit
+    # read of BE bytes 01 00 / 00 02 sees 0x0001 / 0x0200 -- 1 > 512 is false).
+    vcase("vcmpgtsh mixed", vx_form(838, 2, 0, 1),
+          1, be_h([2, 10, 1, 7, 5, 5, 5, 5]), 2, be_h([0xFFFF, 0, 0, 0, 0, 0, 0, 0]),
+          va_reg=0, va_bytes=be_h([256, 10, 0, 7, 5, 5, 5, 5]))
+
+    # vadduwm: values straddling a byte boundary (0xFF + 0x01 = 0x100). A
+    # native (unswapped) add sees BE bytes 00 00 00 FF / 00 00 00 01 as
+    # 0xFF000000 / 0x01000000; that sum overflows 32 bits and wraps to 0,
+    # not 0x100. (0x100+0x100 alone does NOT discriminate here -- neither
+    # representation carries across a byte boundary for that pair, so it is
+    # included only as a non-discriminating sanity lane; 0xFFFFFFFF+1 is a
+    # second, stronger discriminating lane: true result 0, native-read result
+    # 0xFFFFFF00.)
+    vcase("vadduwm canary", vx_form(128, 2, 0, 1),
+          1, be_w([0x01, 0x100, 1, 0]), 2, be_w([0x100, 0x200, 0, 0]),
+          va_reg=0, va_bytes=be_w([0xFF, 0x100, 0xFFFFFFFF, 0]))
+
+    # vmaddfp: vD = vA*vC + vB with exact 2.0-family values (2.0*3.0+1.0=7.0).
+    # A native float* cast on raw-BE storage reinterprets 2.0's bytes
+    # (40 00 00 00) as a subnormal near zero, so the pre-fix product/sum is
+    # nowhere near 7.0. Raw encoding fields: RA=vA (mult. operand 1, "va"
+    # here), RB=vC (mult. operand 2 -- the mandatory vb_reg/vb_bytes below is
+    # actually the ADD operand vB; RC=vC is the optional vc_reg/vc_bytes),
+    # per ppu_lifter.py's vmaddfp comment ("operand order is vD, vA, vC, vB").
+    vcase("vmaddfp canary", va_form(46, 2, 0, 1, 3),
+          1, be_f([1.0, 1.0, 1.0, 1.0]), 2, be_f([7.0, 7.0, 7.0, 7.0]),
+          va_reg=0, va_bytes=be_f([2.0, 2.0, 2.0, 2.0]),
+          vc_reg=3, vc_bytes=be_f([3.0, 3.0, 3.0, 3.0]))
+
+    # vspltw/vsplth of a multi-byte value: included per the audit's requested
+    # coverage, but these do NOT discriminate the bug (see ppu_lifter.py's
+    # comment on vspltw) -- a splat only copies an existing lane's raw bytes
+    # to other lanes with no arithmetic in between, so reading and writing
+    # with the same (even wrong) reinterpretation cancels out and the
+    # transferred bytes are correct either way. Kept green across the
+    # revert-and-recount step as a deliberate non-discriminating control.
+    vcase("vspltw w=1 canary", vx_form(652, 2, 1, 5),
+          5, be_w([0x12345678, 0x9ABCDEF0, 0x11111111, 0x22222222]),
+          2, be_w([0x9ABCDEF0] * 4))
+    vcase("vsplth w=3 canary", vx_form(588, 2, 3, 5),
+          5, be_h([0x1234, 0x5678, 0x9ABC, 0xDEF0, 0x1111, 0x2222, 0x3333, 0x4444]),
+          2, be_h([0xDEF0] * 8))
+
 build_vcases()
 
 # ---------------------------------------------------------------------------
@@ -615,6 +694,14 @@ static void check_vr(const char* name, const uint8_t* got, const uint8_t* want) 
         out.append("      memset(ctx, 0, sizeof(*ctx));")
         out.append(f"      {{ uint8_t _vb[16] = {{ {vb_hex} }}; "
                     f"memcpy(&ctx->vr[{c['vb_reg']}], _vb, 16); }}")
+        if c.get("va_reg") is not None:
+            va_hex = ", ".join(f"0x{b:02X}" for b in c["va_bytes"])
+            out.append(f"      {{ uint8_t _va[16] = {{ {va_hex} }}; "
+                        f"memcpy(&ctx->vr[{c['va_reg']}], _va, 16); }}")
+        if c.get("vc_reg") is not None:
+            vc_hex = ", ".join(f"0x{b:02X}" for b in c["vc_bytes"])
+            out.append(f"      {{ uint8_t _vc[16] = {{ {vc_hex} }}; "
+                        f"memcpy(&ctx->vr[{c['vc_reg']}], _vc, 16); }}")
         out.append(f"      {code}")
         out.append(f"      {{ uint8_t _want[16] = {{ {want_hex} }}; "
                     f'check_vr("{nm}", (const uint8_t*)&ctx->vr[{c["vd_reg"]}], _want); }}')


### PR DESCRIPTION
﻿I found this while working the Yakuza port: the VMX element wise handlers in this tree read and write vector lanes through native typed pointer casts, and on an x86 host that silently byte reverses every multi byte lane value before any math happens to it. ctx->vr holds raw big endian bytes, since lvx and stvx are plain memcpys and vm_read32 in ppu_loader.cpp proves that convention by explicitly bswapping on read, but a handler like vcmpgtsw just does (int32_t*)&ctx->vr[va] and compares, so 256 stored as big endian bytes 00 00 01 00 gets read natively as 0x00010000, which is 65536, and 2 stored as 00 00 00 02 reads as 0x02000000, which is 33554432, so the compare returns false when the real answer is 256 is greater than 2, true. The same thing happens to every add, subtract, min, max, multiply, shift, splat immediate, convert, and pack instruction that operates on halfword, word, or float lanes, and the float ops have it worse, since reinterpreting a byte reversed IEEE 754 bit pattern does not even land near the right magnitude, so vaddfp, vmaddfp, vrefp, vcfsx, and friends were computing on essentially random values. Tests missed this for a long time because every byte width op, vperm, vspltb, vand, vxor, vsldoi, and so on, is exactly invariant to the byte order confusion, so anything exercising only those looked fine, and single byte values in a multi byte lane also happen to survive a reversal unchanged, which hides the bug further.

The fix ports the swap aware lane accessor pattern I already use in the Yakuza port: vrh, vrw, vrd, and vrf do a memcpy plus a width appropriate byteswap on read, vsth, vstw, vstd, and vstf byteswap then memcpy on write, and every affected handler now routes through them, the compare family, the add and subtract family, min and max, the float arithmetic and float compares, the int and float convert instructions, the shifts and rotates, the multiplies, the sum and multiply accumulate instructions, the pack, and the unpacks. Storage itself never changes, it stays raw big endian, so lvx and stvx keep doing their plain memcpy exactly as before, only the accessors swap. Byte width lanes and pure bitwise ops are deliberately left alone, and I want to call out one counterintuitive case, vspltw and vsplth read as multi byte but turn out to already be correct, since a splat only copies an existing lane's bytes to other lane positions with no arithmetic in between, so reading and writing with the same reinterpretation cancels out, and I added a case for both to the suite specifically to document that as a control rather than silently skip them.

Verified: py -3 tools/test_ppu_lift.py passes 1301 checks, 0 failed, 0 skipped, out of 995 generated cases with 0 skipped at generation. I added conformance cases chosen to discriminate the bug rather than just exercise the instruction, vcmpgtsw and vcmpgtsh on 256 versus 2, vadduwm on values that straddle a byte boundary, and vmaddfp on exact 2.0 family values, and corrected the four vupk* reference functions in the suite that had been modeling the byte reversed output as the intended behavior. Reverting just the lifter change and rerunning against the same new cases fails exactly 16 of them, the four discriminating cases plus the 12 vupk* cases whose reference changed, while the vspltw and vsplth control cases stay green in both states as expected. Every element wise VMX compare, add, splat immediate, and float op in this file computed the wrong value for any lane wider than one byte on an x86 host before this change.
