### PR TITLE
cellSpurs: implement CreateJobChain and make KickJobChain start the chain

### DIFF
--- a/libs/spurs/cellSpurs.c
+++ b/libs/spurs/cellSpurs.c
@@ -1897,6 +1897,24 @@ s32 cellSpursJobChainAttributeSetName(u64 attr_ea, u64 name_ea)
     return CELL_OK;
 }
 
+/* Register (or re-register) a job chain handle. Shared by both Create forms. */
+static s32 jc_register(u32 jc_ea, u32 entry_ea, u16 size_desc, u16 max_grab,
+                       const char* who)
+{
+    for (int i = 0; i < MAX_JOBCHAINS; i++) {
+        if (!s_jobchains[i].jc_ea || s_jobchains[i].jc_ea == jc_ea) {
+            s_jobchains[i].jc_ea     = jc_ea;
+            s_jobchains[i].entry_ea  = entry_ea;
+            s_jobchains[i].size_desc = size_desc;
+            s_jobchains[i].max_grab  = max_grab;
+            s_jobchains[i].run_count = 0;
+            return CELL_OK;
+        }
+    }
+    printf("[cellSpurs] %s: registry full\n", who);
+    return CELL_OK;
+}
+
 s32 cellSpursCreateJobChainWithAttribute(u64 spurs_ea, u64 jc_ea, u64 attr_ea)
 {
     if (!spurs_ea || !jc_ea || !attr_ea) return CELL_SPURS_TASK_ERROR_NULL_POINTER;
@@ -1923,18 +1941,43 @@ s32 cellSpursCreateJobChainWithAttribute(u64 spurs_ea, u64 jc_ea, u64 attr_ea)
            (u32)jc_ea, entry, sd_mg >> 16, sd_mg & 0xFFFFu,
            name_ea ? (const char*)(vm_base + name_ea) : "-");
 
-    for (int i = 0; i < MAX_JOBCHAINS; i++) {
-        if (!s_jobchains[i].jc_ea || s_jobchains[i].jc_ea == (u32)jc_ea) {
-            s_jobchains[i].jc_ea     = (u32)jc_ea;
-            s_jobchains[i].entry_ea  = entry;
-            s_jobchains[i].size_desc = (u16)(sd_mg >> 16);
-            s_jobchains[i].max_grab  = (u16)(sd_mg & 0xFFFFu);
-            s_jobchains[i].run_count = 0;
-            return CELL_OK;
-        }
+    return jc_register((u32)jc_ea, entry, (u16)(sd_mg >> 16), (u16)(sd_mg & 0xFFFFu),
+                       "CreateJobChainWithAttribute");
+}
+
+/* cellSpursCreateJobChain -- the no-attribute form, and the one the WWS job
+ * manager's own wrapper calls. Same registration, with the fields passed
+ * directly instead of read back out of a CellSpursJobChainAttribute:
+ *
+ *   cellSpursCreateJobChain(CellSpurs*, CellSpursJobChain*, const u64* entry,
+ *                           u16 sizeJobDescriptor, u16 maxGrabbedJob,
+ *                           const u8 priorityTable[8], u32 maxContention,
+ *                           bool autoRequestSpuCount, u32 tag1, u32 tag2)
+ *
+ * tag1/tag2 are guest-stack args, past the 8-GPR HLE adapter; nothing here
+ * needs them. Without this entry point the chain is never registered at all,
+ * so the later kick finds "UNKNOWN chain (no Create seen)" and returns
+ * CELL_OK having walked nothing -- and the title waits forever on SPU work
+ * that was never started. Gran Turismo 5 Prologue parks its whole boot there. */
+s32 cellSpursCreateJobChain(u64 spurs_ea, u64 jc_ea, u64 entry_ea,
+                            u32 sizeJobDescriptor, u32 maxGrabbedJob,
+                            u64 prio_ea, u32 maxContention,
+                            u32 autoRequestSpuCount)
+{
+    (void)spurs_ea; (void)prio_ea;
+    if (!jc_ea) return CELL_SPURS_TASK_ERROR_NULL_POINTER;
+
+    static int _n = 0;
+    if (_n++ < 3) {
+        printf("[cellSpurs] CreateJobChain(jc=0x%08X entry=0x%08X sizeDesc=%u maxGrab=%u "
+               "maxCont=%u autoReq=%u)\n",
+               (u32)jc_ea, (u32)entry_ea, sizeJobDescriptor, maxGrabbedJob,
+               maxContention, autoRequestSpuCount);
+        if (entry_ea && (u32)entry_ea < 0x10000000u)
+            jc_dump_commands("CreateJobChain", (u32)entry_ea, 16);
     }
-    printf("[cellSpurs] CreateJobChainWithAttribute: registry full\n");
-    return CELL_OK;
+    return jc_register((u32)jc_ea, (u32)entry_ea, (u16)sizeJobDescriptor,
+                       (u16)maxGrabbedJob, "CreateJobChain");
 }
 
 /* ---------------------------------------------------------------------------
@@ -2279,7 +2322,7 @@ static DWORD WINAPI jc_thread(LPVOID p)
  * Verified against the guest: Create takes the chain in r4 (r3 is the CellSpurs)
  * and passes 0x02932A80; Run then arrives with r3=0x02932A80. Join and Shutdown
  * are the same one-argument shape. */
-s32 cellSpursRunJobChain(u64 jc_ea)
+static s32 jc_start(u64 jc_ea, const char* who)
 {
     static int s_off = -1;
     if (s_off < 0) s_off = getenv("PS3_NO_JOBCHAIN") ? 1 : 0;
@@ -2288,9 +2331,9 @@ s32 cellSpursRunJobChain(u64 jc_ea)
         if (s_jobchains[i].jc_ea != (u32)jc_ea) continue;
         s_jobchains[i].run_count++;
         if (s_jobchains[i].run_count <= 3) {
-            printf("[cellSpurs] RunJobChain(jc=0x%08X) run#%d entry=0x%08X\n",
-                   (u32)jc_ea, s_jobchains[i].run_count, s_jobchains[i].entry_ea);
-            jc_dump_commands("RunJobChain", s_jobchains[i].entry_ea, 16);
+            printf("[cellSpurs] %s(jc=0x%08X) run#%d entry=0x%08X\n",
+                   who, (u32)jc_ea, s_jobchains[i].run_count, s_jobchains[i].entry_ea);
+            jc_dump_commands(who, s_jobchains[i].entry_ea, 16);
         }
         if (s_off || !s_jobchains[i].entry_ea) return CELL_OK;
 #ifdef _WIN32
@@ -2303,8 +2346,13 @@ s32 cellSpursRunJobChain(u64 jc_ea)
 #endif
         return CELL_OK;
     }
-    printf("[cellSpurs] RunJobChain(jc=0x%08X) -- UNKNOWN chain (no Create seen)\n", (u32)jc_ea);
+    printf("[cellSpurs] %s(jc=0x%08X) -- UNKNOWN chain (no Create seen)\n", who, (u32)jc_ea);
     return CELL_OK;
+}
+
+s32 cellSpursRunJobChain(u64 jc_ea)
+{
+    return jc_start(jc_ea, "RunJobChain");
 }
 
 /* cellSpursJoinJobChain(const CellSpursJobChain*) -- one argument, as above. */
@@ -2323,11 +2371,18 @@ s32 cellSpursJobChainGetError(u64 jc_ea, u64 cause_out_ea)
     return CELL_OK;
 }
 
-/* cellSpursKickJobChain — kick a running job chain */
-s32 cellSpursKickJobChain(void* spurs, void* jobChain)
+/* cellSpursKickJobChain(CellSpursJobChain* jobChain, u8 numReadyCount)
+ *
+ * Two arguments, jobChain in r3 -- the same one-handle shape as Run/Join, not
+ * (spurs, jobChain). It is the *other* way a title starts a chain: Run for one
+ * that was created ready to go, Kick to hand the SPUs another `numReadyCount`
+ * units of an already-created chain. Titles built on the WWS job manager use
+ * Kick, so leaving this a no-op meant their chains were created and then never
+ * walked -- which looks exactly like a hang with no error anywhere. */
+s32 cellSpursKickJobChain(u64 jc_ea, u32 numReadyCount)
 {
-    (void)spurs; (void)jobChain;
-    return CELL_OK;
+    (void)numReadyCount;
+    return jc_start(jc_ea, "KickJobChain");
 }
 
 /* =========================================================================

--- a/runtime/ppu/ppu_hle.cpp
+++ b/runtime/ppu/ppu_hle.cpp
@@ -224,6 +224,24 @@ extern "C" void ps3_hle_call(uint32_t nid, ppu_context* ctx)
                 nid, (uint32_t)ctx->gpr[3], (uint32_t)ctx->gpr[4],
                 (uint32_t)ctx->gpr[5], (uint32_t)ctx->lr);
     }
+    /* PS3_HLE_ARGS=<nid-hex>: dump the full PPC64 argument register set (r3-r10)
+     * for one import. PS3_HLE_TRACE only shows r3-r5, which is not enough to tell
+     * a MISDECLARED HLE prototype from a guest passing bad values -- the two look
+     * identical from the callee side, and getting it wrong silently shifts every
+     * argument after the mistake. */
+    { static long s_ha = -1;
+      if (s_ha < 0) { const char* e = getenv("PS3_HLE_ARGS");
+                      s_ha = e ? (long)strtoul(e, 0, 16) : 0; }
+      if (s_ha && nid == (uint32_t)s_ha) {
+        static int _n = 0;
+        if (_n++ < 6)
+          fprintf(stderr, "[hle-args] nid=0x%08X r3=0x%08X r4=0x%08X r5=0x%08X r6=0x%08X "
+                          "r7=0x%08X r8=0x%08X r9=0x%08X r10=0x%08X lr=0x%08X\n",
+                  nid, (uint32_t)ctx->gpr[3], (uint32_t)ctx->gpr[4], (uint32_t)ctx->gpr[5],
+                  (uint32_t)ctx->gpr[6], (uint32_t)ctx->gpr[7], (uint32_t)ctx->gpr[8],
+                  (uint32_t)ctx->gpr[9], (uint32_t)ctx->gpr[10], (uint32_t)ctx->lr);
+      } }
+
     /* Bad-lock locator (FLOW_BADLOCK): sys_lwmutex_lock (0x1573DC3F) on a garbage/null
      * object (r3 < 0x10000 or high-bit set) in m_InitEntityHierarchy — host backtrace
      * to find the null global it dereferences. Map RVAs via flow.map. */

--- a/runtime/spu/spu_channels.c
+++ b/runtime/spu/spu_channels.c
@@ -293,8 +293,13 @@ static int spu_mfc_atomic(spu_context* ctx, uint32_t cmd)
             fprintf(stderr, "[atomcnt] %llu atomic ops; last cmd=0x%X ea=0x%08X\n",
                     (unsigned long long)s_n, cmd, ea);
           s_lastea = ea; } } }
-    { static int s_at = -1; if (s_at < 0) s_at = getenv("YDKJ_ATOMTRACE") ? 1 : 0;
-      if (s_at) { static int _a=0; if (_a++ < 40)
+    /* YDKJ_ATOMTRACE=1 keeps the old 40-line cap; =<N> raises it. A busy image
+     * (FMOD) exhausts 40 before a quieter one issues its first atomic, which
+     * reads as "that image never does atomics" when it simply never got a line. */
+    { static int s_at = -1;
+      if (s_at < 0) { const char* e = getenv("YDKJ_ATOMTRACE");
+                      int v = e ? atoi(e) : 0; s_at = e ? (v > 1 ? v : 40) : 0; }
+      if (s_at) { static int _a=0; if (_a++ < s_at)
         fprintf(stderr, "[atom] cmd=0x%02X ea=0x%08X (img=%d)\n", cmd, ea, ctx->image_id); } }
     /* cri task (img22) atomic on the taskset: dump the loaded bitset line so we can
      * see if the task reads MY taskset (0x4005E000) with my READY bit, or elsewhere. */

--- a/runtime/spu/spu_channels.c
+++ b/runtime/spu/spu_channels.c
@@ -353,9 +353,13 @@ static int spu_mfc_atomic(spu_context* ctx, uint32_t cmd)
           if (_n++ < 48) {
               extern uint8_t* vm_base;
               const uint8_t* r = vm_base + ((uint32_t)ea & ~127u);
-              fprintf(stderr, "[atom-ea] cmd=0x%X img=%d pc=0x%05X ea=0x%08X "
+              /* lr (gpr[0]) too: these atomics sit in generic inc/dec helpers, so
+               * pc names the HELPER and only the link register names the caller
+               * that gives the counter its meaning. */
+              fprintf(stderr, "[atom-ea] cmd=0x%X img=%d pc=0x%05X lr=0x%05X ea=0x%08X "
                       "RAM=%02X%02X%02X%02X %02X%02X%02X%02X",
-                      cmd, ctx->image_id, (uint32_t)ctx->pc & SPU_LS_MASK, (uint32_t)ea,
+                      cmd, ctx->image_id, (uint32_t)ctx->pc & SPU_LS_MASK,
+                      ctx->gpr[0]._u32[0] & SPU_LS_MASK, (uint32_t)ea,
                       r[0],r[1],r[2],r[3], r[4],r[5],r[6],r[7]);
               if (cmd == MFC_PUTLLC_CMD) {
                   fprintf(stderr, " STORE=%02X%02X%02X%02X %02X%02X%02X%02X",

--- a/runtime/syscalls/sys_timer.c
+++ b/runtime/syscalls/sys_timer.c
@@ -109,6 +109,31 @@ int64_t sys_timer_usleep(ppu_context* ctx)
     uint64_t usec = LV2_ARG_U64(ctx, 0);
     { static int n=0; if (n++ < 60) fprintf(stderr, "[WAIT] timer_usleep(%llu us) lr=0x%08llX cia=0x%08llX\n",
         (unsigned long long)usec, (unsigned long long)ctx->lr, (unsigned long long)ctx->cia); }
+    /* PS3_WAIT_OBJ=<lr-hex>: when a usleep spin is reached from this return
+     * address, dump the registers and the object they point at. A poll loop
+     * tells you WHERE it is spinning; this tells you WHAT it is spinning on,
+     * which is the part you actually need to find who never releases it. */
+    { static long s_wo = -1;
+      if (s_wo < 0) { const char* e = getenv("PS3_WAIT_OBJ");
+                      s_wo = e ? (long)strtoul(e, 0, 16) : 0; }
+      if (s_wo && (uint32_t)ctx->lr == (uint32_t)s_wo) {
+        static int _n = 0;
+        if (_n++ < 8) {
+          uint32_t o = (uint32_t)ctx->gpr[29];
+          fprintf(stderr, "[wait-obj] lr=0x%08X r3=%llu r9=0x%08X r29=0x%08X r30=0x%08X r31=0x%08X",
+                  (uint32_t)ctx->lr, (unsigned long long)usec, (uint32_t)ctx->gpr[9],
+                  o, (uint32_t)ctx->gpr[30], (uint32_t)ctx->gpr[31]);
+          /* guest memory is big-endian: assemble the words explicitly. */
+          if (o && vm_base) {
+            const uint8_t* p = vm_base + o;
+            uint32_t w0 = (uint32_t)(((uint32_t)(p)[0]<<24)|((uint32_t)(p)[1]<<16)|((uint32_t)(p)[2]<<8)|(uint32_t)(p)[3]);
+            p = vm_base + o + 0x24;
+            uint32_t w24 = (uint32_t)(((uint32_t)(p)[0]<<24)|((uint32_t)(p)[1]<<16)|((uint32_t)(p)[2]<<8)|(uint32_t)(p)[3]);
+            fprintf(stderr, "  [r29+0x00]=0x%08X [r29+0x24]=0x%08X", w0, w24);
+          }
+          fprintf(stderr, "\n"); fflush(stderr);
+        } } }
+
     /* POLLSITE: resolve the host chain of the 1ms poller (LBP bringup) to
      * guest functions -- names the stage that is starving. */
     { static int _ps = -1; if (_ps < 0) _ps = getenv("POLLSITE") ? 12 : 0;


### PR DESCRIPTION
Two gaps that together make a WWS-job-manager title hang with no error anywhere.

## `cellSpursCreateJobChain` had no implementation

NID `0x60EB2DEC` was never registered, so it fell through to the unresolved-NID
path and faked `CELL_OK`. The chain was never recorded, and the later start
found `UNKNOWN chain (no Create seen)` and walked nothing.

Only the `WithAttribute` form existed. This is the same registration with the
fields passed directly — `entry`, `sizeJobDescriptor`, `maxGrabbedJob` — instead
of read back out of a `CellSpursJobChainAttribute`. `tag1`/`tag2` are
guest-stack args, past the 8-GPR HLE adapter, and nothing here needs them.

## `cellSpursKickJobChain` was a no-op with the wrong shape

It was declared `(spurs, jobChain)` and returned `CELL_OK` without doing
anything. It is `(jobChain, numReadyCount)` — the same one-handle shape as
`Run`/`Join`, verified against the guest — and it is the *other* way a title
starts a chain: `Run` for one created ready to go, `Kick` to hand the SPUs
another `numReadyCount` units of an existing chain.

Titles built on the WWS job manager use `Kick`, not `Run`, so their chains were
created and then never walked. That looks exactly like a hang: no error, no
`MISS`, nothing in the log.

`Run` and `Kick` now share `jc_start()`; both `Create` forms share
`jc_register()`.

## Effect

Gran Turismo 5 Prologue uses Create + Kick. Before, its boot parked forever in
`sys_event_queue_receive` and produced 293 lines of log. After:

| | before | after |
|---|---|---|
| log lines in 90 s | 293 | 3.8 M |
| job chains walked | 0 | yes, repeatedly |
| SPU job dispatches | 0 | ~500 k |
| files opened | 0 | `PARAM.SFO` read |
| `cellAudio` | not reached | Init / PortOpen / PortStart / mixing thread |
| guest threads | 5 | 15 |

Existing `Run`-based titles are unaffected: `cellSpursRunJobChain` keeps its
signature and behaviour, and the shared helper is the code it already ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMAcq6gVEVdf6qLaLTKyZd

---

## Follow-ups on this branch

### `cellSpursShutdownJobChain` had no implementation

NID `0x738E40E6` was also unregistered and faked `CELL_OK` (13 times a boot in
GT5P). A chain now carries a shutdown flag: `jc_execute` honours it wherever
the walk has reached — a service chain loops by design and otherwise outlives
the subsystem that asked it to stop — `jc_start` refuses to restart a shut-down
chain, `jc_register` clears it on re-create, and Shutdown signals completion so
a thread parked on the attached queue wakes.

On its own this did not move GT5P's boot; the NID was genuinely missing, which
is why it is here, but the hang it was reached from had another cause:

### The completion event dropped the finished job's index

`jc_signal_done` computed `d2`/`d3` from the SPU's outbound mailbox and then
threw them away — the push hardcoded `data2 = 0`. That is not cosmetic: the PPU
side of a job chain reads `data2` as *which* job finished.

GT5P's SGX audio service runs

```
do { JobGuardNotify(guard); receive(q); i = data2; dispatch[i](); }
while (i + 1 < queued);
```

so a `data2` that is always 0 pins `i` at 0 and the loop never terminates — and
it holds the chain's lwmutex across the whole loop, so the main thread blocks in
`sys_lwmutex_lock` trying to tear the chain down. 151,685 receives in 25 s,
214,702 SPU job dispatches, no progress.

The event now carries the mailbox value when the SPU produced one, and the job's
ordinal in the chain otherwise — which is what that loop counts.

| | before | after |
|---|---|---|
| audio loop | never exits | terminates |
| chain lwmutex | held ~10 s+, never released | released |
| main thread | blocked in `sys_lwmutex_lock` | reaches RSX setup |

After: `cellGcmInit`, `MapMainMemory(174 MB)`, six tile regions, zcull,
1280x720 display buffers, and a first `SetPrepareFlip`.
