### PR TITLE
ppu_lifter: fix jump-table discovery silently skipping all tables (+ PS3_TITLE)

### DIFF
--- a/runtime/ppu/tests/boot_main.cpp
+++ b/runtime/ppu/tests/boot_main.cpp
@@ -169,7 +169,9 @@ extern "C" int sys_event_queue_inject(unsigned int, unsigned long long, unsigned
 
 static DWORD WINAPI vblank_ticker(LPVOID)
 {
-    int rsx_ok = (rsx_d3d12_backend_init(1280, 720, "You Don't Know Jack (ps3recomp)") == 0);
+    const char* _title = getenv("PS3_TITLE");
+    if (!_title || !*_title) _title = "You Don't Know Jack (ps3recomp)";
+    int rsx_ok = (rsx_d3d12_backend_init(1280, 720, _title) == 0);
     fprintf(stderr, "[rsx] backend init %s\n", rsx_ok ? "OK -- window open" : "FAILED");
     unsigned last_flip = 0;
     /* The game's frame pacing (vblank/flip handlers -> display frame counter) must

--- a/tools/ppu_lifter.py
+++ b/tools/ppu_lifter.py
@@ -3290,8 +3290,20 @@ def discover_jump_tables(all_insns, read_u32, toc, text_lo, text_hi):
                         rA = a[1].split('(')[1].rstrip(')').strip()
                         return (d, rA)
             return None
-        r_val = p[0]
+        rC = p[0]
         r_base = None; table_base = None
+        disp = None; mid_disp = None
+        # `toc` may be a single value or a list of TOC candidates (multi-TOC
+        # titles). This preliminary pass confirms which register holds the table
+        # base, the TOC displacement (`disp`) to it, and -- for the two-level
+        # (global-of-global) idiom -- the intermediate displacement (`mid_disp`).
+        # (Bug: this block used the raw `toc` list in `toc + d_base`, throwing
+        # "can only concatenate list (not int) to list"; the caller caught it and
+        # SILENTLY SKIPPED all jump-table discovery -- e.g. gcm/cube's printf
+        # _Putfld switch, mis-lifted as a bare bctr that leaked the frame. And
+        # the per-candidate loop below referenced undefined `disp`/`base_is_ld`.)
+        toc_candidates = toc if isinstance(toc, (list, tuple)) else [toc]
+        _tocs = [t for t in toc_candidates if t]
         for cand in (p[1], p[2]):
             ld = _lwz_of(cand)
             if ld is None:
@@ -3299,19 +3311,25 @@ def discover_jump_tables(all_insns, read_u32, toc, text_lo, text_hi):
             d_base, rA = ld
             if d_base is None:
                 continue
-            if rA == 'r2' and toc:                       # one-level: lwz base, d(r2)
-                table_base = read_u32((toc + d_base) & 0xFFFFFFFF)
-            else:                                        # two-level: base <- global <- TOC
-                mid = _lwz_of(rA)
-                if mid is not None and mid[0] is not None and mid[1] == 'r2' and toc:
-                    midval = read_u32((toc + mid[0]) & 0xFFFFFFFF)
-                    if midval is not None:
-                        table_base = read_u32((midval + d_base) & 0xFFFFFFFF)
+            for _t in _tocs:
+                if rA == 'r2':                           # one-level: lwz base, d(r2)
+                    table_base = read_u32((_t + d_base) & 0xFFFFFFFF)
+                    if table_base is not None:
+                        disp = d_base; mid_disp = None
+                else:                                    # two-level: base <- global <- TOC
+                    mid = _lwz_of(rA)
+                    if mid is not None and mid[0] is not None and mid[1] == 'r2':
+                        midval = read_u32((_t + mid[0]) & 0xFFFFFFFF)
+                        if midval is not None:
+                            table_base = read_u32((midval + d_base) & 0xFFFFFFFF)
+                            if table_base is not None:
+                                disp = d_base; mid_disp = mid[0]
+                if table_base is not None:
+                    break
             if table_base is not None:
                 r_base = cand; break
-        if table_base is None or not toc:
+        if table_base is None or disp is None or not _tocs:
             continue
-        toc_candidates = toc if isinstance(toc, (list, tuple)) else [toc]
         # offset table iff an `add rC, *, r_base` combines the loaded value + base
         is_offset = any(
             w.mnemonic == 'add' and
@@ -3339,12 +3357,10 @@ def discover_jump_tables(all_insns, read_u32, toc, text_lo, text_hi):
         for cand in toc_candidates:
             if not cand:
                 continue
-            if base_is_ld:
-                hi = read_u32((cand + disp) & 0xFFFFFFFF)
-                table_base = read_u32((cand + disp + 4) & 0xFFFFFFFF)
-                if hi:              # table addresses live in the 32-bit VA space
-                    table_base = None
-            else:
+            if mid_disp is not None:    # two-level: base <- *(*(TOC+mid)+disp)
+                midval = read_u32((cand + mid_disp) & 0xFFFFFFFF)
+                table_base = read_u32((midval + disp) & 0xFFFFFFFF) if midval else None
+            else:                       # one-level: base <- *(TOC+disp)
                 table_base = read_u32((cand + disp) & 0xFFFFFFFF)
             _dbg(all_insns[i].addr, f"cand_toc=0x{cand:X} table_base={None if table_base is None else hex(table_base)} count={count} is_offset={is_offset} text=[0x{text_lo:X},0x{text_hi:X})")
             if table_base is None:


### PR DESCRIPTION
Fixes a bug that **silently disabled all jump-table discovery** in the lifter, plus a small harness quality-of-life change. Found by getting the SDK `gcm/cube` sample to render end-to-end (recompiled PPU → C → D3D12).

## The bug: `discover_jump_tables` threw and was silently skipped

`discover_jump_tables` raised an exception that the caller catches and turns into a one-line `jump-table discovery skipped: <exc>` on stderr — so for **every** binary hitting this path, zero jump tables were lifted. Each `mtctr; bctr` switch then fell through to the default `ps3_indirect_call(ctx); return`, which (1) skips the case body and (2) returns **without restoring the frame**, leaking r1.

Two distinct bugs, both introduced by the two-level (global-of-global) jump-table commit:

1. **`read_u32(toc + d_base)` with a list.** `toc` arrives as a *list* of TOC candidates (multi-TOC titles), so `toc + d_base` throws `can only concatenate list (not "int") to list`. The normalization to `toc_candidates` happened *after* this use. Fixed: normalize first, try each candidate.
2. **Undefined `base_is_ld` / `disp` / `rC`.** The per-candidate decode loop referenced three variables that were never defined in this flow (leftovers from an earlier version). Fixed: capture `disp` (TOC→table displacement) and `mid_disp` (two-level intermediate) in the preliminary pass, set `rC = p[0]` (the `lwzx` dest), and decode one-level vs two-level consistently.

## How it was found

The SDK `gcm/cube` sample's libc `printf` core `_Putfld` is a gcc offset-table switch (`lwz r11,d(r2); lwzx r0,idx,r11; add r0,r0,r11; mtctr; bctr`). Mis-lifted as a bare `bctr`, it leaked **0x100 of stack per printf call**, drifting the caller's r1 so `_Printf`'s `ld r31,0x158(r1)` restore read the wrong slot → **r31** (a callee-saved base pointer; the sample keeps `g_Width` at `r31+0x6C`) came back garbage → every r31-relative global read returned junk → the sample computed a 0/garbage framebuffer size and self-exited.

One root cause produced three misleading symptoms (missing printf args, "Out of Local Memory", garbage width). With the fix, `_Putfld`'s `bctr` emits a proper `switch { case: goto loc_X; }` over the decoded targets, the frame is preserved, and **the cube renders** — textured spinning cube + dbgfont overlay, 60 FPS, D3D12.

## Also here

- **`PS3_TITLE` env overrides the boot window title** — the generic harness hardcoded `"You Don't Know Jack (ps3recomp)"`; now `$PS3_TITLE` overrides it (same default otherwise), so a per-game harness can name its window without editing shared `boot_main.cpp`.

## Verification

- `ppu-conformance`: **1311 passed, 0 FAILED, 0 skipped** (no instruction-level regression — this change is in table discovery, not emission).
- The recompiled `gcm/cube` renders and runs stably for 75+ s.
- cube's lift now reports `jump tables: 3 dispatchers, 20 case targets` instead of `jump-table discovery skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
