### PR TITLE
Linux bring-up: CI, a headless RSX backend, and the PPU boot scaffold to zero on POSIX

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -98,6 +98,16 @@ jobs:
             -o /tmp/test_spu_helpers runtime/spu/tests/test_spu_helpers.c
           /tmp/test_spu_helpers
 
+      # runtime/ppu/ is the one part of the runtime no CMake target builds --
+      # it needs the lifter's per-game ppu_recomp.h -- so nothing here ever
+      # compiled it and the POSIX port is unfinished. This ratchets the error
+      # count: it fails if the scaffold gets WORSE, which is what keeps the
+      # port from sliding backwards while it is being done.
+      - name: Check the PPU boot scaffold (ratchet)
+        env:
+          CXX: ${{ matrix.compiler == 'clang' && 'clang++' || 'g++' }}
+        run: python tools/check_ppu_scaffold.py
+
       # Drives a real NV4097 command buffer through cellGcm -> RSX -> the null
       # backend's headless software path and asserts the presented pixel. No
       # display and no GPU are involved, so exit 0 means the whole graphics

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,9 +12,9 @@
 # something finally linked it; Clang rejected it outright. A single-compiler
 # matrix would have shipped that bug.
 #
-# No graphics step yet, unlike the macOS job: ps3recomp_host is gated on APPLE
-# in CMakeLists.txt because Metal is the only non-Windows backend that renders.
-# This job grows one the moment a portable backend lands.
+# The graphics step runs against the null backend's headless software path,
+# which is what gives Linux an end-to-end check without a GPU, a display, or a
+# render backend of its own.
 name: Linux
 
 on:
@@ -97,3 +97,17 @@ jobs:
             -std=gnu17 -I include -I runtime/spu \
             -o /tmp/test_spu_helpers runtime/spu/tests/test_spu_helpers.c
           /tmp/test_spu_helpers
+
+      # Drives a real NV4097 command buffer through cellGcm -> RSX -> the null
+      # backend's headless software path and asserts the presented pixel. No
+      # display and no GPU are involved, so exit 0 means the whole graphics
+      # bridge is intact on Linux, not merely that it compiled.
+      - name: Run the POSIX host (headless end-to-end)
+        run: |
+          # Clear + flip: asserts the guest clear colour reaches the framebuffer.
+          ./build/ps3recomp_host
+          # Clear + a real NV4097 draw: asserts the triangle covers the centre
+          # pixel, which exercises guest vertex fetch, primitive expansion and
+          # the draw path, not just the clear.
+          ./build/ps3recomp_host --draw
+          ./build/ps3recomp_host --draw --frames=60

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,99 @@
+# Builds the runtime library on Linux.
+#
+# Linux was the last platform with no CI and no evidence: the POSIX paths were
+# there, README listed the whole column as "untested", and nobody had ever run
+# a compiler over it. Two real defects were sitting in that gap -- an
+# Apple-only QueryPerformanceCounter shim reached from a shared translation
+# unit, and a Darwin-only pthread_threadid_np called from the POSIX branch of
+# win32_compat.h. This job is what stops the next two from accumulating.
+#
+# Both compilers, deliberately. GCC accepted the pthread_threadid_np call as an
+# implicit declaration and produced an archive that would only have failed when
+# something finally linked it; Clang rejected it outright. A single-compiler
+# matrix would have shipped that bug.
+#
+# No graphics step yet, unlike the macOS job: ps3recomp_host is gated on APPLE
+# in CMakeLists.txt because Metal is the only non-Windows backend that renders.
+# This job grows one the moment a portable backend lands.
+name: Linux
+
+on:
+  push:
+    branches: [ master, main ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Linux x64 (${{ matrix.compiler }}, ${{ matrix.build_type }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [gcc, clang]
+        build_type: [Debug, Release]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # SDL2 is not optional off Windows: cellPad and cellAudio select their
+      # SDL2 backends unconditionally there, and CMakeLists.txt hard-fails
+      # without it.
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build libsdl2-dev clang
+
+      - name: Configure
+        run: |
+          if [ "${{ matrix.compiler }}" = "clang" ]; then
+            CC=clang CXX=clang++ cmake -S . -B build -G Ninja \
+              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          else
+            CC=gcc CXX=g++ cmake -S . -B build -G Ninja \
+              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          fi
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Verify the archive exists and is x86-64
+        run: |
+          test -f build/libps3recomp_runtime.a
+          file build/libps3recomp_runtime.a
+          # An archive links nothing, so a bad extern survives the build. Catch
+          # the undefined symbols the compiler let through -- this is exactly
+          # how pthread_threadid_np hid from GCC.
+          nm --undefined-only build/libps3recomp_runtime.a \
+            | awk '{print $2}' | sort -u > /tmp/undef.txt
+          if grep -qE '^(pthread_threadid_np|QueryPerformance|GetTickCount64)' /tmp/undef.txt; then
+            echo "Win32/Darwin-only symbol left undefined in a POSIX build:"
+            grep -E '^(pthread_threadid_np|QueryPerformance|GetTickCount64)' /tmp/undef.txt
+            exit 1
+          fi
+
+      # The Python suites are the project's real correctness net -- the
+      # conformance one compiles and runs 1300+ lifted instruction cases with
+      # the host compiler, so it is genuinely testing this platform's codegen
+      # and not just re-checking the lifter's Python.
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run the lifter test suites
+        env:
+          CI: "1"          # makes a skipped conformance run fail instead of passing
+        run: |
+          set -e
+          for t in tools/test_*.py; do
+            echo "--- $t"
+            python "$t"
+          done
+
+      - name: Run self-contained SPU helper tests
+        run: |
+          ${{ matrix.compiler == 'clang' && 'clang' || 'gcc' }} \
+            -std=gnu17 -I include -I runtime/spu \
+            -o /tmp/test_spu_helpers runtime/spu/tests/test_spu_helpers.c
+          /tmp/test_spu_helpers

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -121,3 +121,11 @@ jobs:
           # the draw path, not just the clear.
           ./build/ps3recomp_host --draw
           ./build/ps3recomp_host --draw --frames=60
+
+      # RSX texture layout -- format class, row sizes, Morton addressing. Pure
+      # arithmetic with no host API in it, so it runs everywhere, and it is the
+      # regression net for having lifted that maths out of the D3D12 uploader.
+      - name: Run self-contained RSX texture layout tests
+        run: |
+          ${{ matrix.compiler == 'clang' && 'clang' || 'gcc' }} -std=gnu17 -Wall -Wextra -I include -I libs/video -o /tmp/test_texture_layout libs/video/tests/test_texture_layout.c libs/video/rsx_texture_layout.c
+          /tmp/test_texture_layout

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -84,3 +84,11 @@ jobs:
       # output is what to record with --update.
       - name: Check the PPU boot scaffold (ratchet)
         run: python tools/check_ppu_scaffold.py
+
+      # RSX texture layout -- format class, row sizes, Morton addressing. Pure
+      # arithmetic with no host API in it, so it runs everywhere, and it is the
+      # regression net for having lifted that maths out of the D3D12 uploader.
+      - name: Run self-contained RSX texture layout tests
+        run: |
+          clang -std=gnu17 -Wall -Wextra -I include -I libs/video -o /tmp/test_texture_layout libs/video/tests/test_texture_layout.c libs/video/rsx_texture_layout.c
+          /tmp/test_texture_layout

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -77,3 +77,10 @@ jobs:
           # and the draw path, not just the clear.
           PS3RECOMP_METAL_HEADLESS=1 ./build/ps3recomp_host --draw
           PS3RECOMP_METAL_HEADLESS=1 ./build/ps3recomp_host --draw --frames=60
+
+      # runtime/ppu/ is the one part of the runtime no CMake target builds --
+      # it needs the lifter's per-game ppu_recomp.h. macOS has no recorded
+      # baseline yet, so this reports its numbers and passes; the first run's
+      # output is what to record with --update.
+      - name: Check the PPU boot scaffold (ratchet)
+        run: python tools/check_ppu_scaffold.py

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -88,3 +88,12 @@ jobs:
       # fails the job.
       - name: Check the PPU boot scaffold (ratchet)
         run: python tools/check_ppu_scaffold.py
+
+      # RSX texture layout -- format class, row sizes, Morton addressing. Pure
+      # arithmetic with no host API in it, so it runs everywhere, and it is the
+      # regression net for having lifted that maths out of the D3D12 uploader.
+      - name: Run self-contained RSX texture layout tests
+        shell: bash
+        run: |
+          clang-cl /nologo /W0 /D_CRT_SECURE_NO_WARNINGS -I include -I libs/video /Fe:test_texture_layout.exe libs/video/tests/test_texture_layout.c libs/video/rsx_texture_layout.c
+          ./test_texture_layout.exe

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -93,7 +93,11 @@ jobs:
       # arithmetic with no host API in it, so it runs everywhere, and it is the
       # regression net for having lifted that maths out of the D3D12 uploader.
       - name: Run self-contained RSX texture layout tests
-        shell: bash
+        # NOT shell: bash. Git Bash rewrites a leading-slash argument into a
+        # Windows path, so /nologo arrived at the linker as an .obj under the
+        # Git install directory. PowerShell leaves MSVC-style flags alone.
         run: |
-          clang-cl /nologo /W0 /D_CRT_SECURE_NO_WARNINGS -I include -I libs/video /Fe:test_texture_layout.exe libs/video/tests/test_texture_layout.c libs/video/rsx_texture_layout.c
-          ./test_texture_layout.exe
+          clang-cl /nologo /W0 /D_CRT_SECURE_NO_WARNINGS /I include /I libs/video /Fe:test_texture_layout.exe libs/video/tests/test_texture_layout.c libs/video/rsx_texture_layout.c
+          if ($LASTEXITCODE -ne 0) { exit 1 }
+          .\test_texture_layout.exe
+          if ($LASTEXITCODE -ne 0) { exit 1 }

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -80,3 +80,11 @@ jobs:
             echo "--- $t"
             python "$t"
           done
+
+      # runtime/ppu/ is the one part of the runtime no CMake target builds --
+      # it needs the lifter's per-game ppu_recomp.h -- so it was only ever
+      # compiled inside somebody's game port. Windows is where it works, so
+      # this is a real gate here: the baseline is near zero and any new error
+      # fails the job.
+      - name: Check the PPU boot scaffold (ratchet)
+        run: python tools/check_ppu_scaffold.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,9 +182,10 @@ endif()
 # ---------------------------------------------------------------------------
 # Drives the cellGcm -> RSX -> backend bridge with no lifted game, so a backend
 # can be brought up and regression-tested without a game binary or a recompiler
-# run. Currently Apple-only because the Metal backend is the only non-Windows
-# backend that renders; it will build anywhere once another one lands.
-if(APPLE)
+# run. Builds on any POSIX host: it picks Metal on Apple and the null backend's
+# headless software path everywhere else, so Linux -- which has no real backend
+# yet -- can still run the whole guest command stream end to end in CI.
+if(UNIX)
     add_executable(ps3recomp_host
         runtime/host/host_posix.c
         runtime/host/host_stubs.c

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Verified by CI on every push unless noted.
 
 | | Windows | macOS (arm64) | Linux |
 |---|---|---|---|
-| Runtime library builds | yes | yes | untested |
-| Lifter + 8 test suites | yes | yes | untested |
+| Runtime library builds | yes | yes | yes |
+| Lifter + 8 test suites | yes | yes | yes |
 | Render backend | D3D12 | Metal | none |
 | Runs a recompiled game | **yes** | **no** | no |
 
@@ -51,9 +51,11 @@ suite, but cannot yet load and run a title. `ps3recomp_host` drives
 cellGcm → RSX → Metal end to end without a game, which is what makes further
 graphics work possible there.
 
-Linux has no CI and no render backend. The POSIX paths exist and the library
-may well build; nobody has checked, so it is listed as untested rather than
-supported.
+Linux now builds and passes the same suites, under both GCC and Clang, on
+every push. It has no render backend — Metal is Apple-only and D3D12 is
+Windows-only — so it is one portable backend plus the same PPU boot scaffold
+away from where macOS stands. Until then there is nothing for `ps3recomp_host`
+to drive, so the Linux job has no end-to-end graphics step.
 
 ## The Challenge
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Verified by CI on every push unless noted.
 |---|---|---|---|
 | Runtime library builds | yes | yes | yes |
 | Lifter + 8 test suites | yes | yes | yes |
-| Render backend | D3D12 | Metal | none |
+| Render backend | D3D12 | Metal | null (headless software) |
 | Runs a recompiled game | **yes** | **no** | no |
 
 The gap on macOS is the PPU boot scaffold — `ppu_loader.cpp`, `boot_main.cpp`
@@ -51,11 +51,13 @@ suite, but cannot yet load and run a title. `ps3recomp_host` drives
 cellGcm → RSX → Metal end to end without a game, which is what makes further
 graphics work possible there.
 
-Linux now builds and passes the same suites, under both GCC and Clang, on
-every push. It has no render backend — Metal is Apple-only and D3D12 is
-Windows-only — so it is one portable backend plus the same PPU boot scaffold
-away from where macOS stands. Until then there is nothing for `ps3recomp_host`
-to drive, so the Linux job has no end-to-end graphics step.
+Linux builds and passes the same suites under both GCC and Clang, and runs
+`ps3recomp_host` end to end, on every push. Its backend is the null backend's
+headless software path: a host-memory framebuffer with a CPU triangle filler,
+enough to prove the guest's command stream produced the pixels it asked for on
+a runner with no display and no GPU. It is not a renderer — no depth, no
+blending, no textures — so Linux is still one real backend, plus the same PPU
+boot scaffold macOS needs, away from running a title.
 
 ## The Challenge
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -168,9 +168,9 @@ toolchain, and the check fails only if a number goes **up**. A toolchain with
 no baseline entry reports its numbers and passes, so a new platform's first CI
 run tells you what to record.
 
-Both Linux toolchains are now at **zero** — the whole scaffold compiles under
-GCC and Clang — so in practice the ratchet is a hard gate there: any new error
-fails the build. Windows sits at 1, for the `<dirent.h>` reason below.
+Every recorded toolchain is now at **zero** — the whole scaffold compiles under
+GCC, Clang and clang-cl — so in practice this is a hard gate: any new error
+fails the build.
 
 Compiling is not the same as running. The scaffold is not linked or executed by
 anything in this repository (that needs a lifted game), and `boot_main.cpp`
@@ -178,9 +178,9 @@ still starts its vblank ticker, hang watchdog and profiler inside
 `#ifdef _WIN32` with no `#else`, so a POSIX host has no frame clock. Those are
 the remaining gaps between "builds" and "runs a title".
 
-Known non-zero: `ppu_fs.cpp` includes `<dirent.h>` unguarded and uses
-`opendir`/`readdir` directly, which MSVC does not provide — game ports vendor
-their own shim to get around it. See the note under [Windows](#windows).
+It compiles the four scaffold translation units. `boot_main.cpp` is excluded:
+it also pulls in the per-game SPU recomp header and the generated function
+table, which a stub cannot stand in for.
 
 ### Compile Definitions
 
@@ -218,14 +218,12 @@ cmake -B build -DPS3_MODULE_MAX_FUNCS=1024
 **Definitions:**
 - `_CRT_SECURE_NO_WARNINGS` — Suppress MSVC CRT security warnings
 
-> **`ppu_fs.cpp` needs a `dirent.h`.** The PPU boot scaffold's filesystem
-> layer includes `<dirent.h>` unguarded and calls `opendir`/`readdir`/
-> `closedir` directly, none of which MSVC ships. Every game port therefore
-> vendors its own Win32 `dirent.h` shim on the include path. Nothing in this
-> repository supplies one, which is why
-> [the scaffold check](#checking-the-ppu-boot-scaffold) reports one error for
-> that file even on Windows. Guarding the include and providing an in-tree
-> shim would remove that duplication from every port.
+> **`dirent.h` is supplied in-tree.** The PPU boot scaffold's filesystem layer
+> walks host directories with `opendir`/`readdir`/`closedir`, none of which
+> MSVC ships, so game ports used to vendor their own Win32 shim on the include
+> path. `runtime/platform/win32_dirent.h` provides one (`FindFirstFileA`
+> behind the POSIX names, passing straight through to the system header off
+> Windows) — a port carrying its own copy can drop it.
 
 ### Linux
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -143,6 +143,38 @@ The test build currently registers the deterministic synchronization stress
 suite. It can still be configured directly from `tests/sync_stress` when
 testing an alternate runtime tree with `PS3RECOMP_TREE_ROOT`.
 
+### Checking the PPU boot scaffold
+
+`runtime/ppu/` is the one part of the runtime no CMake target builds. Those
+files `#include "ppu_recomp.h"`, which the lifter generates per game, so
+`CMakeLists.txt` excludes them from the library and they are only ever
+compiled inside somebody's game port — historically, on Windows.
+
+```bash
+python tools/check_ppu_scaffold.py            # check against the baseline
+python tools/check_ppu_scaffold.py --verbose  # show the diagnostics
+python tools/check_ppu_scaffold.py --update   # re-record after improving it
+```
+
+It synthesises a stub `ppu_recomp.h` from the lifter's own `HEADER_PREAMBLE`
+— imported from `ppu_lifter.py`, not copied, so it cannot drift from what
+games really get — and compiles the scaffold against it. It does not link and
+runs nothing; it proves only that every declaration the scaffold reaches for
+exists on this platform.
+
+Because the POSIX port is unfinished, it is a **ratchet** rather than a
+pass/fail gate: `tools/ppu_scaffold_baseline.json` records the current error
+count per toolchain, and the check fails only if a number goes **up**. Windows
+sits near zero, so a regression there is a hard failure today; Linux starts
+high and every step of the port is expected to lower it. A toolchain with no
+baseline entry reports its numbers and passes, so a new platform's first CI
+run tells you what to record.
+
+Known non-zero on every platform: `ppu_fs.cpp` includes `<dirent.h>`
+unguarded and uses `opendir`/`readdir` directly, which MSVC does not provide —
+game ports vendor their own shim to get around it. See the note under
+[Windows](#windows).
+
 ### Compile Definitions
 
 | Definition | Default | Description |
@@ -178,6 +210,15 @@ cmake -B build -DPS3_MODULE_MAX_FUNCS=1024
 
 **Definitions:**
 - `_CRT_SECURE_NO_WARNINGS` — Suppress MSVC CRT security warnings
+
+> **`ppu_fs.cpp` needs a `dirent.h`.** The PPU boot scaffold's filesystem
+> layer includes `<dirent.h>` unguarded and calls `opendir`/`readdir`/
+> `closedir` directly, none of which MSVC ships. Every game port therefore
+> vendors its own Win32 `dirent.h` shim on the include path. Nothing in this
+> repository supplies one, which is why
+> [the scaffold check](#checking-the-ppu-boot-scaffold) reports one error for
+> that file even on Windows. Guarding the include and providing an in-tree
+> shim would remove that duplication from every port.
 
 ### Linux
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -183,12 +183,14 @@ cmake -B build -DPS3_MODULE_MAX_FUNCS=1024
 
 Builds and is covered by CI (`.github/workflows/linux.yml`, x86-64, GCC and
 Clang, Debug and Release on every push). That workflow builds the runtime
-library and runs all eight lifter suites plus the SPU helper tests.
+library, runs all eight lifter suites plus the SPU helper tests, and drives
+`ps3recomp_host` end to end against the headless software backend.
 
-> **No render backend.** Metal is Apple-only and D3D12 is Windows-only, so
-> nothing on Linux draws yet and `ps3recomp_host` is not built there. Running
-> a recompiled title additionally needs the PPU boot scaffold ported off
-> Win32 — the same gap macOS has.
+> **No hardware render backend.** Metal is Apple-only and D3D12 is
+> Windows-only. Linux falls back to the null backend's headless software path
+> (`libs/video/rsx_null_backend.c`), which rasterises into host memory — a
+> correctness probe, not a renderer. Running a recompiled title additionally
+> needs the PPU boot scaffold ported off Win32 — the same gap macOS has.
 
 **Compiler Flags (GCC/Clang):**
 - `-Wall -Wextra` — Enable warnings

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -181,9 +181,14 @@ cmake -B build -DPS3_MODULE_MAX_FUNCS=1024
 
 ### Linux
 
-> **Untested.** There is no Linux CI and no render backend for it. The POSIX
-> paths exist and the library may build, but nobody has verified it — treat
-> the notes below as a starting point rather than a supported configuration.
+Builds and is covered by CI (`.github/workflows/linux.yml`, x86-64, GCC and
+Clang, Debug and Release on every push). That workflow builds the runtime
+library and runs all eight lifter suites plus the SPU helper tests.
+
+> **No render backend.** Metal is Apple-only and D3D12 is Windows-only, so
+> nothing on Linux draws yet and `ps3recomp_host` is not built there. Running
+> a recompiled title additionally needs the PPU boot scaffold ported off
+> Win32 — the same gap macOS has.
 
 **Compiler Flags (GCC/Clang):**
 - `-Wall -Wextra` — Enable warnings

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -162,18 +162,25 @@ games really get — and compiles the scaffold against it. It does not link and
 runs nothing; it proves only that every declaration the scaffold reaches for
 exists on this platform.
 
-Because the POSIX port is unfinished, it is a **ratchet** rather than a
-pass/fail gate: `tools/ppu_scaffold_baseline.json` records the current error
-count per toolchain, and the check fails only if a number goes **up**. Windows
-sits near zero, so a regression there is a hard failure today; Linux starts
-high and every step of the port is expected to lower it. A toolchain with no
-baseline entry reports its numbers and passes, so a new platform's first CI
+It is a **ratchet** rather than a pass/fail gate:
+`tools/ppu_scaffold_baseline.json` records the current error count per
+toolchain, and the check fails only if a number goes **up**. A toolchain with
+no baseline entry reports its numbers and passes, so a new platform's first CI
 run tells you what to record.
 
-Known non-zero on every platform: `ppu_fs.cpp` includes `<dirent.h>`
-unguarded and uses `opendir`/`readdir` directly, which MSVC does not provide —
-game ports vendor their own shim to get around it. See the note under
-[Windows](#windows).
+Both Linux toolchains are now at **zero** — the whole scaffold compiles under
+GCC and Clang — so in practice the ratchet is a hard gate there: any new error
+fails the build. Windows sits at 1, for the `<dirent.h>` reason below.
+
+Compiling is not the same as running. The scaffold is not linked or executed by
+anything in this repository (that needs a lifted game), and `boot_main.cpp`
+still starts its vblank ticker, hang watchdog and profiler inside
+`#ifdef _WIN32` with no `#else`, so a POSIX host has no frame clock. Those are
+the remaining gaps between "builds" and "runs a title".
+
+Known non-zero: `ppu_fs.cpp` includes `<dirent.h>` unguarded and uses
+`opendir`/`readdir` directly, which MSVC does not provide — game ports vendor
+their own shim to get around it. See the note under [Windows](#windows).
 
 ### Compile Definitions
 

--- a/lbp/main.cpp
+++ b/lbp/main.cpp
@@ -56,7 +56,7 @@ void     ps3_load_prx_modules(void) {}
 extern "C" uint32_t    g_last_hle_nid;    /* ppu_hle.cpp breadcrumb */
 extern "C" const char* g_last_hle_name;
 
-extern "C" __declspec(thread) ppu_context* g_active_ctx;
+extern "C" PPU_THREAD_LOCAL ppu_context* g_active_ctx;
 static LONG WINAPI ydkj_crash_filter(EXCEPTION_POINTERS* ep)
 {
     EXCEPTION_RECORD* er = ep->ExceptionRecord;

--- a/libs/video/rsx_d3d12_backend.c
+++ b/libs/video/rsx_d3d12_backend.c
@@ -19,6 +19,7 @@
 #include "rsx_d3d12_backend.h"
 #include "rsx_primitives.h"
 #include "rsx_vertex_fetch.h"
+#include "rsx_texture_layout.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -2389,18 +2390,6 @@ static u32 rsx_remap_to_d3d(u32 c1, u32 basef)
  * bits run out, then the larger dimension's remaining bits ride above -- the
  * NV40 layout (matches RPCS3 convert_linear_swizzle). POT dims only, which is
  * what the hardware requires for swizzled textures. */
-static inline u32 rsx_swz_off(u32 x, u32 y, u32 log2w, u32 log2h)
-{
-    u32 off = 0, shift = 0;
-    while (log2w && log2h) {
-        off |= (x & 1u) << shift; x >>= 1; shift++;
-        off |= (y & 1u) << shift; y >>= 1; shift++;
-        log2w--; log2h--;
-    }
-    off |= (x | y) << shift;     /* only one of x/y still has bits */
-    return off;
-}
-static inline u32 rsx_log2u(u32 v) { u32 l = 0; while ((1u << l) < v) l++; return l; }
 
 /* Sparse FNV-1a over a texture's source bytes -- enough to notice an animated
  * surface changing, cheap enough to run on every bind. Kept a function rather
@@ -2427,25 +2416,28 @@ static int vp_upload_tex_slot(u32 off, u32 w, u32 h, u32 fmt, int cube, u32 mips
      * 0x85 A8R8G8B8 (swizzled UI art), 0x8B G8B8 (the 1024x2048 linear FONT
      * atlas -- without it no text renders at all), 0x86/87/88 DXT1/23/45
      * (512x512 detail/LUT layers bound at t1/t3 on every draw). */
-    u32 basef = fmt & 0x9F;
-    int argb = (basef == 0x85);
-    int g8b8 = (basef == 0x8B);
-    int dxt  = (basef == 0x86 || basef == 0x87 || basef == 0x88);
-    u32 bpp = argb ? 4u : g8b8 ? 2u : 1u;
-    DXGI_FORMAT dxfmt = argb ? DXGI_FORMAT_R8G8B8A8_UNORM
-                      : g8b8 ? DXGI_FORMAT_R8G8_UNORM
-                      : (basef == 0x86) ? DXGI_FORMAT_BC1_UNORM
-                      : (basef == 0x87) ? DXGI_FORMAT_BC2_UNORM
-                      : (basef == 0x88) ? DXGI_FORMAT_BC3_UNORM
+    /* Format class, row sizes and swizzling are RSX semantics: rsx_texture_
+     * layout.c owns them so the Metal backend can read a guest texture without
+     * re-deriving any of it. Only the DXGI mapping below is ours. */
+    rsx_tex_layout tl;
+    rsx_texture_layout(fmt, w, h, &tl);
+    u32 basef = fmt & 0x9F;              /* still needed for the SRV remap */
+    int argb = (tl.fmt == RSX_TEXFMT_R8G8B8A8);
+    int g8b8 = (tl.fmt == RSX_TEXFMT_R8G8);
+    int dxt  = tl.compressed;
+    /* Compressed rows are counted in blocks, so keep bpp at 1 for the byte
+     * arithmetic the diagnostics below do. */
+    u32 bpp = tl.compressed ? 1u : tl.bytes_per_texel;
+    DXGI_FORMAT dxfmt = (tl.fmt == RSX_TEXFMT_R8G8B8A8) ? DXGI_FORMAT_R8G8B8A8_UNORM
+                      : (tl.fmt == RSX_TEXFMT_R8G8)     ? DXGI_FORMAT_R8G8_UNORM
+                      : (tl.fmt == RSX_TEXFMT_BC1)      ? DXGI_FORMAT_BC1_UNORM
+                      : (tl.fmt == RSX_TEXFMT_BC2)      ? DXGI_FORMAT_BC2_UNORM
+                      : (tl.fmt == RSX_TEXFMT_BC3)      ? DXGI_FORMAT_BC3_UNORM
                       : DXGI_FORMAT_R8_UNORM;
     /* DXT data is stored as linear 4x4 block rows (compressed formats are
      * never Morton-swizzled on RSX). Row of blocks = (w/4)*blocksize. */
-    u32 blkrow = 0, blkrows = 0;
-    if (dxt) {
-        u32 bs = (basef == 0x86) ? 8u : 16u;
-        blkrow  = ((w + 3) / 4) * bs;
-        blkrows = (h + 3) / 4;
-    }
+    u32 blkrow  = dxt ? tl.row_bytes : 0;
+    u32 blkrows = dxt ? tl.rows      : 0;
     const u32 key_off = off;         /* lookup key: the offset as bound */
     /* Sparse checksum of a texture's source bytes -- enough to notice an
      * animated surface changing, cheap enough to run on every bind. */
@@ -2628,8 +2620,8 @@ static int vp_upload_tex_slot(u32 off, u32 w, u32 h, u32 fmt, int cube, u32 mips
      * Uploading them as linear rows produced the diagonal-stripe garbage on
      * LBP's loading screen (every texture there is 0x85 swizzled). POT dims
      * only -- the hardware requires that for swizzled textures anyway. */
-    int swz = !dxt && !(fmt & 0x20) && (w & (w - 1)) == 0 && (h & (h - 1)) == 0;
-    u32 l2w = rsx_log2u(w), l2h = rsx_log2u(h);
+    int swz = tl.swizzled;
+    u32 l2w = rsx_log2_ceil(w), l2h = rsx_log2_ceil(h);
     /* Cube textures store their 6 faces consecutively. Convert each into its own
      * slice of the upload buffer; the conversion below is unchanged and simply
      * runs once per face with off/mapped rebased. */
@@ -2671,7 +2663,7 @@ static int vp_upload_tex_slot(u32 off, u32 w, u32 h, u32 fmt, int cube, u32 mips
             u8* drow = (u8*)mapped + (u64)y * pitch;
             if (swz) {
                 for (u32 x = 0; x < w; x++) {
-                    const u8* s = sbase + (u64)rsx_swz_off(x, y, l2w, l2h) * 2;
+                    const u8* s = sbase + (u64)rsx_swizzle_offset(x, y, l2w, l2h) * 2;
                     drow[x*2+0] = s[0]; drow[x*2+1] = s[1];
                 }
             } else {
@@ -2702,7 +2694,7 @@ static int vp_upload_tex_slot(u32 off, u32 w, u32 h, u32 fmt, int cube, u32 mips
         for (u32 y = 0; y < h; y++) {
             u8* drow = (u8*)mapped + (u64)y * pitch;
             for (u32 x = 0; x < w; x++) {
-                const u8* s = sbase + (u64)(swz ? rsx_swz_off(x, y, l2w, l2h)
+                const u8* s = sbase + (u64)(swz ? rsx_swizzle_offset(x, y, l2w, l2h)
                                                 : y * w + x) * 4;
                 if (rgba) {
                     drow[x*4+0] = s[0]; drow[x*4+1] = s[1];
@@ -2718,7 +2710,7 @@ static int vp_upload_tex_slot(u32 off, u32 w, u32 h, u32 fmt, int cube, u32 mips
         for (u32 y = 0; y < h; y++) {
             u8* drow = (u8*)mapped + (u64)y * pitch;
             for (u32 x = 0; x < w; x++)
-                drow[x] = sbase[rsx_swz_off(x, y, l2w, l2h)];
+                drow[x] = sbase[rsx_swizzle_offset(x, y, l2w, l2h)];
         }
     } else {
         for (u32 y = 0; y < h; y++)

--- a/libs/video/rsx_d3d12_backend.c
+++ b/libs/video/rsx_d3d12_backend.c
@@ -18,6 +18,7 @@
 
 #include "rsx_d3d12_backend.h"
 #include "rsx_primitives.h"
+#include "rsx_vertex_fetch.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -4983,14 +4984,6 @@ static void d3d12_set_viewport(void* ud, const rsx_state* state)
  * + texcoord (uv), 36 bytes. (The real VP path feeds raw float4 attrib0.) */
 typedef struct { float x, y, z; float r, g, b, a; float u, v; } BasicVertex;
 
-/* Read a big-endian 32-bit float from guest memory. */
-static float rd_bef(const u8* src)
-{
-    u32 w;
-    memcpy(&w, src, 4);
-    w = ((w>>24)&0xFF)|((w>>8)&0xFF00)|((w<<8)&0xFF0000)|((w<<24)&0xFF000000);
-    float f; memcpy(&f, &w, 4); return f;
-}
 
 /* Read one RSX vertex (by absolute vertex index) from guest memory into our
  * host layout. Position is attrib 0 (float3+), color is attrib 3 (ubyte4 or
@@ -5009,9 +5002,9 @@ static void read_rsx_vertex(const rsx_state* state, u32 vindex, BasicVertex* out
     const rsx_vertex_attrib* pos = &state->vertex_attribs[0];
     if (pos->enabled && pos->type == 2 /* float */ && pos->size >= 2) {
         u8* src = vm_base + cellGcmResolveOffset(pos->offset + vindex * pos->stride);
-        out->x = rd_bef(src);
-        out->y = rd_bef(src + 4);
-        if (pos->size >= 3) out->z = rd_bef(src + 8);
+        out->x = rsx_rd_bef(src);
+        out->y = rsx_rd_bef(src + 4);
+        if (pos->size >= 3) out->z = rsx_rd_bef(src + 8);
 
         /* dbgfont (and similar 2D overlays) store screen positions biased far
          * outside clip space; their vertex program folds them back to clip
@@ -5029,8 +5022,8 @@ static void read_rsx_vertex(const rsx_state* state, u32 vindex, BasicVertex* out
             out->y = 1.0f - sy * 2.0f;
             out->z = 0.0f;
             if (pos->size >= 4) {
-                out->u = rd_bef(src + 8);   /* U */
-                out->v = rd_bef(src + 12);  /* V */
+                out->u = rsx_rd_bef(src + 8);   /* U */
+                out->v = rsx_rd_bef(src + 12);  /* V */
             }
         }
     }
@@ -5106,104 +5099,21 @@ static u32 upload_quads_from_rsx(u32 first, u32 count)
 typedef struct { float v[4]; } VPSlot;
 #define VP_VERT_STRIDE (16 * sizeof(VPSlot))   /* 256 */
 
-static float rd_half_be(const u8* p)
-{
-    u16 h = (u16)((p[0] << 8) | p[1]);
-    u32 sgn = (h >> 15) & 1, exp = (h >> 10) & 0x1F, man = h & 0x3FF;
-    u32 f;
-    if (exp == 0)       f = (sgn << 31);                                    /* +-0 / denorm->0 */
-    else if (exp == 31) f = (sgn << 31) | 0x7F800000u | (man << 13);        /* inf/nan */
-    else                f = (sgn << 31) | ((exp - 15 + 127) << 23) | (man << 13);
-    float out; memcpy(&out, &f, 4); return out;
-}
 
+void rsx_vtx_pos_dbg(const rsx_state* state, const float* v, u32 n);
+
+/* Fill all 16 attribute slots for one vertex. The per-attribute work lives in
+ * rsx_vertex_fetch.c so the Metal and null backends read guest vertices the
+ * same way this one does, rather than each porting the logic again. */
 static void read_vp_vertex(const rsx_state* state, u32 vi, VPSlot* out16)
 {
-    extern uint8_t* vm_base;
-    extern u32 cellGcmResolveOffset(u32);
-    extern u32 cellGcmResolveLocated(int, u32);
     for (int i = 0; i < 16; i++) {
-        VPSlot* o = &out16[i];
-        /* A disabled attribute array feeds the CONSTANT vertex attribute
-         * register (NV4097_SET_VERTEX_DATA4F_M), not zero -- same rule as
-         * glColor4f with the colour array off. Defaulting these to black
-         * multiplied Rubber Ducky's duck texture away in the fragment program. */
-        o->v[0] = state->vertex_data4f[i][0];
-        o->v[1] = state->vertex_data4f[i][1];
-        o->v[2] = state->vertex_data4f[i][2];
-        o->v[3] = state->vertex_data4f[i][3];
-        const rsx_vertex_attrib* a = &state->vertex_attribs[i];
-        if (!a->enabled || a->stride == 0) continue;
-        /* Vertex frequency divisor (instancing). freq 0/1 = per-vertex. For
-         * freq > 1 the element index is either vertex/freq (DIVIDE: per-instance
-         * data advances once per freq verts) or vertex%freq (MODULO: a mesh
-         * repeats every freq verts). NV4097_SET_FREQUENCY_DIVIDER_OPERATION's
-         * per-attribute bit selects MODULO. DeferredShading's cube rings need
-         * this: the shared cube mesh is MODULO, the per-instance transform in
-         * attrib9 is DIVIDE -- without it attrib9 advanced every vertex and the
-         * instanced cubes drew with garbage transforms (only the baseplate,
-         * which isn't instanced, survived). */
-        u32 ei = vi;
-        if (a->frequency > 1 && !getenv("VP_NOFREQ")) {   /* VP_NOFREQ: instancing kill-switch */
-            ei = (state->frequency_divider_op & (1u << i))
-                     ? (vi % a->frequency)      /* MODULO: repeat mesh */
-                     : (vi / a->frequency);     /* DIVIDE: per-instance */
+        rsx_fetch_attrib(state, i, vi, out16[i].v);
+        if (i == 0) {
+            const rsx_vertex_attrib* a = &state->vertex_attribs[0];
+            u32 n = a->size ? a->size : 4; if (n > 4) n = 4;
+            rsx_vtx_pos_dbg(state, out16[0].v, n);
         }
-        /* The vertex-array OFFSET register (NV4097_SET_VERTEX_DATA_ARRAY_OFFSET)
-         * carries the context-DMA location in bit 31: 0 = LOCAL (VRAM), 1 = MAIN
-         * (IO-mapped system memory). DeferredShading is the first sample to put
-         * its meshes in the main heap -- passing the raw 0x80xxxxxx offset to
-         * cellGcmResolveOffset made page = 0x80x and resolved to garbage VRAM
-         * (vertices read as -7.992 => degenerate => empty G-buffer). Strip the
-         * bit and resolve MAIN explicitly; local offsets keep the old path. */
-        u32 off = (a->offset & 0x7FFFFFFFu) + ei * a->stride;
-        /* Bit 31 of the vertex-array OFFSET selects the context DMA: 0 = LOCAL
-         * (VRAM), 1 = MAIN. Resolve LOCAL as local -- routing it through
-         * cellGcmResolveOffset lets the IO table win for any offset whose page
-         * the IO region also covers. This title's vertex arrays sit at offsets
-         * like 0x4480, shadowed by its 1MB IO window at 0x11100000: the array
-         * was uploaded to VRAM 0xC0004480 but resolved to main 0x11104480,
-         * which is empty -- so every INDEXED mesh fetched zeros and collapsed
-         * to the origin, while non-indexed geometry whose arrays lie outside
-         * the shadowed pages drew fine. */
-        const u8* p = vm_base + ((a->offset & 0x80000000u)
-            ? cellGcmResolveLocated(0, off)   /* MAIN: IO offset table */
-            : cellGcmResolveLocated(1, off)); /* LOCAL: VRAM, never the IO table */
-        u32 n = a->size ? a->size : 4; if (n > 4) n = 4;
-        switch (a->type) {
-        case 2: /* CELL_GCM_VERTEX_F: float32 BE */
-            for (u32 k = 0; k < n; k++) o->v[k] = rd_bef(p + k * 4);
-            break;
-        case 3: /* SF: half float BE */
-            for (u32 k = 0; k < n; k++) o->v[k] = rd_half_be(p + k * 2);
-            break;
-        case 4: /* UB: u8 normalized [0,1] */
-            for (u32 k = 0; k < n; k++) o->v[k] = p[k] / 255.0f;
-            break;
-        case 1: /* S1: s16 normalized [-1,1] */
-            for (u32 k = 0; k < n; k++) {
-                s16 s = (s16)((p[k*2] << 8) | p[k*2+1]);
-                o->v[k] = (float)s / 32767.0f;
-            }
-            break;
-        case 5: /* S32K: s16 integer */
-            for (u32 k = 0; k < n; k++)
-                o->v[k] = (float)(s16)((p[k*2] << 8) | p[k*2+1]);
-            break;
-        case 7: /* UB256: u8 unnormalized */
-            for (u32 k = 0; k < n; k++) o->v[k] = (float)p[k];
-            break;
-        default:
-            { static int _t = -1; if (_t < 0) _t = getenv("VTX_TYPEDBG") ? 1 : 0;
-              if (_t) { static u32 seen = 0;
-                  if (!(seen & (1u << (a->type & 31)))) { seen |= 1u << (a->type & 31);
-                      fprintf(stderr, "[VTXTYPE] UNHANDLED type=%u attr=%d size=%u stride=%u%c",
-                              a->type, i, a->size, a->stride, 10); } } }
-            for (u32 k = 0; k < n; k++) o->v[k] = rd_bef(p + k * 4);
-            break;
-        }
-        if (i == 0) { void rsx_vtx_pos_dbg(const rsx_state*, const float*, u32);
-                      rsx_vtx_pos_dbg(state, o->v, n); }
     }
 }
 
@@ -5273,13 +5183,13 @@ static void vp_attrs_dbg(const rsx_state* state)
               const u8* rp = vm_base + (a->offset & 0x7FFFFFFFu);   /* raw, unresolved */
               fprintf(stderr, "[VPDUMP] a%d off=0x%X  LOCAL@0x%X=(%g,%g,%g)  MAIN@0x%X=(%g,%g,%g)"
                               "  RAW@0x%X=(%g,%g,%g)%c",
-                      ai, aoff, la, rd_bef(lp), rd_bef(lp+4), rd_bef(lp+8),
-                      ma, rd_bef(mp), rd_bef(mp+4), rd_bef(mp+8),
-                      (a->offset & 0x7FFFFFFFu), rd_bef(rp), rd_bef(rp+4), rd_bef(rp+8), 10);
+                      ai, aoff, la, rsx_rd_bef(lp), rsx_rd_bef(lp+4), rsx_rd_bef(lp+8),
+                      ma, rsx_rd_bef(mp), rsx_rd_bef(mp+4), rsx_rd_bef(mp+8),
+                      (a->offset & 0x7FFFFFFFu), rsx_rd_bef(rp), rsx_rd_bef(rp+4), rsx_rd_bef(rp+8), 10);
           }
           u32 nc = a->size ? a->size : 3; if (nc > 3) nc = 3;
           float f[3] = {0,0,0};
-          for (u32 k = 0; k < nc; k++) f[k] = rd_bef(q + k * 4);
+          for (u32 k = 0; k < nc; k++) f[k] = rsx_rd_bef(q + k * 4);
           if (v < 12)
               fprintf(stderr, "[VPDUMP] a%d[%d] = (%g, %g, %g)%c", ai, v, f[0], f[1], f[2], 10);
           int allz = 1; for (u32 k = 0; k < nc; k++) if (f[k] != 0.f) allz = 0;
@@ -5294,14 +5204,14 @@ static void vp_attrs_dbg(const rsx_state* state)
       { float f0[3]; u32 o0 = (a->offset & 0x7FFFFFFFu);
         const u8* q0 = vm_base + ((a->offset & 0x80000000u)
                        ? cellGcmResolveLocated(0, o0) : cellGcmResolveLocated(1, o0));
-        for (int k = 0; k < 3; k++) f0[k] = rd_bef(q0 + k * 4);
+        for (int k = 0; k < 3; k++) f0[k] = rsx_rd_bef(q0 + k * 4);
         u32 diff = 0;
         for (int v = 1; v < cnt; v++) {
             u32 ao = o0 + (u32)v * a->stride;
             const u8* q = vm_base + ((a->offset & 0x80000000u)
                           ? cellGcmResolveLocated(0, ao) : cellGcmResolveLocated(1, ao));
             for (int k = 0; k < 3; k++)
-                if (rd_bef(q + k * 4) != f0[k]) { diff++; break; }
+                if (rsx_rd_bef(q + k * 4) != f0[k]) { diff++; break; }
         }
         fprintf(stderr, "[VPDUMP] a%d: %u/%d entries differ from entry 0 (%g,%g,%g)%c",
                 ai, diff, cnt, f0[0], f0[1], f0[2], 10);
@@ -5312,7 +5222,7 @@ static void vp_attrs_dbg(const rsx_state* state)
               u32 ao = o0 + (u32)v * a->stride;
               const u8* q = vm_base + ((a->offset & 0x80000000u)
                             ? cellGcmResolveLocated(0, ao) : cellGcmResolveLocated(1, ao));
-              for (int k = 0; k < 3; k++) { float f = rd_bef(q + k * 4);
+              for (int k = 0; k < 3; k++) { float f = rsx_rd_bef(q + k * 4);
                   if (f < lo[k]) lo[k] = f; if (f > hi[k]) hi[k] = f; } }
           u32 nnan = 0, nfin = 0;
           for (int v = 0; v < cnt; v++) {
@@ -5320,7 +5230,7 @@ static void vp_attrs_dbg(const rsx_state* state)
               const u8* q = vm_base + ((a->offset & 0x80000000u)
                             ? cellGcmResolveLocated(0, ao) : cellGcmResolveLocated(1, ao));
               int bad = 0;
-              for (int k = 0; k < 3; k++) { float f = rd_bef(q + k * 4);
+              for (int k = 0; k < 3; k++) { float f = rsx_rd_bef(q + k * 4);
                   if (!(f == f) || f > 1e30f || f < -1e30f) bad = 1; }
               if (bad) nnan++; else nfin++;
           }

--- a/libs/video/rsx_metal_backend.m
+++ b/libs/video/rsx_metal_backend.m
@@ -24,6 +24,7 @@
 
 #include "rsx_commands.h"
 #include "rsx_metal_backend.h"
+#include "rsx_vertex_fetch.h"
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -205,71 +206,20 @@ static int create_window(const char* title)
 #endif
 
 /* ---- guest vertex fetch --------------------------------------------------
- * Ported from the D3D12 backend's read_vp_vertex: every RSX component is
- * big-endian, and the vertex-array OFFSET register carries the context-DMA
- * location in bit 31 (0 = LOCAL/VRAM, 1 = MAIN/IO-mapped).
+ * Was a port of the D3D12 backend's read_vp_vertex, kept here as a second
+ * copy. It had already drifted from the original in two ways that matter --
+ * it fed caller literals rather than the constant vertex attribute register
+ * for a disabled array, and it resolved LOCAL offsets through the IO table --
+ * so both copies are now gone and rsx_vertex_fetch.c holds the one definition.
  * --------------------------------------------------------------------------*/
-
-extern uint8_t* vm_base;
-extern u32 cellGcmResolveOffset(u32);
-extern u32 cellGcmResolveLocated(int, u32);
-
-static float rd_bef(const u8* p)
-{
-    u32 w; memcpy(&w, p, 4);
-    w = ((w >> 24) & 0xFFu) | ((w >> 8) & 0xFF00u) |
-        ((w << 8) & 0xFF0000u) | ((w << 24) & 0xFF000000u);
-    float f; memcpy(&f, &w, 4); return f;
-}
-
-static float rd_half_be(const u8* p)
-{
-    u16 h = (u16)((p[0] << 8) | p[1]);
-    u32 sgn = (h >> 15) & 1u, exp = (h >> 10) & 0x1Fu, man = h & 0x3FFu, f;
-    if (exp == 0)        f = sgn << 31;
-    else if (exp == 31)  f = (sgn << 31) | 0x7F800000u | (man << 13);
-    else                 f = (sgn << 31) | ((exp - 15u + 127u) << 23) | (man << 13);
-    float o; memcpy(&o, &f, 4); return o;
-}
-
-/* Read one attribute of one vertex as float4. */
-static void fetch_attrib(const rsx_state* st, int idx, u32 vi, float out[4],
-                         float d0, float d1, float d2, float d3)
-{
-    out[0] = d0; out[1] = d1; out[2] = d2; out[3] = d3;
-    const rsx_vertex_attrib* a = &st->vertex_attribs[idx];
-    if (!a->enabled || a->stride == 0 || !vm_base) return;
-
-    u32 ei = vi;
-    if (a->frequency > 1)
-        ei = (st->frequency_divider_op & (1u << idx)) ? (vi % a->frequency)
-                                                      : (vi / a->frequency);
-
-    u32 off = (a->offset & 0x7FFFFFFFu) + ei * a->stride;
-    u32 ea  = (a->offset & 0x80000000u) ? cellGcmResolveLocated(0, off)
-                                        : cellGcmResolveOffset(off);
-    const u8* p = vm_base + ea;
-    u32 n = a->size ? a->size : 4; if (n > 4) n = 4;
-
-    switch (a->type) {
-    case 2: for (u32 k = 0; k < n; k++) out[k] = rd_bef(p + k * 4);            break;
-    case 3: for (u32 k = 0; k < n; k++) out[k] = rd_half_be(p + k * 2);        break;
-    case 4: for (u32 k = 0; k < n; k++) out[k] = (float)p[k] / 255.0f;         break;  /* UB norm */
-    case 1: for (u32 k = 0; k < n; k++) {                                              /* S16 norm */
-                s16 v = (s16)((p[k*2] << 8) | p[k*2+1]);
-                out[k] = (float)v / 32767.0f;
-            } break;
-    default: break;
-    }
-}
 
 /* Position is attrib 0, diffuse colour attrib 3, texcoord0 attrib 8 -- the same
  * slots the D3D12 fallback path assumes. */
 static void fetch_vertex(const rsx_state* st, u32 vi, MtlVertex* out)
 {
-    fetch_attrib(st, 0, vi, out->pos, 0.0f, 0.0f, 0.0f, 1.0f);
-    fetch_attrib(st, 3, vi, out->col, 1.0f, 1.0f, 1.0f, 1.0f);
-    fetch_attrib(st, 8, vi, out->tc,  0.0f, 0.0f, 0.0f, 0.0f);
+    rsx_fetch_attrib(st, 0, vi, out->pos);
+    rsx_fetch_attrib(st, 3, vi, out->col);
+    rsx_fetch_attrib(st, 8, vi, out->tc);
 }
 
 /* ---- primitive conversion -------------------------------------------------

--- a/libs/video/rsx_null_backend.c
+++ b/libs/video/rsx_null_backend.c
@@ -289,20 +289,233 @@ int rsx_null_backend_pump_messages(void)
 
 #else /* !_WIN32 */
 
-/* Stub for non-Windows platforms — TODO: SDL2 or X11 backend */
+/* ---------------------------------------------------------------------------
+ * Headless software backend
+ *
+ * No window and no GPU: the RSX target is a plain u32 framebuffer in host
+ * memory, and triangles are filled on the CPU. That is enough to answer the
+ * one question this backend exists to answer -- did the guest's command
+ * stream actually reach a backend and produce the pixels it asked for -- on
+ * any platform, including a CI runner with no display and no GPU driver.
+ *
+ * Linux has no real backend yet (Metal is Apple-only, D3D12 Windows-only), so
+ * without this ps3recomp_host cannot be built or run there at all and the
+ * whole cellGcm -> RSX -> backend bridge goes unexercised on the platform.
+ *
+ * ponytail: flat-shaded triangles from the first vertex's colour, no depth
+ * buffer, no blending, no textures, no clipping beyond the framebuffer
+ * bounds, and the viewport is the whole target. It is a correctness probe,
+ * not a renderer. Anything more belongs in a real backend.
+ * -----------------------------------------------------------------------*/
+
+#include "rsx_vertex_fetch.h"
+#include <stdlib.h>
+
+typedef struct {
+    u32* fb;                /* width * height, 0x00RRGGBB          */
+    u32  width, height;
+    u32  clear_argb;        /* last NV4097_SET_COLOR_CLEAR_VALUE   */
+    u32  last_present;      /* centre pixel of the last presented frame */
+    int  presented;
+    const rsx_state* state; /* live state, for the draw path       */
+} NullSoftState;
+
+static NullSoftState s_soft;
+
+static void nullsw_clear(void* ud, u32 flags, u32 color, float depth, u8 stencil)
+{
+    (void)ud; (void)depth; (void)stencil;
+    s_soft.clear_argb = color;
+    if (!s_soft.fb || !(flags & 0xF0u)) return;   /* colour bits only */
+    u32 rgb = color & 0x00FFFFFFu;
+    for (u32 i = 0; i < s_soft.width * s_soft.height; i++) s_soft.fb[i] = rgb;
+}
+
+static void nullsw_set_render_target(void* ud, const rsx_state* state)
+{
+    (void)ud; s_soft.state = state;
+}
+
+static void nullsw_set_vertex_attribs(void* ud, const rsx_state* state)
+{
+    (void)ud; s_soft.state = state;
+}
+
+/* NDC -> framebuffer pixels. The guest's clip-space position is divided by w
+ * (1.0 for the identity-transform case) and mapped over the whole target;
+ * see the ponytail note above about the viewport. */
+static void ndc_to_px(const float p[4], float* sx, float* sy)
+{
+    float w = (p[3] != 0.0f) ? p[3] : 1.0f;
+    *sx = ( p[0] / w * 0.5f + 0.5f) * (float)s_soft.width;
+    *sy = (-p[1] / w * 0.5f + 0.5f) * (float)s_soft.height;
+}
+
+static u32 colour_of(const float c[4])
+{
+    float r = c[0] < 0 ? 0 : (c[0] > 1 ? 1 : c[0]);
+    float g = c[1] < 0 ? 0 : (c[1] > 1 ? 1 : c[1]);
+    float b = c[2] < 0 ? 0 : (c[2] > 1 ? 1 : c[2]);
+    return ((u32)(r * 255.0f + 0.5f) << 16) |
+           ((u32)(g * 255.0f + 0.5f) <<  8) |
+            (u32)(b * 255.0f + 0.5f);
+}
+
+/* Bounding-box scan with the three edge functions; fills when a pixel centre
+ * is on the same side of all three edges, so winding does not matter. */
+static void fill_triangle(const float a[4], const float b[4], const float c[4],
+                          u32 rgb)
+{
+    float ax, ay, bx, by, cx, cy;
+    ndc_to_px(a, &ax, &ay); ndc_to_px(b, &bx, &by); ndc_to_px(c, &cx, &cy);
+
+    float area = (bx - ax) * (cy - ay) - (by - ay) * (cx - ax);
+    if (area == 0.0f) return;                       /* degenerate */
+
+    /* Bounding box. Plain casts truncate toward zero rather than flooring,
+     * which only differs for negative coordinates -- and those clamp to 0 on
+     * the next line anyway. +1 on the max side covers the truncation. Keeps
+     * this file off libm. */
+    float lox = ax < bx ? (ax < cx ? ax : cx) : (bx < cx ? bx : cx);
+    float hix = ax > bx ? (ax > cx ? ax : cx) : (bx > cx ? bx : cx);
+    float loy = ay < by ? (ay < cy ? ay : cy) : (by < cy ? by : cy);
+    float hiy = ay > by ? (ay > cy ? ay : cy) : (by > cy ? by : cy);
+
+    long x0 = (long)lox,       y0 = (long)loy;
+    long x1 = (long)hix + 1,   y1 = (long)hiy + 1;
+    if (x0 < 0) x0 = 0; if (y0 < 0) y0 = 0;
+    if (x1 > (long)s_soft.width)  x1 = (long)s_soft.width;
+    if (y1 > (long)s_soft.height) y1 = (long)s_soft.height;
+
+    for (long y = y0; y < y1; y++) {
+        for (long x = x0; x < x1; x++) {
+            float px = (float)x + 0.5f, py = (float)y + 0.5f;
+            float w0 = (bx - ax) * (py - ay) - (by - ay) * (px - ax);
+            float w1 = (cx - bx) * (py - by) - (cy - by) * (px - bx);
+            float w2 = (ax - cx) * (py - cy) - (ay - cy) * (px - cx);
+            int neg = (w0 < 0) || (w1 < 0) || (w2 < 0);
+            int pos = (w0 > 0) || (w1 > 0) || (w2 > 0);
+            if (neg && pos) continue;               /* outside */
+            s_soft.fb[(u32)y * s_soft.width + (u32)x] = rgb;
+        }
+    }
+}
+
+/* Map sequence position -> guest vertex index, expanding the primitives the
+ * hardware has and a triangle list does not. Returns the triangle count and
+ * writes 3 indices per triangle through `emit`. */
+static void draw_prim(u32 prim, u32 first, u32 count)
+{
+    const rsx_state* st = s_soft.state;
+    if (!st || !s_soft.fb || count < 3) return;
+
+    /* Position is attribute 0 and diffuse colour attribute 3 -- the same slots
+     * the D3D12 and Metal fallback paths assume. */
+    #define TRI(i0, i1, i2) do {                                        \
+        float p0[4], p1[4], p2[4], col[4];                              \
+        rsx_fetch_attrib(st, 0, (i0), p0);                              \
+        rsx_fetch_attrib(st, 0, (i1), p1);                              \
+        rsx_fetch_attrib(st, 0, (i2), p2);                              \
+        rsx_fetch_attrib(st, 3, (i0), col);                             \
+        fill_triangle(p0, p1, p2, colour_of(col));                      \
+    } while (0)
+
+    switch (prim) {
+    case RSX_PRIMITIVE_TRIANGLES:
+        for (u32 i = 0; i + 2 < count; i += 3)
+            TRI(first + i, first + i + 1, first + i + 2);
+        break;
+    case RSX_PRIMITIVE_TRIANGLE_STRIP:
+        for (u32 i = 0; i + 2 < count; i++)
+            TRI(first + i, first + i + 1 + (i & 1), first + i + 2 - (i & 1));
+        break;
+    case RSX_PRIMITIVE_TRIANGLE_FAN:
+    case RSX_PRIMITIVE_POLYGON:
+        for (u32 i = 1; i + 1 < count; i++)
+            TRI(first, first + i, first + i + 1);
+        break;
+    case RSX_PRIMITIVE_QUADS:
+        for (u32 i = 0; i + 3 < count; i += 4) {
+            TRI(first + i, first + i + 1, first + i + 2);
+            TRI(first + i, first + i + 2, first + i + 3);
+        }
+        break;
+    case RSX_PRIMITIVE_QUAD_STRIP:
+        for (u32 i = 0; i + 3 < count; i += 2) {
+            TRI(first + i,     first + i + 1, first + i + 3);
+            TRI(first + i,     first + i + 3, first + i + 2);
+        }
+        break;
+    default:
+        break;   /* points and lines contribute no coverage here */
+    }
+    #undef TRI
+}
+
+static void nullsw_draw_arrays(void* ud, u32 primitive, u32 first, u32 count)
+{
+    (void)ud;
+    draw_prim(primitive, first, count);
+}
+
+static void nullsw_draw_indexed(void* ud, u32 primitive, u32 offset, u32 count)
+{
+    /* ponytail: index buffers are not read; the probe's geometry is
+     * non-indexed. A backend that needs them reads them for real. */
+    (void)ud; (void)primitive; (void)offset; (void)count;
+}
+
+static void nullsw_present(void* ud, u32 buffer_id)
+{
+    (void)ud; (void)buffer_id;
+    if (!s_soft.fb) return;
+    s_soft.last_present =
+        s_soft.fb[(s_soft.height / 2) * s_soft.width + s_soft.width / 2];
+    s_soft.presented++;
+}
+
+static rsx_backend s_nullsw_backend = {
+    .userdata          = &s_soft,
+    .set_render_target = nullsw_set_render_target,
+    .set_vertex_attribs= nullsw_set_vertex_attribs,
+    .clear             = nullsw_clear,
+    .draw_arrays       = nullsw_draw_arrays,
+    .draw_indexed      = nullsw_draw_indexed,
+    .present           = nullsw_present,
+};
 
 int rsx_null_backend_init(u32 width, u32 height, const char* title)
 {
-    (void)width; (void)height; (void)title;
-    printf("[RSX null] Window backend not available on this platform\n");
-    return -1;
+    memset(&s_soft, 0, sizeof(s_soft));
+    s_soft.width  = width  ? width  : 1280;
+    s_soft.height = height ? height : 720;
+    s_soft.fb = (u32*)calloc((size_t)s_soft.width * s_soft.height, sizeof(u32));
+    if (!s_soft.fb) return -1;
+    rsx_set_backend(&s_nullsw_backend);
+    printf("[RSX null] headless software backend %ux%u (%s)\n",
+           s_soft.width, s_soft.height, title ? title : "");
+    return 0;
 }
 
-void rsx_null_backend_shutdown(void) {}
-
-int rsx_null_backend_pump_messages(void)
+void rsx_null_backend_shutdown(void)
 {
-    return 0;
+    rsx_set_backend(NULL);
+    free(s_soft.fb);
+    s_soft.fb = NULL;
+}
+
+/* Headless has no event queue and no window to close. */
+int rsx_null_backend_pump_messages(void) { return 0; }
+
+void rsx_null_backend_present(void) { nullsw_present(NULL, 0); }
+
+u32 rsx_null_backend_debug_color(void) { return s_soft.clear_argb; }
+
+u32 rsx_null_backend_readback_center(void)
+{
+    /* 0 means "nothing presented yet", so give a presented black pixel a
+     * non-zero alpha the way a real drawable readback would. */
+    return s_soft.presented ? (0xFF000000u | s_soft.last_present) : 0u;
 }
 
 #endif /* _WIN32 */

--- a/libs/video/rsx_null_backend.h
+++ b/libs/video/rsx_null_backend.h
@@ -30,8 +30,29 @@ void rsx_null_backend_shutdown(void);
 
 /* Process Win32 messages. Call this from the game's main loop
  * or from a timer/idle callback. Returns 0 normally, -1 if the
- * window was closed. */
+ * window was closed. Headless builds have no event queue and always
+ * return 0. */
 int rsx_null_backend_pump_messages(void);
+
+#ifndef _WIN32
+/* --- headless software build only ---------------------------------------
+ * Off Windows this backend has no window: it renders into a host-memory
+ * framebuffer, which makes it usable on a CI runner with no display and no
+ * GPU. These mirror the Metal backend's test hooks so a host can assert what
+ * actually came out of the guest command stream.
+ * ---------------------------------------------------------------------- */
+
+/* Copy the framebuffer's centre pixel out as the presented frame. */
+void rsx_null_backend_present(void);
+
+/* The clear colour most recently set via NV4097_SET_COLOR_CLEAR_VALUE, in the
+ * RSX's native ARGB8888. Lets a host assert the command stream arrived. */
+u32 rsx_null_backend_debug_color(void);
+
+/* Centre pixel of the last presented frame as 0xFFRRGGBB, or 0 if nothing has
+ * been presented yet. */
+u32 rsx_null_backend_readback_center(void);
+#endif
 
 #ifdef __cplusplus
 }

--- a/libs/video/rsx_texture_layout.c
+++ b/libs/video/rsx_texture_layout.c
@@ -1,0 +1,68 @@
+/*
+ * ps3recomp - RSX texture layout (see rsx_texture_layout.h)
+ */
+#include "rsx_texture_layout.h"
+
+u32 rsx_log2_ceil(u32 v)
+{
+    u32 l = 0;
+    while ((1u << l) < v) l++;
+    return l;
+}
+
+u32 rsx_swizzle_offset(u32 x, u32 y, u32 log2w, u32 log2h)
+{
+    u32 off = 0, shift = 0;
+    while (log2w && log2h) {
+        off |= (x & 1u) << shift; x >>= 1; shift++;
+        off |= (y & 1u) << shift; y >>= 1; shift++;
+        log2w--; log2h--;
+    }
+    off |= (x | y) << shift;     /* only one of x/y still has bits */
+    return off;
+}
+
+void rsx_texture_layout(u32 rsx_fmt, u32 w, u32 h, rsx_tex_layout* out)
+{
+    if (!out) return;
+
+    /* Format classes (base = fmt & 0x9F, masking off the LN/UN flag bits).
+     * The LBP loading screen exercises all of them: 0x85 A8R8G8B8 (swizzled UI
+     * art), 0x8B G8B8 (the 1024x2048 linear font atlas -- without it no text
+     * renders at all), 0x86/87/88 DXT1/23/45 (512x512 detail and LUT layers
+     * bound on every draw). */
+    u32 basef = rsx_fmt & 0x9Fu;
+
+    out->compressed     = 0;
+    out->block_bytes    = 0;
+    out->bytes_per_texel = 1;
+    out->fmt            = RSX_TEXFMT_R8;
+
+    switch (basef) {
+    case 0x85: out->fmt = RSX_TEXFMT_R8G8B8A8; out->bytes_per_texel = 4; break;
+    case 0x8B: out->fmt = RSX_TEXFMT_R8G8;     out->bytes_per_texel = 2; break;
+    case 0x86: out->fmt = RSX_TEXFMT_BC1; out->compressed = 1; out->block_bytes = 8;  break;
+    case 0x87: out->fmt = RSX_TEXFMT_BC2; out->compressed = 1; out->block_bytes = 16; break;
+    case 0x88: out->fmt = RSX_TEXFMT_BC3; out->compressed = 1; out->block_bytes = 16; break;
+    default:   break;   /* R8, one byte per texel -- the pre-existing fallback */
+    }
+
+    if (out->compressed) {
+        /* Compressed data is stored as linear rows of 4x4 blocks, and is never
+         * Morton-swizzled on RSX. */
+        out->bytes_per_texel = 0;
+        out->swizzled = 0;
+        out->row_bytes = ((w + 3u) / 4u) * out->block_bytes;
+        out->rows      = (h + 3u) / 4u;
+    } else {
+        /* Swizzled unless the LN bit is set. The hardware requires power-of-two
+         * dimensions to swizzle, so a NPOT image is linear regardless. */
+        out->swizzled  = !(rsx_fmt & 0x20u) &&
+                         w && h &&
+                         (w & (w - 1u)) == 0u && (h & (h - 1u)) == 0u;
+        out->row_bytes = w * out->bytes_per_texel;
+        out->rows      = h;
+    }
+
+    out->face_bytes = out->row_bytes * out->rows;
+}

--- a/libs/video/rsx_texture_layout.h
+++ b/libs/video/rsx_texture_layout.h
@@ -1,0 +1,72 @@
+/*
+ * ps3recomp - RSX texture layout: format class, sizes, and swizzle addressing
+ *
+ * Working out what shape a guest texture is -- how many bytes a row takes, how
+ * many rows there are, whether the texels are Morton-ordered, where texel
+ * (x, y) actually lives -- is RSX semantics. It has nothing to do with the host
+ * graphics API, which only needs the answers.
+ *
+ * It lived inside rsx_d3d12_backend.c's uploader, which is why the Metal
+ * backend has no textures at all: a second backend cannot sample a guest
+ * texture without first re-deriving all of this. Pulling it out is what makes
+ * that possible without a third copy (see rsx_vertex_fetch.h for how the
+ * second copy of the vertex fetch worked out).
+ *
+ * Scope is the formats the D3D12 backend actually handles today. Everything
+ * else falls back to one byte per texel, exactly as it did before, so an
+ * unrecognised format degrades rather than reading out of bounds.
+ */
+#ifndef PS3RECOMP_RSX_TEXTURE_LAYOUT_H
+#define PS3RECOMP_RSX_TEXTURE_LAYOUT_H
+
+#include "ps3emu/ps3types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Host-neutral format class. A backend maps these to its own enum -- DXGI,
+ * MTLPixelFormat, VkFormat -- rather than each deriving them from the RSX
+ * format byte. */
+typedef enum {
+    RSX_TEXFMT_R8 = 0,   /* B8, and the fallback for anything unrecognised */
+    RSX_TEXFMT_R8G8,     /* G8B8                                          */
+    RSX_TEXFMT_R8G8B8A8, /* A8R8G8B8                                      */
+    RSX_TEXFMT_BC1,      /* DXT1                                          */
+    RSX_TEXFMT_BC2,      /* DXT23                                         */
+    RSX_TEXFMT_BC3       /* DXT45                                         */
+} rsx_texfmt;
+
+typedef struct {
+    rsx_texfmt fmt;
+    int  compressed;      /* block-compressed: rows are rows of 4x4 blocks   */
+    int  swizzled;        /* texels are Morton/Z-ordered, not row-major      */
+    u32  bytes_per_texel; /* 0 when compressed                               */
+    u32  block_bytes;     /* 0 when not compressed (8 for BC1, else 16)      */
+    u32  row_bytes;       /* one texel row, or one block row                 */
+    u32  rows;            /* texel rows, or block rows                       */
+    u32  face_bytes;      /* row_bytes * rows: one face, one mip level       */
+} rsx_tex_layout;
+
+/* Classify `rsx_fmt` (the NV4097 SET_TEXTURE_FORMAT byte) at `w` x `h`.
+ *
+ * `swizzled` is set when the LN bit (0x20) is clear, the format is not
+ * compressed, and both dimensions are powers of two -- the hardware only
+ * swizzles under those conditions, and compressed data is never swizzled.
+ * Treating a swizzled texture as linear is what produced diagonal-stripe
+ * garbage on LBP's loading screen, so the flag is load-bearing. */
+void rsx_texture_layout(u32 rsx_fmt, u32 w, u32 h, rsx_tex_layout* out);
+
+/* Byte offset of texel (x, y) within a swizzled (Morton-ordered) image whose
+ * dimensions are 2^log2w by 2^log2h, in texels -- multiply by bytes_per_texel.
+ * Interleaves the low bits of x and y, then appends whichever axis still has
+ * bits left when the other is exhausted (non-square images). */
+u32 rsx_swizzle_offset(u32 x, u32 y, u32 log2w, u32 log2h);
+
+/* ceil(log2(v)); 0 for v <= 1. */
+u32 rsx_log2_ceil(u32 v);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* PS3RECOMP_RSX_TEXTURE_LAYOUT_H */

--- a/libs/video/rsx_vertex_fetch.c
+++ b/libs/video/rsx_vertex_fetch.c
@@ -1,0 +1,113 @@
+/*
+ * ps3recomp - RSX guest vertex fetch (see rsx_vertex_fetch.h)
+ */
+#include "rsx_vertex_fetch.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern u8* vm_base;
+extern u32 cellGcmResolveOffset(u32);
+extern u32 cellGcmResolveLocated(int, u32);
+
+float rsx_rd_bef(const u8* p)
+{
+    u32 w; memcpy(&w, p, 4);
+    w = ((w >> 24) & 0xFFu) | ((w >> 8) & 0xFF00u) |
+        ((w << 8) & 0xFF0000u) | ((w << 24) & 0xFF000000u);
+    float f; memcpy(&f, &w, 4); return f;
+}
+
+float rsx_rd_half_be(const u8* p)
+{
+    u16 h = (u16)((p[0] << 8) | p[1]);
+    u32 sgn = (h >> 15) & 1u, exp = (h >> 10) & 0x1Fu, man = h & 0x3FFu, f;
+    if (exp == 0)        f = sgn << 31;
+    else if (exp == 31)  f = (sgn << 31) | 0x7F800000u | (man << 13);
+    else                 f = (sgn << 31) | ((exp - 15u + 127u) << 23) | (man << 13);
+    float o; memcpy(&o, &f, 4); return o;
+}
+
+void rsx_fetch_attrib(const rsx_state* st, int idx, u32 vi, float out[4])
+{
+    /* A disabled attribute array feeds the CONSTANT vertex attribute register
+     * (NV4097_SET_VERTEX_DATA4F_M), not zero -- same rule as glColor4f with
+     * the colour array off. Defaulting these to black multiplied Rubber
+     * Ducky's duck texture away in the fragment program. Components the array
+     * does not supply (size < 4) keep the register's value too. */
+    out[0] = st->vertex_data4f[idx][0];
+    out[1] = st->vertex_data4f[idx][1];
+    out[2] = st->vertex_data4f[idx][2];
+    out[3] = st->vertex_data4f[idx][3];
+
+    const rsx_vertex_attrib* a = &st->vertex_attribs[idx];
+    if (!a->enabled || a->stride == 0 || !vm_base) return;
+
+    /* Vertex frequency divisor (instancing). freq 0/1 = per-vertex. For
+     * freq > 1 the element index is either vertex/freq (DIVIDE: per-instance
+     * data advances once per freq verts) or vertex%freq (MODULO: a mesh
+     * repeats every freq verts). NV4097_SET_FREQUENCY_DIVIDER_OPERATION's
+     * per-attribute bit selects MODULO. DeferredShading's cube rings need
+     * this: the shared cube mesh is MODULO, the per-instance transform in
+     * attrib9 is DIVIDE -- without it attrib9 advanced every vertex and the
+     * instanced cubes drew with garbage transforms (only the baseplate,
+     * which isn't instanced, survived). */
+    u32 ei = vi;
+    if (a->frequency > 1) {
+        static int nofreq = -1;                 /* VP_NOFREQ: instancing kill-switch */
+        if (nofreq < 0) nofreq = getenv("VP_NOFREQ") ? 1 : 0;
+        if (!nofreq)
+            ei = (st->frequency_divider_op & (1u << idx))
+                     ? (vi % a->frequency)      /* MODULO: repeat mesh */
+                     : (vi / a->frequency);     /* DIVIDE: per-instance */
+    }
+
+    /* Bit 31 of the vertex-array OFFSET selects the context DMA: 0 = LOCAL
+     * (VRAM), 1 = MAIN (IO-mapped system memory). Resolve LOCAL as local --
+     * routing it through cellGcmResolveOffset lets the IO table win for any
+     * offset whose page the IO region also covers. One title's vertex arrays
+     * sit at offsets like 0x4480, shadowed by its 1MB IO window at 0x11100000:
+     * the array was uploaded to VRAM 0xC0004480 but resolved to main
+     * 0x11104480, which is empty -- so every INDEXED mesh fetched zeros and
+     * collapsed to the origin, while non-indexed geometry whose arrays lie
+     * outside the shadowed pages drew fine. */
+    u32 off = (a->offset & 0x7FFFFFFFu) + ei * a->stride;
+    const u8* p = vm_base + ((a->offset & 0x80000000u)
+        ? cellGcmResolveLocated(0, off)   /* MAIN:  IO offset table          */
+        : cellGcmResolveLocated(1, off)); /* LOCAL: VRAM, never the IO table */
+
+    u32 n = a->size ? a->size : 4; if (n > 4) n = 4;
+    switch (a->type) {
+    case 2: /* CELL_GCM_VERTEX_F: float32 BE */
+        for (u32 k = 0; k < n; k++) out[k] = rsx_rd_bef(p + k * 4);
+        break;
+    case 3: /* SF: half float BE */
+        for (u32 k = 0; k < n; k++) out[k] = rsx_rd_half_be(p + k * 2);
+        break;
+    case 4: /* UB: u8 normalized [0,1] */
+        for (u32 k = 0; k < n; k++) out[k] = p[k] / 255.0f;
+        break;
+    case 1: /* S1: s16 normalized [-1,1] */
+        for (u32 k = 0; k < n; k++) {
+            s16 s = (s16)((p[k*2] << 8) | p[k*2+1]);
+            out[k] = (float)s / 32767.0f;
+        }
+        break;
+    case 5: /* S32K: s16 integer */
+        for (u32 k = 0; k < n; k++)
+            out[k] = (float)(s16)((p[k*2] << 8) | p[k*2+1]);
+        break;
+    case 7: /* UB256: u8 unnormalized */
+        for (u32 k = 0; k < n; k++) out[k] = (float)p[k];
+        break;
+    default:
+        { static int t = -1; if (t < 0) t = getenv("VTX_TYPEDBG") ? 1 : 0;
+          if (t) { static u32 seen = 0;
+              if (!(seen & (1u << (a->type & 31)))) { seen |= 1u << (a->type & 31);
+                  fprintf(stderr, "[VTXTYPE] UNHANDLED type=%u attr=%d size=%u stride=%u\n",
+                          a->type, idx, a->size, a->stride); } } }
+        for (u32 k = 0; k < n; k++) out[k] = rsx_rd_bef(p + k * 4);
+        break;
+    }
+}

--- a/libs/video/rsx_vertex_fetch.c
+++ b/libs/video/rsx_vertex_fetch.c
@@ -7,10 +7,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-extern u8* vm_base;
-extern u32 cellGcmResolveOffset(u32);
-extern u32 cellGcmResolveLocated(int, u32);
-
 float rsx_rd_bef(const u8* p)
 {
     u32 w; memcpy(&w, p, 4);

--- a/libs/video/rsx_vertex_fetch.h
+++ b/libs/video/rsx_vertex_fetch.h
@@ -37,6 +37,20 @@
 extern "C" {
 #endif
 
+/* Guest memory, and the RSX offset -> effective address resolvers.
+ *
+ * Declared here because every backend that reads guest data needs them, and
+ * each one was otherwise carrying its own local `extern` block -- which is how
+ * the Metal backend ended up with a use whose declaration lived inside a
+ * duplicated fetch routine, and lost it when that duplicate was removed.
+ *
+ * location: 0 = MAIN (IO-mapped system memory), 1 = LOCAL (VRAM). Resolving
+ * LOCAL through cellGcmResolveOffset instead lets the IO table shadow it; see
+ * the note on rsx_fetch_attrib below. */
+extern u8* vm_base;
+u32 cellGcmResolveOffset(u32 offset);
+u32 cellGcmResolveLocated(int location, u32 offset);
+
 /* Big-endian scalar reads. Every component in a guest vertex array is stored
  * in the PS3's byte order, so these are the bottom of every fetch path. */
 float rsx_rd_bef(const u8* p);      /* 4-byte IEEE float          */

--- a/libs/video/rsx_vertex_fetch.h
+++ b/libs/video/rsx_vertex_fetch.h
@@ -1,0 +1,60 @@
+/*
+ * ps3recomp - RSX guest vertex fetch
+ *
+ * Reading a vertex out of guest memory is RSX semantics, not host-API
+ * semantics: big-endian components, the NV4097 type encodings, the vertex
+ * frequency divisor, and the context-DMA bit in the array offset. Nothing
+ * about it is specific to D3D12, Metal or anything else.
+ *
+ * It nevertheless existed twice -- once in rsx_d3d12_backend.c and again in
+ * rsx_metal_backend.m, whose header openly said "ported from the D3D12
+ * backend's read_vp_vertex" -- and the two copies had already drifted apart in
+ * two ways that matter:
+ *
+ *   - A DISABLED attribute array must feed the constant vertex attribute
+ *     register (NV4097_SET_VERTEX_DATA4F_M), exactly like glColor4f with the
+ *     colour array switched off. The D3D12 copy learned this the hard way
+ *     (defaulting to black multiplied Rubber Ducky's duck texture away); the
+ *     Metal copy substituted caller-supplied literals and never read the
+ *     register at all.
+ *
+ *   - A LOCAL (VRAM) array offset must resolve as local. Routing it through
+ *     cellGcmResolveOffset lets the IO table win for any offset whose page the
+ *     IO window also covers, and the array silently reads from empty main
+ *     memory. The D3D12 copy resolves LOCAL explicitly; the Metal copy did
+ *     not, which is that bug still sitting there.
+ *
+ * So this is the D3D12 version, which is the one that has met real games,
+ * lifted out to a single definition. A third backend that needs vertices calls
+ * this rather than porting the logic a third time.
+ */
+#ifndef PS3RECOMP_RSX_VERTEX_FETCH_H
+#define PS3RECOMP_RSX_VERTEX_FETCH_H
+
+#include "rsx_commands.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Big-endian scalar reads. Every component in a guest vertex array is stored
+ * in the PS3's byte order, so these are the bottom of every fetch path. */
+float rsx_rd_bef(const u8* p);      /* 4-byte IEEE float          */
+float rsx_rd_half_be(const u8* p);  /* 2-byte IEEE half -> float  */
+
+/* Fetch attribute `idx` (0..15) of vertex `vi` as a float4 into `out`.
+ *
+ * `out` is always fully written: when the attribute's array is disabled or
+ * has a zero stride, it receives the constant vertex attribute register for
+ * that slot, which is what the hardware feeds. Components the attribute does
+ * not supply (size < 4) keep that register's value.
+ *
+ * Handles the frequency divisor (instancing) and resolves the array offset
+ * through the correct context DMA. Reads guest memory; requires vm_base.
+ */
+void rsx_fetch_attrib(const rsx_state* st, int idx, u32 vi, float out[4]);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* PS3RECOMP_RSX_VERTEX_FETCH_H */

--- a/libs/video/tests/test_texture_layout.c
+++ b/libs/video/tests/test_texture_layout.c
@@ -1,0 +1,182 @@
+/*
+ * ps3recomp - self-contained tests for RSX texture layout
+ *
+ * Build and run directly, no framework:
+ *   cc -I include -I libs/video -o /tmp/t libs/video/tests/test_texture_layout.c \
+ *      libs/video/rsx_texture_layout.c && /tmp/t
+ *
+ * The expectations are the behaviour rsx_d3d12_backend.c's uploader had before
+ * the layout maths moved out of it, so this is a regression net for the
+ * extraction as much as a unit test.
+ */
+#include "rsx_texture_layout.h"
+
+#include <stdio.h>
+
+static int g_fail = 0;
+
+#define CHECK(cond)                                                        \
+    do { if (!(cond)) { printf("FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+                        g_fail++; } } while (0)
+
+#define CHECK_EQ(got, want)                                                \
+    do { unsigned long long _g = (unsigned long long)(got),                \
+                            _w = (unsigned long long)(want);               \
+         if (_g != _w) { printf("FAIL %s:%d  %s = %llu, want %llu\n",      \
+                                __FILE__, __LINE__, #got, _g, _w);         \
+                         g_fail++; } } while (0)
+
+/* NV4097 texture format bytes. 0x20 is the LN (linear) flag. */
+#define FMT_A8R8G8B8 0x85u
+#define FMT_G8B8     0x8Bu
+#define FMT_DXT1     0x86u
+#define FMT_DXT23    0x87u
+#define FMT_DXT45    0x88u
+#define FMT_LN       0x20u
+
+static void test_argb(void)
+{
+    rsx_tex_layout L;
+    /* Swizzled UI art: no LN bit, power-of-two dims. */
+    rsx_texture_layout(FMT_A8R8G8B8, 256, 256, &L);
+    CHECK_EQ(L.fmt, RSX_TEXFMT_R8G8B8A8);
+    CHECK_EQ(L.bytes_per_texel, 4);
+    CHECK(!L.compressed);
+    CHECK(L.swizzled);
+    CHECK_EQ(L.row_bytes, 256u * 4u);
+    CHECK_EQ(L.rows, 256);
+    CHECK_EQ(L.face_bytes, 256u * 256u * 4u);
+
+    /* The LN bit turns swizzling off and changes nothing else. */
+    rsx_texture_layout(FMT_A8R8G8B8 | FMT_LN, 256, 256, &L);
+    CHECK(!L.swizzled);
+    CHECK_EQ(L.fmt, RSX_TEXFMT_R8G8B8A8);
+    CHECK_EQ(L.face_bytes, 256u * 256u * 4u);
+
+    /* Non-power-of-two cannot be swizzled even with the LN bit clear -- the
+     * hardware only swizzles POT, and treating NPOT as swizzled would read
+     * the image apart. */
+    rsx_texture_layout(FMT_A8R8G8B8, 100, 100, &L);
+    CHECK(!L.swizzled);
+    CHECK_EQ(L.row_bytes, 400);
+
+    /* One POT axis is not enough. */
+    rsx_texture_layout(FMT_A8R8G8B8, 256, 100, &L);
+    CHECK(!L.swizzled);
+}
+
+static void test_g8b8(void)
+{
+    rsx_tex_layout L;
+    /* The 1024x2048 font atlas: two bytes per texel, linear. */
+    rsx_texture_layout(FMT_G8B8 | FMT_LN, 1024, 2048, &L);
+    CHECK_EQ(L.fmt, RSX_TEXFMT_R8G8);
+    CHECK_EQ(L.bytes_per_texel, 2);
+    CHECK(!L.compressed);
+    CHECK(!L.swizzled);
+    CHECK_EQ(L.row_bytes, 2048);
+    CHECK_EQ(L.rows, 2048);
+    CHECK_EQ(L.face_bytes, 1024u * 2048u * 2u);
+}
+
+static void test_compressed(void)
+{
+    rsx_tex_layout L;
+    /* DXT1: 8-byte blocks, one block row per 4 texel rows. */
+    rsx_texture_layout(FMT_DXT1, 512, 512, &L);
+    CHECK_EQ(L.fmt, RSX_TEXFMT_BC1);
+    CHECK(L.compressed);
+    CHECK_EQ(L.block_bytes, 8);
+    CHECK_EQ(L.bytes_per_texel, 0);
+    CHECK_EQ(L.row_bytes, (512u / 4u) * 8u);
+    CHECK_EQ(L.rows, 512u / 4u);
+    CHECK_EQ(L.face_bytes, (512u / 4u) * 8u * (512u / 4u));
+
+    /* Compressed data is NEVER swizzled, LN bit clear or not. */
+    CHECK(!L.swizzled);
+
+    rsx_texture_layout(FMT_DXT23, 512, 512, &L);
+    CHECK_EQ(L.fmt, RSX_TEXFMT_BC2);
+    CHECK_EQ(L.block_bytes, 16);
+    CHECK_EQ(L.row_bytes, (512u / 4u) * 16u);
+
+    rsx_texture_layout(FMT_DXT45, 64, 32, &L);
+    CHECK_EQ(L.fmt, RSX_TEXFMT_BC3);
+    CHECK_EQ(L.block_bytes, 16);
+    CHECK_EQ(L.rows, 8);
+
+    /* Dimensions that are not a multiple of 4 round UP to whole blocks;
+     * rounding down would truncate the last row and column. */
+    rsx_texture_layout(FMT_DXT1, 10, 10, &L);
+    CHECK_EQ(L.row_bytes, 3u * 8u);
+    CHECK_EQ(L.rows, 3);
+}
+
+static void test_unknown_format_degrades(void)
+{
+    rsx_tex_layout L;
+    /* Anything unrecognised falls back to one byte per texel rather than
+     * guessing wider and reading past the end of guest memory. */
+    rsx_texture_layout(0x81u, 64, 64, &L);
+    CHECK_EQ(L.fmt, RSX_TEXFMT_R8);
+    CHECK_EQ(L.bytes_per_texel, 1);
+    CHECK(!L.compressed);
+    CHECK_EQ(L.face_bytes, 64u * 64u);
+}
+
+static void test_swizzle_offset(void)
+{
+    /* 4x4 Morton order: x and y bits interleave, x first. */
+    CHECK_EQ(rsx_swizzle_offset(0, 0, 2, 2), 0);
+    CHECK_EQ(rsx_swizzle_offset(1, 0, 2, 2), 1);
+    CHECK_EQ(rsx_swizzle_offset(0, 1, 2, 2), 2);
+    CHECK_EQ(rsx_swizzle_offset(1, 1, 2, 2), 3);
+    CHECK_EQ(rsx_swizzle_offset(2, 0, 2, 2), 4);
+    CHECK_EQ(rsx_swizzle_offset(3, 3, 2, 2), 15);
+
+    /* Every texel of a 4x4 image maps to a distinct offset in [0,16). */
+    int seen[16] = {0};
+    for (u32 y = 0; y < 4; y++)
+        for (u32 x = 0; x < 4; x++) {
+            u32 o = rsx_swizzle_offset(x, y, 2, 2);
+            CHECK(o < 16);
+            if (o < 16) { CHECK_EQ(seen[o], 0); seen[o] = 1; }
+        }
+
+    /* Non-square: once the short axis runs out, the long axis's remaining
+     * bits are appended above the interleaved part. */
+    CHECK_EQ(rsx_swizzle_offset(5, 1, 3, 1), 11);
+
+    /* 8x2 covers [0,16) exactly once, same as the square case. */
+    int seen2[16] = {0};
+    for (u32 y = 0; y < 2; y++)
+        for (u32 x = 0; x < 8; x++) {
+            u32 o = rsx_swizzle_offset(x, y, 3, 1);
+            CHECK(o < 16);
+            if (o < 16) { CHECK_EQ(seen2[o], 0); seen2[o] = 1; }
+        }
+}
+
+static void test_log2_ceil(void)
+{
+    CHECK_EQ(rsx_log2_ceil(1), 0);
+    CHECK_EQ(rsx_log2_ceil(2), 1);
+    CHECK_EQ(rsx_log2_ceil(3), 2);   /* ceil, not floor */
+    CHECK_EQ(rsx_log2_ceil(4), 2);
+    CHECK_EQ(rsx_log2_ceil(256), 8);
+    CHECK_EQ(rsx_log2_ceil(1024), 10);
+}
+
+int main(void)
+{
+    test_argb();
+    test_g8b8();
+    test_compressed();
+    test_unknown_format_degrades();
+    test_swizzle_offset();
+    test_log2_ceil();
+
+    if (g_fail) { printf("\nRSX texture layout: %d FAILED\n", g_fail); return 1; }
+    printf("RSX texture layout tests: all passed\n");
+    return 0;
+}

--- a/runtime/host/host_posix.c
+++ b/runtime/host/host_posix.c
@@ -16,7 +16,30 @@
 #include "cellGcmSys.h"
 #include "../memory/vm.h"           /* VM_HLE_INJECT_BASE */
 #include "rsx_commands.h"
-#include "rsx_metal_backend.h"
+
+/* Backend selection. Metal where there is one, otherwise the null backend's
+ * headless software path -- which is what lets this harness run on Linux,
+ * where no real backend exists yet. Both expose the same four entry points
+ * plus the same two test hooks, so the body below is backend-agnostic. */
+#if defined(__APPLE__)
+#  include "rsx_metal_backend.h"
+#  define HOST_BACKEND_NAME     "Metal"
+#  define host_backend_init     rsx_metal_backend_init
+#  define host_backend_shutdown rsx_metal_backend_shutdown
+#  define host_backend_pump     rsx_metal_backend_pump_messages
+#  define host_backend_present  rsx_metal_backend_present
+#  define host_backend_color    rsx_metal_backend_debug_color
+#  define host_backend_center   rsx_metal_backend_readback_center
+#else
+#  include "rsx_null_backend.h"
+#  define HOST_BACKEND_NAME     "null (headless software)"
+#  define host_backend_init     rsx_null_backend_init
+#  define host_backend_shutdown rsx_null_backend_shutdown
+#  define host_backend_pump     rsx_null_backend_pump_messages
+#  define host_backend_present  rsx_null_backend_present
+#  define host_backend_color    rsx_null_backend_debug_color
+#  define host_backend_center   rsx_null_backend_readback_center
+#endif
 
 #include <ps3emu/guest_call.h>
 #include <stdint.h>
@@ -111,11 +134,18 @@ static void upload_triangle(void)
 /* type[3:0]=2 (float32), size[7:4], stride[15:8] */
 #define VFMT(size, stride) (2u | ((u32)(size) << 4) | ((u32)(stride) << 8))
 
+/* Bit 31 of a vertex-array offset selects the context DMA: 0 = LOCAL (VRAM),
+ * 1 = MAIN (IO-mapped system memory). This harness writes its vertices into
+ * the IO window, so they are MAIN and must say so. Leaving the bit clear used
+ * to work by accident: one backend resolved LOCAL through the IO offset table,
+ * which happens to be right for these vertices and wrong for a real title's. */
+#define VTX_MAIN(off)  (0x80000000u | (u32)(off))
+
 static void emit_triangle_draw(void)
 {
-    emit(NV4097_SET_VERTEX_DATA_ARRAY_OFFSET + 0 * 4, VTX_OFFSET +  0);  /* position */
+    emit(NV4097_SET_VERTEX_DATA_ARRAY_OFFSET + 0 * 4, VTX_MAIN(VTX_OFFSET +  0));  /* position */
     emit(NV4097_SET_VERTEX_DATA_ARRAY_FORMAT + 0 * 4, VFMT(4, 32));
-    emit(NV4097_SET_VERTEX_DATA_ARRAY_OFFSET + 3 * 4, VTX_OFFSET + 16);  /* colour   */
+    emit(NV4097_SET_VERTEX_DATA_ARRAY_OFFSET + 3 * 4, VTX_MAIN(VTX_OFFSET + 16));  /* colour   */
     emit(NV4097_SET_VERTEX_DATA_ARRAY_FORMAT + 3 * 4, VFMT(4, 32));
 
     emit(NV4097_SET_BEGIN_END, 5u);                       /* TRIANGLES        */
@@ -150,7 +180,8 @@ int main(int argc, char** argv)
     vm_base = (uint8_t*)calloc(1, VM_SIZE);
     if (!vm_base) { fprintf(stderr, "[host] guest VM alloc failed\n"); return 1; }
 
-    if (rsx_metal_backend_init(1280, 720, "ps3recomp") != 0) {
+    printf("[host] backend: %s\n", HOST_BACKEND_NAME);
+    if (host_backend_init(1280, 720, "ps3recomp") != 0) {
         fprintf(stderr, "[host] backend init failed\n");
         free(vm_base);
         return 1;
@@ -167,7 +198,7 @@ int main(int argc, char** argv)
     if (do_draw) upload_triangle();
     submit_frame(do_draw);
 
-    u32 got = rsx_metal_backend_debug_color();
+    u32 got = host_backend_color();
     printf("[host] clear colour through the FIFO: 0x%08X (expected 0x%08X) %s\n",
            got, CLEAR_ARGB, got == CLEAR_ARGB ? "OK" : "MISMATCH");
 
@@ -175,18 +206,18 @@ int main(int argc, char** argv)
     cellGcmSetFlipCommand(0);
     int presented = 0;
     for (int i = 0; frames == 0 || i < frames; i++) {
-        if (rsx_metal_backend_pump_messages() < 0) { printf("[host] window closed\n"); break; }
+        if (host_backend_pump() < 0) { printf("[host] window closed\n"); break; }
         /* Re-submit every frame, as a title does: the backend records draws
          * per frame and clears the record when it presents. */
         if (i > 0) submit_frame(do_draw);
         cellGcmTickVBlank();
         cellGcmTickFlip();
         if (cellGcm_take_flip_pending_synced()) presented++;
-        rsx_metal_backend_present();
+        host_backend_present();
     }
     printf("[host] presented %d frame(s)\n", presented);
 
-    u32 back = rsx_metal_backend_readback_center();
+    u32 back = host_backend_center();
     int rc = (got == CLEAR_ARGB) ? 0 : 2;
     if (back) {
         /* Headless: the drawable is ours, so verify what actually landed.
@@ -200,7 +231,7 @@ int main(int argc, char** argv)
         if ((back & 0x00FFFFFFu) != (want & 0x00FFFFFFu)) rc = 3;
     }
 
-    rsx_metal_backend_shutdown();
+    host_backend_shutdown();
     free(vm_base);
     return rc;
 }

--- a/runtime/platform/darwin_compat.h
+++ b/runtime/platform/darwin_compat.h
@@ -21,31 +21,6 @@
  * resolution the guest timeout APIs actually express. */
 #define PS3_TIMEDWAIT_POLL_NS  200000L
 
-/* QueryPerformanceCounter/Frequency, for the timing DIAGNOSTICS that measure
- * SPU interpreter throughput. Those call sites are not Windows-specific in
- * intent -- they just used the Win32 clock because that is where they were
- * written -- so shim the three names onto CLOCK_MONOTONIC rather than fence
- * every use site off with #ifdef and lose the diagnostic on macOS.
- *
- * Frequency is reported in nanoseconds so the counter is a plain ns count;
- * callers only ever divide one by the other. */
-typedef struct { long long QuadPart; } PS3_LARGE_INTEGER;
-#define LARGE_INTEGER PS3_LARGE_INTEGER
-
-static inline int QueryPerformanceCounter(PS3_LARGE_INTEGER* v)
-{
-    struct timespec ts;
-    clock_gettime(CLOCK_MONOTONIC, &ts);
-    v->QuadPart = (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec;
-    return 1;
-}
-
-static inline int QueryPerformanceFrequency(PS3_LARGE_INTEGER* v)
-{
-    v->QuadPart = 1000000000LL;
-    return 1;
-}
-
 static inline int ps3__deadline_passed(const struct timespec* abs)
 {
     struct timespec now;

--- a/runtime/platform/win32_backtrace.h
+++ b/runtime/platform/win32_backtrace.h
@@ -1,0 +1,132 @@
+/*
+ * ps3recomp - Win32 host-backtrace API on POSIX
+ *
+ * The PPU boot scaffold is dense with host-side backtrace diagnostics: when a
+ * guest store lands somewhere impossible, or an OPD resolves to nothing, the
+ * only useful question is which lifted function did it, and the answer is the
+ * host call stack at that moment. Those probes are written against
+ * RtlCaptureStackBackTrace and GetModuleHandleA, and they account for the
+ * single largest block of Windows-only symbols in runtime/ppu/ -- around sixty
+ * uses, none of them load-bearing for actually running a game.
+ *
+ * Fencing every one off behind #ifdef _WIN32 would compile, and would also
+ * mean the platform being brought up is the one platform with no way to
+ * diagnose it. So, following runtime/platform/win32_compat.h: supply the names
+ * on POSIX and let the call sites stand.
+ *
+ * The mapping is exact enough for what the probes print, which is always an
+ * RVA -- a frame address minus the image base -- to be fed back through
+ * llvm-symbolizer or addr2line:
+ *
+ *   RtlCaptureStackBackTrace -> backtrace(3)
+ *   GetModuleHandleA(NULL)   -> dladdr(3) on this image, giving its load base
+ *   GetModuleHandleExA(..FROM_ADDRESS..) -> dladdr(3) on the queried address
+ *
+ * A returned HMODULE is therefore a load base, not a Win32 module handle, and
+ * is only ever valid to subtract. That is all the scaffold does with it.
+ *
+ * Kept out of win32_compat.h deliberately. That header is included by library
+ * translation units (cellSpurs.c, cellGcmSys.c, spu_channels.c, lv2_register.c)
+ * and <execinfo.h> does not exist on musl, so folding these in would put a
+ * needless portability floor under the whole runtime for the sake of a
+ * debug-only facility the library never calls.
+ */
+#ifndef PS3RECOMP_WIN32_BACKTRACE_H
+#define PS3RECOMP_WIN32_BACKTRACE_H
+
+#ifdef _WIN32
+
+#ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+#else /* !_WIN32 */
+
+#include <stddef.h>
+#include <stdint.h>   /* uintptr_t, for the function-pointer -> void* cast */
+
+/* backtrace(3) is a glibc/Apple extension; musl ships no <execinfo.h>. Where it
+ * is missing the shims stay, but report an empty stack -- the diagnostics then
+ * print nothing useful instead of failing to build, which is the right trade
+ * for a debug path. */
+#if defined(__GLIBC__) || defined(__APPLE__)
+#  include <execinfo.h>
+#  define PS3_HAVE_BACKTRACE 1
+#else
+#  define PS3_HAVE_BACKTRACE 0
+#endif
+#include <dlfcn.h>
+
+#ifndef PS3_WIN32_TYPES_USHORT
+#define PS3_WIN32_TYPES_USHORT
+typedef unsigned short USHORT;
+#endif
+typedef void*       HMODULE;
+typedef const char* LPCSTR;
+
+/* Only the two flags the scaffold passes. Both are honoured implicitly:
+ * dladdr always resolves from an address and never takes a reference. */
+#define GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT 0x00000002
+#define GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS       0x00000004
+
+/* Load base of the mapped object containing `addr`, or NULL. */
+static inline void* ps3__image_base_of(const void* addr)
+{
+    Dl_info info;
+    if (addr && dladdr(addr, &info) && info.dli_fbase)
+        return info.dli_fbase;
+    return NULL;
+}
+
+/* GetModuleHandleA(NULL) means "the image I am running in". The scaffold never
+ * asks for any other module, so a named lookup would be dead code; resolving
+ * this header's own address gives the right answer and needs no name. */
+static inline HMODULE GetModuleHandleA(LPCSTR name)
+{
+    (void)name;
+    return (HMODULE)ps3__image_base_of((const void*)(uintptr_t)&ps3__image_base_of);
+}
+
+static inline int GetModuleHandleExA(unsigned long flags, LPCSTR addr,
+                                     HMODULE* out)
+{
+    (void)flags;
+    if (!out) return 0;
+    *out = (HMODULE)ps3__image_base_of((const void*)addr);
+    return *out != NULL;   /* nonzero == success, as on Win32 */
+}
+
+/* Win32 counts `skip` from the CALLER of RtlCaptureStackBackTrace; backtrace(3)
+ * starts at itself, so one extra frame comes off the top for this shim. */
+static inline USHORT RtlCaptureStackBackTrace(unsigned long skip,
+                                             unsigned long count,
+                                             void** frames,
+                                             unsigned long* hash)
+{
+    if (hash) *hash = 0;
+    if (!frames || count == 0) return 0;
+#if PS3_HAVE_BACKTRACE
+    enum { PS3_BT_CAP = 160 };   /* deepest in-tree request is 62 + skip */
+    void* raw[PS3_BT_CAP];
+    unsigned long want = skip + count + 1;   /* +1: this frame */
+    if (want > PS3_BT_CAP) want = PS3_BT_CAP;
+
+    int got = backtrace(raw, (int)want);
+    if (got <= 0) return 0;
+
+    unsigned long first = skip + 1;
+    if (first >= (unsigned long)got) return 0;
+
+    unsigned long n = (unsigned long)got - first;
+    if (n > count) n = count;
+    for (unsigned long i = 0; i < n; i++) frames[i] = raw[first + i];
+    return (USHORT)n;
+#else
+    (void)skip; (void)count;
+    return 0;
+#endif
+}
+
+#endif /* _WIN32 */
+#endif /* PS3RECOMP_WIN32_BACKTRACE_H */

--- a/runtime/platform/win32_compat.h
+++ b/runtime/platform/win32_compat.h
@@ -137,6 +137,12 @@ static inline LONG _InterlockedExchangeAdd(volatile LONG* target, LONG value)
     return __atomic_fetch_add(target, value, __ATOMIC_SEQ_CST);
 }
 
+/* Returns the NEW value, unlike the Exchange pair above. */
+static inline LONG InterlockedIncrement(volatile LONG* target)
+{
+    return __atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST);
+}
+
 /* Spin hint: tells the core this is a wait loop, so it can back off rather
  * than burn the pipeline. Purely advisory -- doing nothing is correct, just
  * slower, which is why the fallback is empty rather than a syscall. */

--- a/runtime/platform/win32_compat.h
+++ b/runtime/platform/win32_compat.h
@@ -1,10 +1,17 @@
 /*
- * ps3recomp - Win32 sync/timing compatibility shim for POSIX hosts
+ * ps3recomp - Win32 sync/timing/type compatibility shim for POSIX hosts
  *
- * A handful of translation units were written directly against the Win32
- * synchronisation and timing API (SRWLOCK, CONDITION_VARIABLE, QPC, events).
- * This header supplies those names on POSIX so the call sites compile
- * unchanged. On Windows it is a no-op passthrough to <windows.h>.
+ * A good deal of this tree was written directly against Win32: the
+ * synchronisation and timing API (SRWLOCK, CONDITION_VARIABLE, QPC, events),
+ * the interlocked intrinsics behind the PPU reservation spinlock, and the
+ * scalar typedefs (DWORD, ULONGLONG, SIZE_T, ...) those call sites use. This
+ * header supplies all of it on POSIX so the call sites compile unchanged. On
+ * Windows it is a no-op passthrough to <windows.h>.
+ *
+ * Usable from C AND C++. That is deliberate: the runtime library is C but the
+ * PPU boot scaffold is C++, and both need these names. Nothing in here may use
+ * a C-only construct -- see the note on ps3_lazy_obj below for the one that
+ * did, and how far it got before anyone noticed.
  *
  * IMPORTANT -- storage size. Win32 SRWLOCK and CONDITION_VARIABLE are exactly
  * pointer-sized and zero-initialise validly, so several structs (notably
@@ -26,7 +33,6 @@
 
 #include <pthread.h>
 #include <limits.h>
-#include <stdatomic.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <time.h>
@@ -46,6 +52,10 @@
 typedef uint32_t           DWORD;
 typedef int                BOOL;
 typedef long long          LONGLONG;
+typedef unsigned long long ULONGLONG;
+typedef long               LONG;
+typedef unsigned long      ULONG;
+typedef size_t             SIZE_T;
 typedef void*              HANDLE;
 typedef union { LONGLONG QuadPart; } LARGE_INTEGER;
 
@@ -55,20 +65,25 @@ typedef void*  CONDITION_VARIABLE;
 #define SRWLOCK_INIT            NULL
 #define CONDITION_VARIABLE_INIT NULL
 
-/* --- lazy, race-free materialisation of the pthread object into a void* slot -- */
+/* --- lazy, race-free materialisation of the pthread object into a void* slot --
+ *
+ * __atomic builtins rather than C11 <stdatomic.h>: _Atomic and
+ * atomic_load_explicit are C-only spellings, so the C11 version restricted
+ * this whole header to .c files. The PPU boot scaffold is C++, and including
+ * it from there failed under GCC (Clang accepts _Atomic in C++ as an
+ * extension, which is exactly the kind of difference that hides until the
+ * other compiler tries). The builtins mean the same thing in both languages. */
 static inline void* ps3_lazy_obj(void** slot, size_t sz,
                                  void (*init)(void*))
 {
-    _Atomic(void*)* a = (_Atomic(void*)*)slot;
-    void* cur = atomic_load_explicit(a, memory_order_acquire);
+    void* cur = __atomic_load_n(slot, __ATOMIC_ACQUIRE);
     if (cur) return cur;
     void* fresh = calloc(1, sz);
     if (!fresh) return NULL;
     init(fresh);
     void* expected = NULL;
-    if (atomic_compare_exchange_strong_explicit(a, &expected, fresh,
-                                                memory_order_acq_rel,
-                                                memory_order_acquire))
+    if (__atomic_compare_exchange_n(slot, &expected, fresh, 0 /* strong */,
+                                    __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE))
         return fresh;
     free(fresh);                 /* lost the race; use the winner's object */
     return expected;
@@ -105,6 +120,33 @@ static inline BOOL SleepConditionVariableSRW(CONDITION_VARIABLE* c, SRWLOCK* l,
     ts.tv_nsec += (long)(ms % 1000u) * 1000000L;
     if (ts.tv_nsec >= 1000000000L) { ts.tv_sec++; ts.tv_nsec -= 1000000000L; }
     return pthread_cond_timedwait(cv, mx, &ts) == 0;
+}
+
+/* --- interlocked ops and the spin hint ------------------------------------
+ * The PPU reservation slots (lwarx/stwcx) are guarded by an open-coded
+ * spinlock written against the MSVC intrinsics. Both are plain sequentially
+ * consistent RMWs, which is exactly what the __atomic builtins give, and both
+ * return the PREVIOUS value the way the Win32 ones do. */
+static inline LONG _InterlockedExchange(volatile LONG* target, LONG value)
+{
+    return __atomic_exchange_n(target, value, __ATOMIC_SEQ_CST);
+}
+
+static inline LONG _InterlockedExchangeAdd(volatile LONG* target, LONG value)
+{
+    return __atomic_fetch_add(target, value, __ATOMIC_SEQ_CST);
+}
+
+/* Spin hint: tells the core this is a wait loop, so it can back off rather
+ * than burn the pipeline. Purely advisory -- doing nothing is correct, just
+ * slower, which is why the fallback is empty rather than a syscall. */
+static inline void YieldProcessor(void)
+{
+#if defined(__x86_64__) || defined(__i386__)
+    __builtin_ia32_pause();
+#elif defined(__aarch64__) || defined(__arm__)
+    __asm__ __volatile__("yield" ::: "memory");
+#endif
 }
 
 /* --- timing ------------------------------------------------------------- */

--- a/runtime/platform/win32_compat.h
+++ b/runtime/platform/win32_compat.h
@@ -30,6 +30,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <time.h>
+#include <unistd.h>
+#include <sys/syscall.h>
 
 #ifndef FALSE
 #  define FALSE 0
@@ -116,11 +118,26 @@ static inline unsigned long long GetTickCount64(void) { return ps3__mono_ns() / 
 static inline BOOL QueryPerformanceFrequency(LARGE_INTEGER* f) { f->QuadPart = 1000000000LL; return TRUE; }
 static inline BOOL QueryPerformanceCounter  (LARGE_INTEGER* c) { c->QuadPart = (LONGLONG)ps3__mono_ns(); return TRUE; }
 
+/* A stable, per-thread integer id. Only ever logged or hashed, never handed
+ * back to the OS, so any injective-per-thread value will do. Darwin and Linux
+ * both offer the real kernel tid, which is what a debugger and the guest-side
+ * logs show; elsewhere pthread_self is the only portable handle there is.
+ *
+ * pthread_threadid_np is Darwin-only. Calling it unguarded built fine under
+ * GCC -- an implicit declaration into a static archive, which links nothing --
+ * and only failed once Clang rejected it. Hence the CI symbol check. */
 static inline DWORD GetCurrentThreadId(void)
 {
+#if defined(__APPLE__)
     uint64_t tid = 0;
-    pthread_threadid_np(NULL, &tid);      /* Darwin; see below for other POSIX */
+    pthread_threadid_np(NULL, &tid);
     return (DWORD)tid;
+#elif defined(__linux__)
+    /* Not gettid(3): that wrapper only appeared in glibc 2.30. */
+    return (DWORD)syscall(SYS_gettid);
+#else
+    return (DWORD)(uintptr_t)pthread_self();
+#endif
 }
 
 /* --- auto-reset event (only the create/set/wait subset used in-tree) ------ */

--- a/runtime/platform/win32_dirent.h
+++ b/runtime/platform/win32_dirent.h
@@ -1,0 +1,97 @@
+/*
+ * ps3recomp - <dirent.h> for Windows
+ *
+ * runtime/ppu/ppu_fs.cpp walks host directories with the POSIX API --
+ * opendir/readdir/closedir -- to answer the guest's cellFsOpendir. MSVC ships
+ * no <dirent.h>, so that file did not compile on Windows without help, and
+ * every game port quietly carried its own copy of a Win32 shim on the include
+ * path to get past it. Putting one here deletes that copy from all of them.
+ *
+ * On POSIX this is just the system header, so call sites include this and stop
+ * thinking about it.
+ *
+ * Scope is deliberately the four names ppu_fs.cpp actually uses, with d_name
+ * as the only dirent field: no d_type, no rewinddir/seekdir/telldir, no
+ * wide-character variant. FindFirstFileA reports "." and ".." exactly as
+ * readdir does, so the caller's skip logic needs no special case.
+ */
+#ifndef PS3RECOMP_WIN32_DIRENT_H
+#define PS3RECOMP_WIN32_DIRENT_H
+
+#ifndef _WIN32
+
+#include <dirent.h>
+
+#else
+
+#ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct dirent {
+    char d_name[MAX_PATH];
+};
+
+typedef struct DIR {
+    HANDLE           h;
+    WIN32_FIND_DATAA fd;
+    int              pending;   /* FindFirstFile already produced an entry */
+    struct dirent    ent;
+} DIR;
+
+static inline DIR* opendir(const char* path)
+{
+    if (!path || !*path) return NULL;
+
+    size_t n = strlen(path);
+    char*  pattern = (char*)malloc(n + 3);   /* + "\*" + NUL */
+    if (!pattern) return NULL;
+    memcpy(pattern, path, n);
+    /* Tolerate a trailing separator: "dir/" and "dir" must both work. Appending
+     * blindly would produce a doubled separator before the wildcard, which
+     * matches nothing. */
+    if (n && (pattern[n - 1] == '/' || pattern[n - 1] == '\\')) n--;
+    pattern[n]     = '\\';
+    pattern[n + 1] = '*';
+    pattern[n + 2] = '\0';
+
+    DIR* d = (DIR*)calloc(1, sizeof(DIR));
+    if (!d) { free(pattern); return NULL; }
+
+    d->h = FindFirstFileA(pattern, &d->fd);
+    free(pattern);
+    if (d->h == INVALID_HANDLE_VALUE) { free(d); return NULL; }
+
+    d->pending = 1;
+    return d;
+}
+
+static inline struct dirent* readdir(DIR* d)
+{
+    if (!d || d->h == INVALID_HANDLE_VALUE) return NULL;
+
+    if (d->pending) d->pending = 0;
+    else if (!FindNextFileA(d->h, &d->fd)) return NULL;
+
+    /* memcpy rather than strncpy: both buffers are MAX_PATH and cFileName is
+     * already NUL-terminated, and strncpy is deprecated by the CRT. */
+    size_t n = strlen(d->fd.cFileName);
+    if (n >= sizeof d->ent.d_name) n = sizeof d->ent.d_name - 1;
+    memcpy(d->ent.d_name, d->fd.cFileName, n);
+    d->ent.d_name[n] = '\0';
+    return &d->ent;
+}
+
+static inline int closedir(DIR* d)
+{
+    if (!d) return -1;
+    if (d->h != INVALID_HANDLE_VALUE) FindClose(d->h);
+    free(d);
+    return 0;
+}
+
+#endif /* _WIN32 */
+#endif /* PS3RECOMP_WIN32_DIRENT_H */

--- a/runtime/ppu/ppu_context.h
+++ b/runtime/ppu/ppu_context.h
@@ -17,6 +17,19 @@
 extern "C" {
 #endif
 
+/* Thread-local storage qualifier. Defined identically in the lifter's
+ * HEADER_PREAMBLE (tools/ppu_lifter.py), which this header is already kept
+ * in sync with -- code reaches one or the other depending on whether it
+ * built against a generated ppu_recomp.h. The #ifndef makes including both
+ * harmless. */
+#ifndef PPU_THREAD_LOCAL
+#  ifdef _MSC_VER
+#    define PPU_THREAD_LOCAL __declspec(thread)
+#  else
+#    define PPU_THREAD_LOCAL __thread
+#  endif
+#endif
+
 /* ---------------------------------------------------------------------------
  * Condition Register field -- 4 bits: LT, GT, EQ, SO
  * -----------------------------------------------------------------------*/

--- a/runtime/ppu/ppu_fs.cpp
+++ b/runtime/ppu/ppu_fs.cpp
@@ -21,7 +21,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <sys/stat.h>
-#include <dirent.h>
+#include "../platform/win32_dirent.h"   /* <dirent.h>, or a Win32 stand-in */
 
 /* Guest-resolving host backtrace (ppu_loader.cpp). Must be declared at file scope:
  * `extern "C"` inside a function body is ill-formed in C++. */

--- a/runtime/ppu/ppu_fs.cpp
+++ b/runtime/ppu/ppu_fs.cpp
@@ -41,8 +41,7 @@ extern "C" uint32_t ppu_vm_size;
 extern "C" void     ps3_hle_register_ctx(uint32_t nid, const char* name, void (*fn)(ppu_context*));
 extern "C" void     vm_write32(uint64_t a, uint32_t v);
 extern "C" void     vm_write64(uint64_t a, uint64_t v);
-extern "C" char __ImageBase;
-extern "C" unsigned short __stdcall RtlCaptureStackBackTrace(unsigned long,unsigned long,void**,unsigned long*);
+#include "../platform/win32_backtrace.h"   /* RtlCaptureStackBackTrace / GetModuleHandleA on POSIX */
 
 /* Host root that the PS3 mount points map into (dir containing PS3_GAME). */
 extern "C" const char* ppu_vfs_root = ".";
@@ -327,7 +326,7 @@ static void cellFsRead(ppu_context* ctx)
     if (g_fd_usm[fd] && getenv("YDKJ_USMRD")) fprintf(stderr, "[USMRD] READ usm fd=%d nbytes=%llu -> %zu magic=%02X%02X%02X%02X pos=%ld lr=0x%08X\n", fd, (unsigned long long)nbytes, n, vm_base[buf], vm_base[buf+1], vm_base[buf+2], vm_base[buf+3], fpos_before, (uint32_t)ctx->lr);
     if (getenv("YDKJ_FSDBG")) { static int _fd=0; if(_fd++<20) fprintf(stderr,"[FSDBG] fd=%d raw_nbytes=0x%llX clamped=0x%llX buf=0x%08X fpos_before=%ld n=%zu eof=%d err=%d\n", fd,(unsigned long long)raw_nbytes,(unsigned long long)nbytes,buf,fpos_before,n,feof(g_files[fd]),ferror(g_files[fd])); }
 #ifdef _WIN32
-    if (getenv("YDKJ_FSDBG") && buf==0 && raw_nbytes>0x10000) { static int _b=0; if(_b++<2){ void* fr[30]; unsigned short nn=RtlCaptureStackBackTrace(0,30,fr,0); uintptr_t mb=(uintptr_t)&__ImageBase; fprintf(stderr,"[FSBT] null-buf read caller rvas:"); for(unsigned short i=0;i<nn&&i<16;i++) fprintf(stderr," %llX",(unsigned long long)((uintptr_t)fr[i]-mb)); fprintf(stderr,"\n"); } }
+    if (getenv("YDKJ_FSDBG") && buf==0 && raw_nbytes>0x10000) { static int _b=0; if(_b++<2){ void* fr[30]; unsigned short nn=RtlCaptureStackBackTrace(0,30,fr,0); uintptr_t mb=(uintptr_t)GetModuleHandleA(0); fprintf(stderr,"[FSBT] null-buf read caller rvas:"); for(unsigned short i=0;i<nn&&i<16;i++) fprintf(stderr," %llX",(unsigned long long)((uintptr_t)fr[i]-mb)); fprintf(stderr,"\n"); } }
 #endif
     { static uint64_t tot=0; static int _n=0; tot+=n; if(_n++<50) fprintf(stderr,"[fs] read fd=%d nbytes=%llu -> %zu (magic=%02X%02X%02X%02X, total=%llu)\n",fd,(unsigned long long)nbytes,n,vm_base[buf],vm_base[buf+1],vm_base[buf+2],vm_base[buf+3],(unsigned long long)tot); }
     if (getenv("YDKJ_TOCTRACE") && nbytes >= 50000) {  /* data.toc read -> who parses it? */

--- a/runtime/ppu/ppu_hle.cpp
+++ b/runtime/ppu/ppu_hle.cpp
@@ -102,8 +102,7 @@ extern "C" uint64_t ppu_guest_call(uint32_t opd,
                                     uint64_t a4, uint64_t a5, uint64_t a6, uint64_t a7);
 /* Weak: builds that don't link cellGcmSys.c (test harnesses) get a null and skip. */
 extern "C" __attribute__((weak)) void ppu_gcm_pump(void);
-extern "C" __declspec(dllimport) void* __stdcall GetModuleHandleA(const char*);
-static inline void* ps3_GetModuleHandleA(const char* m){ return GetModuleHandleA(m); }
+#include "../platform/win32_backtrace.h"   /* RtlCaptureStackBackTrace / GetModuleHandleA on POSIX */
 
 /* An unresolved NID is a firmware import we never registered. Returning
  * CELL_OK "so the game keeps going" is the single biggest source of
@@ -231,7 +230,6 @@ extern "C" void ps3_hle_call(uint32_t nid, ppu_context* ctx)
       if(_bl && nid==0x1573DC3Fu){ uint32_t r3=(uint32_t)ctx->gpr[3];
         if(r3<0x00010000u || r3>=0x80000000u){ static int _n=0; if(_n++<3){
 #ifdef _WIN32
-          extern unsigned short __stdcall RtlCaptureStackBackTrace(unsigned long,unsigned long,void**,unsigned long*);
           void* bt[44]; unsigned short fr=RtlCaptureStackBackTrace(0,44,bt,0);
           (void)bt;(void)fr;
           /* Guest-stack code-ptr scan (EXACT: a lifted func name IS its guest addr) —
@@ -285,9 +283,7 @@ extern "C" void ps3_hle_call(uint32_t nid, ppu_context* ctx)
               if(v!=prev){ p+=snprintf(b+p,sizeof(b)-p," %08X",v); prev=v; found++; } } }
           fprintf(stderr,"%s\n",b); }
 #ifdef _WIN32
-        { extern unsigned short __stdcall RtlCaptureStackBackTrace(unsigned long,unsigned long,void**,unsigned long*);
-          extern void* __stdcall GetModuleHandleA(const char*);
-          void* bt[40]; unsigned short fr=RtlCaptureStackBackTrace(0,40,bt,0);
+        { void* bt[40]; unsigned short fr=RtlCaptureStackBackTrace(0,40,bt,0);
           char* mb=(char*)GetModuleHandleA(0); char line[1100]; int p=snprintf(line,sizeof line,"[exit-chain] HOST-bt rva:");
           for(int i=0;i<fr;i++) p+=snprintf(line+p,sizeof(line)-p," %llX",(unsigned long long)((char*)bt[i]-mb));
           fprintf(stderr,"%s\n",line); }
@@ -301,7 +297,7 @@ extern "C" void ps3_hle_call(uint32_t nid, ppu_context* ctx)
      * loads (the C++ ctor list, globals, ...) read garbage -> boot corruption. */
     { static int _h=-1; if(_h<0)_h=getenv("FLOW_HLETOC")?1:0;
       if(_h && (uint32_t)(ctx->gpr[1]+0x28)==0x0FEFF268u){ static int _n=0; if(_n++<6){
-        char* mb=(char*)ps3_GetModuleHandleA(0); void* ra0=__builtin_return_address(0); void* ra1=__builtin_return_address(1);
+        char* mb=(char*)GetModuleHandleA(0); void* ra0=__builtin_return_address(0); void* ra1=__builtin_return_address(1);
         fprintf(stderr,"[HLETOC] corrupt nid=0x%08X name=%s r1=0x%08X  host_ra0_rva=0x%llX ra1_rva=0x%llX\n",
           nid,g_last_hle_name?g_last_hle_name:"?",(uint32_t)ctx->gpr[1],
           (unsigned long long)((char*)ra0-mb),(unsigned long long)((char*)ra1-mb)); } } }

--- a/runtime/ppu/ppu_loader.cpp
+++ b/runtime/ppu/ppu_loader.cpp
@@ -22,6 +22,11 @@
 #include "../memory/vm.h"   /* vm_commit -- sys_mmapper_search_and_map maps for real */
 #include "../platform/win32_compat.h"      /* Win32 types, interlocked ops, Sleep/QPC on POSIX */
 #include "../platform/win32_backtrace.h"   /* RtlCaptureStackBackTrace / GetModuleHandleA on POSIX */
+#ifndef _WIN32
+#include <sys/mman.h>   /* the guest-pointer trap reserves the low 4 GB */
+#include <signal.h>
+#include <unistd.h>
+#endif
 extern "C" uint32_t ppu_prof_resolve_host(void* ra);
 
 /* Resolve the GUEST function on the host stack (closest lifted entry below
@@ -66,26 +71,40 @@ extern "C" void ppu_guest_caller(char* out, size_t n)
  * Deliberately does NOT swallow the exception: it reports and lets the normal
  * handling proceed, so a real bug still stops the run.
  * -----------------------------------------------------------------------*/
+/* The report is identical on both platforms; only the trap mechanism differs
+ * (vectored exception handler vs sigaction, VirtualAlloc vs mmap). Written
+ * once so the two cannot drift apart. */
+static void ps3_report_guest_ptr(uintptr_t at, const char* how)
+{
+    static LONG n = 0;
+    if (InterlockedIncrement(&n) > 32) return;
+    char who[64]; ppu_guest_caller(who, sizeof who);
+    fprintf(stderr,
+            "\n[ps3] UNTRANSLATED GUEST POINTER: %s of guest 0x%08X as a host "
+            "address\n      (an HLE function dereferenced a pointer parameter without "
+            "vm_base)\n      guest caller: %s\n", how, (uint32_t)at, who);
+    fflush(stderr);
+}
+
+/* Guest addresses worth reporting: above the first page (a plain NULL deref is
+ * someone else's bug) and below 4 GB. */
+static inline int ps3_is_guest_ptr_fault(uintptr_t at)
+{
+    return at >= 0x10000u && at < 0x100000000ull;
+}
+
+#ifdef _WIN32
+
 static LONG WINAPI ps3_guest_ptr_veh(EXCEPTION_POINTERS* ep)
 {
     const EXCEPTION_RECORD* er = ep->ExceptionRecord;
     if (er->ExceptionCode != EXCEPTION_ACCESS_VIOLATION ||
         er->NumberParameters < 2) return EXCEPTION_CONTINUE_SEARCH;
     uintptr_t at = (uintptr_t)er->ExceptionInformation[1];
-    if (at >= 0x100000000ull) return EXCEPTION_CONTINUE_SEARCH;   /* not a guest addr */
-    if (at < 0x10000u) return EXCEPTION_CONTINUE_SEARCH;          /* a plain NULL deref */
+    if (!ps3_is_guest_ptr_fault(at)) return EXCEPTION_CONTINUE_SEARCH;
 
-    static LONG n = 0;
-    if (InterlockedIncrement(&n) <= 32) {
-        char who[64]; ppu_guest_caller(who, sizeof who);
-        const char* how = er->ExceptionInformation[0] == 0 ? "read"
-                        : er->ExceptionInformation[0] == 1 ? "write" : "execute";
-        fprintf(stderr,
-                "\n[ps3] UNTRANSLATED GUEST POINTER: %s of guest 0x%08X as a host "
-                "address\n      (an HLE function dereferenced a pointer parameter without "
-                "vm_base)\n      guest caller: %s\n", how, (uint32_t)at, who);
-        fflush(stderr);
-    }
+    ps3_report_guest_ptr(at, er->ExceptionInformation[0] == 0 ? "read"
+                           : er->ExceptionInformation[0] == 1 ? "write" : "execute");
     return EXCEPTION_CONTINUE_SEARCH;
 }
 
@@ -105,6 +124,86 @@ extern "C" void ps3_install_guest_ptr_trap(void)
     fprintf(stderr, "[ps3] guest-pointer trap armed (%zu MB of the low 4 GB reserved)\n",
             got >> 20);
 }
+
+#else  /* POSIX */
+
+static struct sigaction s_prev_segv;
+static int              s_prev_segv_valid = 0;
+
+/* Not async-signal-safe, and deliberately so: this runs on a path that is about
+ * to end the process anyway, and the whole value of the report is the guest
+ * function name -- which means walking the stack and formatting. The Windows
+ * handler makes exactly the same trade. */
+static void ps3_guest_ptr_sigsegv(int sig, siginfo_t* si, void* uctx)
+{
+    if (si && ps3_is_guest_ptr_fault((uintptr_t)si->si_addr)) {
+        /* si_code separates unmapped from protected, not read from write, so
+         * unlike the Windows report this cannot name the direction without
+         * decoding a machine-specific trap frame. The address and the guest
+         * caller are what actually locate the bug. */
+        ps3_report_guest_ptr((uintptr_t)si->si_addr, "access");
+    }
+
+    /* Do NOT swallow it, matching the Windows handler: hand back to whoever was
+     * installed before, or restore the default so the faulting instruction
+     * re-runs and the process dies exactly as it would have. */
+    if (s_prev_segv_valid) {
+        if ((s_prev_segv.sa_flags & SA_SIGINFO) && s_prev_segv.sa_sigaction) {
+            s_prev_segv.sa_sigaction(sig, si, uctx);
+            return;
+        }
+        if (s_prev_segv.sa_handler && s_prev_segv.sa_handler != SIG_DFL &&
+            s_prev_segv.sa_handler != SIG_IGN) {
+            s_prev_segv.sa_handler(sig);
+            return;
+        }
+    }
+    struct sigaction dfl;
+    memset(&dfl, 0, sizeof dfl);
+    dfl.sa_handler = SIG_DFL;
+    sigemptyset(&dfl.sa_mask);
+    sigaction(sig, &dfl, NULL);
+}
+
+extern "C" void ps3_install_guest_ptr_trap(void)
+{
+    if (getenv("PS3_NO_GUEST_PTR_TRAP")) return;
+
+    /* Leave the chunk holding the program break alone. Reserving the space just
+     * above it would stop brk from ever growing and silently push every small
+     * allocation onto mmap -- a steep price for a diagnostic. */
+    uintptr_t brk_now = (uintptr_t)sbrk(0);
+
+    size_t got = 0;
+    for (uintptr_t a = 0x10000u; a < 0x100000000ull; a += 0x10000000ull) {
+        size_t len = 0x10000000u;
+        if (a == 0x10000u) len -= 0x10000u;
+        if (brk_now >= a && brk_now < a + len) continue;
+
+        int flags = MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE;
+#ifdef MAP_FIXED_NOREPLACE
+        flags |= MAP_FIXED_NOREPLACE;   /* fail rather than evict a live mapping */
+#endif
+        void* at = mmap((void*)a, len, PROT_NONE, flags, -1, 0);
+        if (at == MAP_FAILED) continue;                 /* chunk already in use */
+        if ((uintptr_t)at != a) { munmap(at, len); continue; }  /* hint ignored */
+        got += len;
+    }
+
+    /* PROT_NONE faults arrive as SIGSEGV on both Linux and Darwin; SIGBUS is for
+     * mapped-but-unbacked access, which this scheme never produces. */
+    struct sigaction sa;
+    memset(&sa, 0, sizeof sa);
+    sa.sa_sigaction = ps3_guest_ptr_sigsegv;
+    sa.sa_flags     = SA_SIGINFO;
+    sigemptyset(&sa.sa_mask);
+    if (sigaction(SIGSEGV, &sa, &s_prev_segv) == 0) s_prev_segv_valid = 1;
+
+    fprintf(stderr, "[ps3] guest-pointer trap armed (%zu MB of the low 4 GB reserved)\n",
+            got >> 20);
+}
+
+#endif /* _WIN32 */
 
 /* PS3_SCTRACE=1: every lv2 syscall with its arguments and RETURN VALUE.
  * An unimplemented syscall is loud (it logs "(stub)") but an IMPLEMENTED one

--- a/runtime/ppu/ppu_loader.cpp
+++ b/runtime/ppu/ppu_loader.cpp
@@ -20,6 +20,7 @@
 
 #include "ppu_recomp.h"     /* ppu_context, func decls, ppu_recomp_register */
 #include "../memory/vm.h"   /* vm_commit -- sys_mmapper_search_and_map maps for real */
+#include "../platform/win32_backtrace.h"   /* RtlCaptureStackBackTrace / GetModuleHandleA on POSIX */
 extern "C" uint32_t ppu_prof_resolve_host(void* ra);
 
 /* Resolve the GUEST function on the host stack (closest lifted entry below

--- a/runtime/ppu/ppu_loader.cpp
+++ b/runtime/ppu/ppu_loader.cpp
@@ -15,7 +15,7 @@
  * Game-agnostic: works on any decrypted PS3 PPU ELF. `vm_base` is owned by the
  * host (allocated large enough to cover the highest segment vaddr+memsz).
  *
- * Compiled as C++ to match the lifted output's `extern "C"` / __declspec(thread).
+ * Compiled as C++ to match the lifted output's `extern "C"` / PPU_THREAD_LOCAL.
  */
 
 #include "ppu_recomp.h"     /* ppu_context, func decls, ppu_recomp_register */
@@ -180,7 +180,7 @@ extern "C" void ppu_log_host_chain(const char* tag);  /* fwd decl (defined below
  * reservation semantics. stwcx is a sync point (rare vs vm_write), so a single
  * lock is cheap enough; shard by address later if it shows up in a profile.
  * -----------------------------------------------------------------------*/
-extern "C" __declspec(thread) ppu_context* g_active_ctx;   /* fwd (defined below) */
+extern "C" PPU_THREAD_LOCAL ppu_context* g_active_ctx;   /* fwd (defined below) */
 #define PPU_RESV_MAX 128
 #define PPU_RESV_INVALID 0x100000000ull   /* out of (uint32_t) ea range */
 static ppu_context* g_resv_ctxs[PPU_RESV_MAX];
@@ -458,11 +458,11 @@ static void vm_hotmap(uint32_t ea, int width)
         for (uint32_t i = 0; i < NB; i++) cnt[i] = 0;
     }
 }
-extern "C" __declspec(thread) ppu_context* g_active_ctx;  /* fwd decl (defined below) */
+extern "C" PPU_THREAD_LOCAL ppu_context* g_active_ctx;  /* fwd decl (defined below) */
 /* Tracks the most recent vm_read32 {addr,value} on this thread, so FLOW_WVAL can
  * report the SOURCE a copied value came from (poison propagation vs true origin). */
-static __declspec(thread) uint32_t g_last_rd_addr = 0;
-static __declspec(thread) uint32_t g_last_rd_val  = 0;
+static PPU_THREAD_LOCAL uint32_t g_last_rd_addr = 0;
+static PPU_THREAD_LOCAL uint32_t g_last_rd_val  = 0;
 /* PT=<hex>: persistent high-byte truncation detector. A write8 that turns the word
  * at some addr into <hex> (e.g. a heap ptr 0x471057A0 zeroed to 0x001057A0) is BENIGN
  * if the word is later restored to a full pointer; it is the BUG if the truncated
@@ -491,8 +491,8 @@ static void pt_restore(uint32_t addr) { for (int i=0;i<g_pt_n;i++) if (g_pt_addr
 #endif
 /* Stack of currently-executing indirect-call (vtable) targets on this thread, so a
  * write hook can name the virtual method that is running when it writes a value. */
-static __declspec(thread) uint32_t g_vcall_stk[128];
-static __declspec(thread) int      g_vcall_sp = 0;
+static PPU_THREAD_LOCAL uint32_t g_vcall_stk[128];
+static PPU_THREAD_LOCAL int      g_vcall_sp = 0;
 extern "C" {
 uint8_t  vm_read8 (uint64_t a) { if (vm_oob((uint32_t)a,1)) return 0; vm_hotmap((uint32_t)a,1);
     /* YDKJ_LV2_SAT (diagnostic): the game polls 0x00543580 ("Continue... (Lv-2 is
@@ -504,7 +504,7 @@ uint8_t  vm_read8 (uint64_t a) { if (vm_oob((uint32_t)a,1)) return 0; vm_hotmap(
 #ifdef VM_SAMPLE_READS
     { static uint64_t c=0; if ((++c % 2000000ull)==0) fprintf(stderr, "[sample] read8  0x%08X ra0=%p ra1=%p\n", (uint32_t)a, __builtin_return_address(0), __builtin_return_address(1)); }
 #endif
-    { static __declspec(thread) uint32_t last=0xFFFFFFFFu; static __declspec(thread) uint32_t n=0;
+    { static PPU_THREAD_LOCAL uint32_t last=0xFFFFFFFFu; static PPU_THREAD_LOCAL uint32_t n=0;
       if ((uint32_t)a==last) { if (++n==200000) {
           fprintf(stderr, "[HOTREAD8] spinning on 0x%08X val=0x%02X tid=%lu guest-fn=0x%08X\n",
                   (uint32_t)a, vm_base[(uint32_t)a], GetCurrentThreadId(),
@@ -513,7 +513,7 @@ uint8_t  vm_read8 (uint64_t a) { if (vm_oob((uint32_t)a,1)) return 0; vm_hotmap(
       else { last=(uint32_t)a; n=0; } }
     return vm_base[(uint32_t)a]; }
 uint16_t vm_read16(uint64_t a) { if (vm_oob((uint32_t)a,2)) return 0; vm_hotmap((uint32_t)a,2); uint16_t v; memcpy(&v, vm_base + (uint32_t)a, 2);
-    { static __declspec(thread) uint32_t last=0xFFFFFFFFu; static __declspec(thread) uint32_t n=0;
+    { static PPU_THREAD_LOCAL uint32_t last=0xFFFFFFFFu; static PPU_THREAD_LOCAL uint32_t n=0;
       if ((uint32_t)a==last) { if (++n==200000) { fprintf(stderr, "[HOTREAD16] spinning on 0x%08X\n", (uint32_t)a); n=0; } } else { last=(uint32_t)a; n=0; } }
     return __builtin_bswap16(v); }
 uint32_t vm_read32(uint64_t a) { if (vm_oob((uint32_t)a,4)) return 0;
@@ -609,7 +609,7 @@ uint32_t vm_read32(uint64_t a) { if (vm_oob((uint32_t)a,4)) return 0;
           for(uint32_t i=0;i<NB;i++) cnt[i]=0; } } }
     /* Hot-poll detector: a thread spinning on the same address (e.g. a GCM FIFO
      * get-pointer / label waiting on RSX) reads it thousands of times in a row. */
-    { static __declspec(thread) uint32_t last=0xFFFFFFFFu; static __declspec(thread) uint32_t n=0;
+    { static PPU_THREAD_LOCAL uint32_t last=0xFFFFFFFFu; static PPU_THREAD_LOCAL uint32_t n=0;
       if ((uint32_t)a==last) { if (++n==200000) { if (((uint32_t)a & ~0xFFFu) == (VM_HLE_INJECT_BASE + 0x2000u)) {
               /* A spin on the GCM control block is a fence/FIFO wait. Print the
                * WHOLE block: put vs get says whether the RSX side is behind or
@@ -647,7 +647,7 @@ uint64_t vm_read64(uint64_t a) { if (vm_oob((uint32_t)a,8)) return 0; vm_hotmap(
 #ifdef VM_SAMPLE_READS
     { static uint64_t c=0; if ((++c % 2000000ull)==0) fprintf(stderr, "[sample] read64 0x%08X\n", (uint32_t)a); }
 #endif
-    { static __declspec(thread) uint32_t last=0xFFFFFFFFu; static __declspec(thread) uint32_t n=0;
+    { static PPU_THREAD_LOCAL uint32_t last=0xFFFFFFFFu; static PPU_THREAD_LOCAL uint32_t n=0;
       if ((uint32_t)a==last) { if (++n==200000) { fprintf(stderr, "[HOTREAD64] spinning on 0x%08X (=0x%016llX)\n", (uint32_t)a, (unsigned long long)__builtin_bswap64(v)); n=0;
 #ifdef _WIN32
         { static int64_t wa=-2; if(wa==-2){const char*e=getenv("YDKJ_SPINBT"); wa=e?(int64_t)strtoul(e,0,0):-1;}
@@ -740,7 +740,7 @@ static inline void barrier_watch_hit(uint32_t a, uint32_t v, int width, void* ra
                       a, v, width, ppu_prof_resolve_host(ra));
               /* On the first write to the watched word, dump the guest caller
                * chain so the origin of a null field can be walked up-stack. */
-              extern __declspec(thread) ppu_context* g_active_ctx;
+              extern PPU_THREAD_LOCAL ppu_context* g_active_ctx;
               extern void ppu_dump_guest_stack(ppu_context*, const char*);
               if (_n == 1 && g_active_ctx) ppu_dump_guest_stack(g_active_ctx, "ww");
           }
@@ -958,11 +958,11 @@ void flow_lookup_alloc(unsigned int p) {
 }
 
 /* Cross-fragment trampoline pointer (matches the lifted header's TLS decl). */
-extern "C" __declspec(thread) void (*g_trampoline_fn)(void*) = nullptr;
+extern "C" PPU_THREAD_LOCAL void (*g_trampoline_fn)(void*) = nullptr;
 
 /* Per-thread active guest context, for the crash handler to report the guest PC
  * (ctx->pc, updated by lifted code at block boundaries) of a host AV. */
-extern "C" __declspec(thread) ppu_context* g_active_ctx = nullptr;
+extern "C" PPU_THREAD_LOCAL ppu_context* g_active_ctx = nullptr;
 
 /* Caller LR of the guest function currently in an HLE call (for HLE-side
  * diagnostics: pin which lifted function invoked us). 0 if none. */
@@ -2119,7 +2119,7 @@ extern "C" uint64_t ppu_guest_call(uint32_t opd_addr,
 
     /* Private scratch stack high in the guest stack region, distinct from the
      * main + ppu_thread stacks. One callback at a time per caller thread. */
-    static __declspec(thread) uint32_t s_cb_sp = 0;
+    static PPU_THREAD_LOCAL uint32_t s_cb_sp = 0;
     if (!s_cb_sp) s_cb_sp = 0xCFFE0000u;
 
     ppu_context ctx;
@@ -2164,7 +2164,7 @@ extern "C" uint64_t ppu_guest_call_ct(uint32_t code, uint32_t toc,
     ppu_fn fn = ppu_lookup(code);
     if (!fn) { fprintf(stderr, "[ppu] guest_call_ct: code 0x%08X not registered\n", code); return 0; }
 
-    static __declspec(thread) uint32_t s_cb_sp = 0;
+    static PPU_THREAD_LOCAL uint32_t s_cb_sp = 0;
     if (!s_cb_sp) s_cb_sp = 0xCFFE0000u;
 
     ppu_context ctx;

--- a/runtime/ppu/ppu_loader.cpp
+++ b/runtime/ppu/ppu_loader.cpp
@@ -20,6 +20,7 @@
 
 #include "ppu_recomp.h"     /* ppu_context, func decls, ppu_recomp_register */
 #include "../memory/vm.h"   /* vm_commit -- sys_mmapper_search_and_map maps for real */
+#include "../platform/win32_compat.h"      /* Win32 types, interlocked ops, Sleep/QPC on POSIX */
 #include "../platform/win32_backtrace.h"   /* RtlCaptureStackBackTrace / GetModuleHandleA on POSIX */
 extern "C" uint32_t ppu_prof_resolve_host(void* ra);
 

--- a/runtime/ppu/ppu_sysprx.cpp
+++ b/runtime/ppu/ppu_sysprx.cpp
@@ -17,7 +17,7 @@
 #include <stdlib.h>
 #include <string.h>
 #ifdef _WIN32
-#include <windows.h>        /* CRITICAL_SECTION for real lwmutex exclusion */
+#include <windows.h>        /* CRITICAL_SECTION for real lwmutex exclusion */
 #include "../memory/vm.h"                 /* VM_HLE_INJECT_BASE */
 #endif
 

--- a/runtime/ppu/ppu_sysprx.cpp
+++ b/runtime/ppu/ppu_sysprx.cpp
@@ -16,10 +16,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#ifdef _WIN32
-#include <windows.h>        /* CRITICAL_SECTION for real lwmutex exclusion */
-#include "../memory/vm.h"                 /* VM_HLE_INJECT_BASE */
-#endif
+/* win32_compat.h is <windows.h> on Windows (CRITICAL_SECTION for the real
+ * lwmutex exclusion) and the POSIX shims elsewhere -- Sleep, DWORD, QPC. */
+#include "../platform/win32_compat.h"
+#include "../memory/vm.h"   /* VM_HLE_INJECT_BASE -- not platform-specific */
 
 extern "C" uint8_t* vm_base;
 extern "C" void ps3_hle_register_ctx(uint32_t nid, const char* name, void (*fn)(ppu_context*));

--- a/runtime/ppu/tests/boot_main.cpp
+++ b/runtime/ppu/tests/boot_main.cpp
@@ -19,6 +19,7 @@
  * otherwise).
  */
 #include "ppu_recomp.h"
+#include "../../platform/win32_backtrace.h"   /* RtlCaptureStackBackTrace / GetModuleHandleA on POSIX */
 /* The lifted ppu_recomp.h already defines `struct ppu_context` (identical to
  * runtime/ppu/ppu_context.h by design -- "keep the two in sync"). A syscall
  * header included later (sys_ppu_thread.h -> lv2_syscall_table.h -> ppu_context.h)

--- a/runtime/ppu/tests/boot_main.cpp
+++ b/runtime/ppu/tests/boot_main.cpp
@@ -60,7 +60,7 @@ void     ps3_load_prx_modules(void) {}
 extern "C" uint32_t    g_last_hle_nid;    /* ppu_hle.cpp breadcrumb */
 extern "C" const char* g_last_hle_name;
 
-extern "C" __declspec(thread) ppu_context* g_active_ctx;
+extern "C" PPU_THREAD_LOCAL ppu_context* g_active_ctx;
 static LONG WINAPI ydkj_crash_filter(EXCEPTION_POINTERS* ep)
 {
     EXCEPTION_RECORD* er = ep->ExceptionRecord;

--- a/runtime/prx/tests/test_prx_loader.cpp
+++ b/runtime/prx/tests/test_prx_loader.cpp
@@ -37,7 +37,7 @@ extern "C" const uint32_t    libsre_export_count;
 
 /* ---- runtime symbols the lifted libsre object links against ------------- */
 extern "C" uint8_t* vm_base = nullptr;
-extern "C" __declspec(thread) void (*g_trampoline_fn)(void*) = nullptr;
+extern "C" PPU_THREAD_LOCAL void (*g_trampoline_fn)(void*) = nullptr;
 
 static inline uint64_t guest(uint64_t a) { return (uint64_t)(uintptr_t)(vm_base + a); }
 extern "C" uint8_t  vm_read8 (uint64_t a){ return *(uint8_t*) (vm_base + a); }

--- a/runtime/syscalls/lv2_register.c
+++ b/runtime/syscalls/lv2_register.c
@@ -29,7 +29,7 @@
 
 #include <stdio.h>
 #include <string.h>
-#include "../platform/darwin_compat.h"   /* QueryPerformanceCounter shim for the SPU_SPEED timing */
+#include "../platform/win32_compat.h"   /* QueryPerformanceCounter shim for the SPU_SPEED timing */
 
 /* ---------------------------------------------------------------------------
  * TTY syscalls (used by PS3 CRT for debug output)

--- a/tests/torture/main.cpp
+++ b/tests/torture/main.cpp
@@ -42,7 +42,7 @@ void     ps3_load_prx_modules(void) {}
 
 extern "C" uint32_t    g_last_hle_nid;    /* ppu_hle.cpp breadcrumb */
 extern "C" const char* g_last_hle_name;
-extern "C" __declspec(thread) ppu_context* g_active_ctx;
+extern "C" PPU_THREAD_LOCAL ppu_context* g_active_ctx;
 
 static LONG WINAPI torture_crash_filter(EXCEPTION_POINTERS* ep)
 {

--- a/tools/check_ppu_scaffold.py
+++ b/tools/check_ppu_scaffold.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""
+Compile-check the PPU boot scaffold, on whatever platform you are standing on.
+
+runtime/ppu/ is the one part of the runtime nothing in this repository builds.
+CMakeLists.txt excludes it from the library because those files #include
+ppu_recomp.h, which the lifter generates per game -- so the scaffold is only
+ever compiled inside somebody's game port, on their machine, on Windows. That
+is exactly the shape of a claim that rots: docs/BUILDING.md advertised macOS as
+"Full support" for months while the tree did not compile there at all, and it
+took CI to find out.
+
+This script closes that hole without needing a game. It synthesises a stub
+ppu_recomp.h from the lifter's OWN HEADER_PREAMBLE -- the same string
+ppu_lifter.py writes into the real header, imported rather than copied, so the
+stub cannot drift from what games actually get -- and compiles the scaffold
+against it. What it proves is that every declaration the scaffold reaches for
+exists on this platform. It does not link, and it cannot run anything.
+
+It is a ratchet, not a pass/fail gate, because the POSIX port is not finished:
+the baseline in ppu_scaffold_baseline.json records how many errors each file
+currently produces per toolchain, and the check fails if a number goes UP. That
+makes every step of the port measurable, and makes a regression on the platform
+that already works (Windows, where the baseline is 0) a hard failure today.
+
+  python tools/check_ppu_scaffold.py            # check against the baseline
+  python tools/check_ppu_scaffold.py --update   # re-record it after improving
+
+A toolchain with no baseline entry reports its numbers and passes, so a new
+platform's first CI run tells you what to record rather than failing on
+arrival.
+"""
+
+import argparse
+import importlib.util
+import json
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BASELINE = os.path.join(ROOT, "tools", "ppu_scaffold_baseline.json")
+
+# The scaffold translation units. boot_main.cpp is deliberately absent: it also
+# includes the per-game SPU recomp header and pulls in the generated function
+# table, so a stub cannot stand in for it.
+SOURCES = [
+    "runtime/ppu/ppu_loader.cpp",
+    "runtime/ppu/ppu_hle.cpp",
+    "runtime/ppu/ppu_fs.cpp",
+    "runtime/ppu/ppu_sysprx.cpp",
+]
+
+INCLUDE_DIRS = [
+    "include",
+    "runtime/ppu",
+    "runtime/spu",
+    "runtime/memory",
+    "libs/video",
+]
+
+
+def stub_header() -> str:
+    """The lifter's real header preamble, plus the few externs the generated
+    header carries that the scaffold calls into.
+
+    Imported from ppu_lifter.py rather than copied: if the ppu_context layout
+    changes, this stub changes with it and the check keeps testing the truth.
+
+    PPU_THREAD_LOCAL is deliberately NOT defined here. The lifter emits it into
+    SOURCE_PREAMBLE -- the generated .cpp -- not the header, so the scaffold
+    (separate translation units) genuinely cannot see it today. Defining it
+    here would hide that.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "ppu_lifter", os.path.join(ROOT, "tools", "ppu_lifter.py"))
+    lifter = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(lifter)
+    return lifter.HEADER_PREAMBLE + (
+        '\n#ifdef __cplusplus\nextern "C" {\n#endif\n'
+        "void ppu_recomp_register(void);\n"
+        '#ifdef __cplusplus\n}\n#endif\n'
+    )
+
+
+def pick_toolchain(explicit=None):
+    """Return (key, argv-prefix). The key names the row in the baseline."""
+    if explicit:
+        cxx = explicit
+    else:
+        cxx = os.environ.get("CXX")
+
+    if sys.platform == "win32":
+        if not cxx:
+            for cand in ("clang-cl",
+                         r"C:\Program Files\LLVM\bin\clang-cl.exe"):
+                if shutil.which(cand) or os.path.exists(cand):
+                    cxx = cand
+                    break
+        if not cxx:
+            return None, None
+        # clang-cl, not cl: the scaffold uses __builtin_bswap*,
+        # __builtin_return_address and __int128, none of which MSVC has.
+        # -ferror-limit=0: clang stops at 20 errors by default, which would
+        # silently cap the ratchet's counts and hide regressions above it.
+        return "windows-clang-cl", [cxx, "/std:c++20", "/c", "/W0", "/EHsc",
+                                    "/D_CRT_SECURE_NO_WARNINGS",
+                                    "/clang:-ferror-limit=0"]
+
+    if not cxx:
+        cxx = "c++"
+    family = "clang" if "clang" in os.path.basename(cxx) else "gcc"
+    osname = "darwin" if sys.platform == "darwin" else "linux"
+    argv = [cxx, "-std=c++20", "-fsyntax-only", "-w"]
+    if family == "clang":
+        argv.append("-ferror-limit=0")   # see the note above
+    return f"{osname}-{family}", argv
+
+
+def count_errors(text: str) -> int:
+    """Diagnostic lines only.
+
+    Matching a bare "error" also caught clang's "1 error generated." trailer and
+    double-counted every file that failed, so the colon is load-bearing.
+    """
+    return len(re.findall(r"(?m)^[^\n]*?\berror:", text))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--update", action="store_true",
+                    help="re-record the baseline for this toolchain")
+    ap.add_argument("--cxx", help="compiler to use (default: $CXX, or the "
+                                  "platform's usual)")
+    ap.add_argument("--verbose", action="store_true",
+                    help="print the compiler diagnostics")
+    args = ap.parse_args()
+
+    key, prefix = pick_toolchain(args.cxx)
+    if not key:
+        print("[ppu-scaffold] no usable C++ compiler found; skipping")
+        return 0
+
+    tmp = tempfile.mkdtemp(prefix="ppu_scaffold_")
+    try:
+        with open(os.path.join(tmp, "ppu_recomp.h"), "w") as fh:
+            fh.write(stub_header())
+
+        inc_flag = "/I" if key.startswith("windows") else "-I"
+        incs = [inc_flag + tmp]
+        incs += [inc_flag + os.path.join(ROOT, d) for d in INCLUDE_DIRS]
+
+        print(f"[ppu-scaffold] toolchain: {key}")
+        print(f"[ppu-scaffold] {' '.join(os.path.basename(p) for p in prefix[:1])}"
+              f" {platform.machine()}")
+
+        results, total = {}, 0
+        for src in SOURCES:
+            cmd = list(prefix) + incs
+            if key.startswith("windows"):
+                cmd += [f"/Fo{os.path.join(tmp, os.path.basename(src))}.obj"]
+            cmd += [os.path.join(ROOT, src)]
+            proc = subprocess.run(cmd, capture_output=True, text=True)
+            n = count_errors(proc.stdout + proc.stderr)
+            results[src] = n
+            total += n
+            print(f"  {n:4d}  {src}")
+            if args.verbose and n:
+                print((proc.stdout + proc.stderr).strip()[:4000])
+        print(f"  {total:4d}  TOTAL")
+
+        base = {}
+        if os.path.exists(BASELINE):
+            with open(BASELINE) as fh:
+                base = json.load(fh)
+
+        if args.update:
+            base[key] = results
+            with open(BASELINE, "w") as fh:
+                json.dump(base, fh, indent=2, sort_keys=True)
+                fh.write("\n")
+            print(f"[ppu-scaffold] baseline recorded for {key}")
+            return 0
+
+        if key not in base:
+            print(f"[ppu-scaffold] no baseline for {key} yet -- reporting only.")
+            print(f"[ppu-scaffold] record it with: "
+                  f"python tools/check_ppu_scaffold.py --update")
+            return 0
+
+        want, bad, better = base[key], [], []
+        for src in SOURCES:
+            got, exp = results[src], want.get(src)
+            if exp is None:
+                print(f"[ppu-scaffold] {src} is new; run --update")
+                continue
+            if got > exp:
+                bad.append(f"{src}: {exp} -> {got}")
+            elif got < exp:
+                better.append(f"{src}: {exp} -> {got}")
+
+        for line in better:
+            print(f"[ppu-scaffold] IMPROVED  {line}")
+        if better and not bad:
+            print("[ppu-scaffold] the port moved forward -- re-record with "
+                  "--update so the ratchet holds the new ground")
+        if bad:
+            print("\n[ppu-scaffold] REGRESSION: the scaffold got worse on "
+                  f"{key}")
+            for line in bad:
+                print(f"  {line}")
+            print("\nRe-run with --verbose to see the diagnostics.")
+            return 1
+
+        print(f"[ppu-scaffold] OK -- no regression against the {key} baseline")
+        return 0
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_ppu_scaffold.py
+++ b/tools/check_ppu_scaffold.py
@@ -70,11 +70,9 @@ def stub_header() -> str:
 
     Imported from ppu_lifter.py rather than copied: if the ppu_context layout
     changes, this stub changes with it and the check keeps testing the truth.
-
-    PPU_THREAD_LOCAL is deliberately NOT defined here. The lifter emits it into
-    SOURCE_PREAMBLE -- the generated .cpp -- not the header, so the scaffold
-    (separate translation units) genuinely cannot see it today. Defining it
-    here would hide that.
+    PPU_THREAD_LOCAL arrives the same way, now that it lives in the header
+    rather than the generated source -- so this check also verifies the
+    scaffold and the lifted code agree on how to spell thread-local.
     """
     spec = importlib.util.spec_from_file_location(
         "ppu_lifter", os.path.join(ROOT, "tools", "ppu_lifter.py"))

--- a/tools/check_ppu_scaffold.py
+++ b/tools/check_ppu_scaffold.py
@@ -85,6 +85,26 @@ def stub_header() -> str:
     )
 
 
+def compiler_family(cxx: str) -> str:
+    """Ask the compiler what it is, rather than guessing from its filename.
+
+    macOS's `c++` is Apple Clang, and a name-based guess called it gcc -- so the
+    first macOS CI run recorded itself under a key that names the wrong
+    compiler. `cc` on Linux is ambiguous the same way.
+    """
+    try:
+        out = subprocess.run([cxx, "--version"], capture_output=True, text=True,
+                             timeout=15)
+        text = (out.stdout + out.stderr).lower()
+        if "clang" in text:
+            return "clang"
+        if "gcc" in text or "free software foundation" in text:
+            return "gcc"
+    except Exception:
+        pass
+    return "clang" if "clang" in os.path.basename(cxx) else "gcc"
+
+
 def pick_toolchain(explicit=None):
     """Return (key, argv-prefix). The key names the row in the baseline."""
     if explicit:
@@ -111,7 +131,7 @@ def pick_toolchain(explicit=None):
 
     if not cxx:
         cxx = "c++"
-    family = "clang" if "clang" in os.path.basename(cxx) else "gcc"
+    family = compiler_family(cxx)
     osname = "darwin" if sys.platform == "darwin" else "linux"
     argv = [cxx, "-std=c++20", "-fsyntax-only", "-w"]
     if family == "clang":

--- a/tools/lift_selftest.py
+++ b/tools/lift_selftest.py
@@ -87,7 +87,7 @@ def gen_driver(cases_meta):
         "  void vm_write32(uint64_t,uint32_t){} void vm_write64(uint64_t,uint64_t){}",
         "  void ps3_indirect_call(ppu_context*){} void ps3_hle_call(unsigned,ppu_context*){}",
         "  uint64_t ppu_timebase_now(){return 0;} void lv2_syscall(ppu_context*){}",
-        "  __declspec(thread) void (*g_trampoline_fn)(void*) = nullptr;",
+        "  PPU_THREAD_LOCAL void (*g_trampoline_fn)(void*) = nullptr;",
         "}",
         "",
     ]

--- a/tools/ppu_lifter.py
+++ b/tools/ppu_lifter.py
@@ -103,6 +103,18 @@ extern "C"
 #endif
 void lv2_syscall(ppu_context* ctx);
 
+/* Thread-local storage qualifier. The runtime's boot scaffold declares the
+ * same objects the generated code does (g_active_ctx, g_trampoline_fn), so
+ * this has to live in the HEADER both sides include -- not in the generated
+ * source, where only the lifted code could see it. */
+#ifndef PPU_THREAD_LOCAL
+#  ifdef _MSC_VER
+#    define PPU_THREAD_LOCAL __declspec(thread)
+#  else
+#    define PPU_THREAD_LOCAL __thread
+#  endif
+#endif
+
 /* Function table (defined in the generated source, sentinel-terminated).
  * The game project's indirect-call dispatcher builds its lookup from this. */
 typedef struct { uint64_t addr; void (*func)(ppu_context*); const char* name; } func_entry;
@@ -292,12 +304,7 @@ extern "C" void ps3_indirect_call(ppu_context* ctx);
 extern "C" void ps3_hle_call(unsigned int nid, ppu_context* ctx);
 
 /* Trampoline function pointer for cross-fragment branches (TLS).
- * Must match the __declspec(thread) definition in indirect_dispatch. */
-#ifdef _MSC_VER
-#  define PPU_THREAD_LOCAL __declspec(thread)
-#else
-#  define PPU_THREAD_LOCAL __thread
-#endif
+ * PPU_THREAD_LOCAL comes from ppu_recomp.h, included above. */
 extern "C" PPU_THREAD_LOCAL void (*g_trampoline_fn)(void*);
 
 /* Drain pending trampolines after any call that might set g_trampoline_fn.

--- a/tools/ppu_scaffold_baseline.json
+++ b/tools/ppu_scaffold_baseline.json
@@ -1,14 +1,14 @@
 {
   "linux-clang": {
     "runtime/ppu/ppu_fs.cpp": 0,
-    "runtime/ppu/ppu_hle.cpp": 1,
-    "runtime/ppu/ppu_loader.cpp": 35,
+    "runtime/ppu/ppu_hle.cpp": 0,
+    "runtime/ppu/ppu_loader.cpp": 19,
     "runtime/ppu/ppu_sysprx.cpp": 4
   },
   "linux-gcc": {
-    "runtime/ppu/ppu_fs.cpp": 1,
-    "runtime/ppu/ppu_hle.cpp": 2,
-    "runtime/ppu/ppu_loader.cpp": 47,
+    "runtime/ppu/ppu_fs.cpp": 0,
+    "runtime/ppu/ppu_hle.cpp": 0,
+    "runtime/ppu/ppu_loader.cpp": 29,
     "runtime/ppu/ppu_sysprx.cpp": 7
   },
   "windows-clang-cl": {

--- a/tools/ppu_scaffold_baseline.json
+++ b/tools/ppu_scaffold_baseline.json
@@ -12,7 +12,7 @@
     "runtime/ppu/ppu_sysprx.cpp": 0
   },
   "windows-clang-cl": {
-    "runtime/ppu/ppu_fs.cpp": 1,
+    "runtime/ppu/ppu_fs.cpp": 0,
     "runtime/ppu/ppu_hle.cpp": 0,
     "runtime/ppu/ppu_loader.cpp": 0,
     "runtime/ppu/ppu_sysprx.cpp": 0

--- a/tools/ppu_scaffold_baseline.json
+++ b/tools/ppu_scaffold_baseline.json
@@ -2,13 +2,13 @@
   "linux-clang": {
     "runtime/ppu/ppu_fs.cpp": 0,
     "runtime/ppu/ppu_hle.cpp": 0,
-    "runtime/ppu/ppu_loader.cpp": 10,
+    "runtime/ppu/ppu_loader.cpp": 0,
     "runtime/ppu/ppu_sysprx.cpp": 0
   },
   "linux-gcc": {
     "runtime/ppu/ppu_fs.cpp": 0,
     "runtime/ppu/ppu_hle.cpp": 0,
-    "runtime/ppu/ppu_loader.cpp": 6,
+    "runtime/ppu/ppu_loader.cpp": 0,
     "runtime/ppu/ppu_sysprx.cpp": 0
   },
   "windows-clang-cl": {

--- a/tools/ppu_scaffold_baseline.json
+++ b/tools/ppu_scaffold_baseline.json
@@ -1,0 +1,20 @@
+{
+  "linux-clang": {
+    "runtime/ppu/ppu_fs.cpp": 0,
+    "runtime/ppu/ppu_hle.cpp": 1,
+    "runtime/ppu/ppu_loader.cpp": 54,
+    "runtime/ppu/ppu_sysprx.cpp": 4
+  },
+  "linux-gcc": {
+    "runtime/ppu/ppu_fs.cpp": 1,
+    "runtime/ppu/ppu_hle.cpp": 2,
+    "runtime/ppu/ppu_loader.cpp": 124,
+    "runtime/ppu/ppu_sysprx.cpp": 7
+  },
+  "windows-clang-cl": {
+    "runtime/ppu/ppu_fs.cpp": 1,
+    "runtime/ppu/ppu_hle.cpp": 0,
+    "runtime/ppu/ppu_loader.cpp": 0,
+    "runtime/ppu/ppu_sysprx.cpp": 0
+  }
+}

--- a/tools/ppu_scaffold_baseline.json
+++ b/tools/ppu_scaffold_baseline.json
@@ -2,14 +2,14 @@
   "linux-clang": {
     "runtime/ppu/ppu_fs.cpp": 0,
     "runtime/ppu/ppu_hle.cpp": 0,
-    "runtime/ppu/ppu_loader.cpp": 19,
-    "runtime/ppu/ppu_sysprx.cpp": 4
+    "runtime/ppu/ppu_loader.cpp": 10,
+    "runtime/ppu/ppu_sysprx.cpp": 0
   },
   "linux-gcc": {
     "runtime/ppu/ppu_fs.cpp": 0,
     "runtime/ppu/ppu_hle.cpp": 0,
-    "runtime/ppu/ppu_loader.cpp": 29,
-    "runtime/ppu/ppu_sysprx.cpp": 7
+    "runtime/ppu/ppu_loader.cpp": 6,
+    "runtime/ppu/ppu_sysprx.cpp": 0
   },
   "windows-clang-cl": {
     "runtime/ppu/ppu_fs.cpp": 1,

--- a/tools/ppu_scaffold_baseline.json
+++ b/tools/ppu_scaffold_baseline.json
@@ -1,4 +1,10 @@
 {
+  "darwin-clang": {
+    "runtime/ppu/ppu_fs.cpp": 0,
+    "runtime/ppu/ppu_hle.cpp": 0,
+    "runtime/ppu/ppu_loader.cpp": 0,
+    "runtime/ppu/ppu_sysprx.cpp": 0
+  },
   "linux-clang": {
     "runtime/ppu/ppu_fs.cpp": 0,
     "runtime/ppu/ppu_hle.cpp": 0,

--- a/tools/ppu_scaffold_baseline.json
+++ b/tools/ppu_scaffold_baseline.json
@@ -2,13 +2,13 @@
   "linux-clang": {
     "runtime/ppu/ppu_fs.cpp": 0,
     "runtime/ppu/ppu_hle.cpp": 1,
-    "runtime/ppu/ppu_loader.cpp": 54,
+    "runtime/ppu/ppu_loader.cpp": 35,
     "runtime/ppu/ppu_sysprx.cpp": 4
   },
   "linux-gcc": {
     "runtime/ppu/ppu_fs.cpp": 1,
     "runtime/ppu/ppu_hle.cpp": 2,
-    "runtime/ppu/ppu_loader.cpp": 124,
+    "runtime/ppu/ppu_loader.cpp": 47,
     "runtime/ppu/ppu_sysprx.cpp": 7
   },
   "windows-clang-cl": {

--- a/wave/main.cpp
+++ b/wave/main.cpp
@@ -54,7 +54,7 @@ void     ps3_load_prx_modules(void) {}
 extern "C" uint32_t    g_last_hle_nid;    /* ppu_hle.cpp breadcrumb */
 extern "C" const char* g_last_hle_name;
 
-extern "C" __declspec(thread) ppu_context* g_active_ctx;
+extern "C" PPU_THREAD_LOCAL ppu_context* g_active_ctx;
 static LONG WINAPI ydkj_crash_filter(EXCEPTION_POINTERS* ep)
 {
     EXCEPTION_RECORD* er = ep->ExceptionRecord;


### PR DESCRIPTION
Brings Linux from "untested" to a first-class CI platform, and takes the PPU
boot scaffold — the one part of the runtime nothing in this repo ever built —
to zero errors on POSIX.

Nothing here changes how Windows behaves. Every step was checked against the
Windows scaffold with clang-cl, and the runtime library, `ps3recomp_host` and
all 8 lifter suites are green under GCC and Clang, Debug and Release, on
Ubuntu 24.04.

## Linux, from nothing to CI

Linux had never had a compiler run over it. Two real defects were sitting in
that gap:

- An Apple-only `QueryPerformanceCounter` shim in `darwin_compat.h` reached
  from `lv2_register.c`, when `win32_compat.h` already supplied the same names
  for *every* POSIX host. The duplicate is gone.
- `win32_compat.h`'s POSIX branch called `pthread_threadid_np`, which is
  Darwin-only. **GCC accepted it as an implicit declaration and produced a
  working archive** — an archive links nothing, so the undefined symbol just
  waited for the first executable. Only Clang rejected it.

`.github/workflows/linux.yml` builds both compilers on purpose, since a
gcc-only matrix would have shipped the second one, and greps the archive for
Win32/Darwin-only undefined symbols so the next one cannot hide the same way.

## A headless backend, and one guest vertex fetch

Linux had no render backend at all, so `ps3recomp_host` could not be built
there and the whole cellGcm → RSX → backend bridge went unexercised. The null
backend's POSIX half was a stub returning -1; it now renders into a host-memory
framebuffer with a CPU triangle filler — no display, no GPU, no driver.

Writing it would have meant a *third* copy of the guest vertex fetch.
`rsx_metal_backend.m` already opened with "ported from the D3D12 backend's
read_vp_vertex", and the two had drifted — the Metal copy fed caller literals
instead of the constant vertex attribute register for a disabled array, and
resolved LOCAL offsets through the IO table. Both are real bugs with comments
in the D3D12 source explaining what they cost. `rsx_vertex_fetch.c` now holds
the single definition and all three backends call it.

That immediately caught a third instance of the same confusion in the harness
itself: `host_posix.c` writes its test triangle into the IO window but tagged
the array LOCAL, which only worked because Metal resolved LOCAL through the IO
table.

## The PPU boot scaffold: 134 → 0

`runtime/ppu/` is excluded from the library because it includes the lifter's
per-game `ppu_recomp.h`, so no CMake target has ever compiled it — the same
shape as the claim CI was added to kill, when `docs/BUILDING.md` advertised
macOS support the tree did not have.

`tools/check_ppu_scaffold.py` synthesises a stub header from the lifter's own
`HEADER_PREAMBLE` (imported, not copied, so it cannot drift) and compiles the
scaffold against it. It is a **ratchet**: the baseline records the error count
per toolchain and the check fails only when a number goes *up*.

| toolchain | before | after |
|---|---:|---:|
| linux-gcc | 134 | **0** |
| linux-clang | 59 | **0** |
| windows-clang-cl | 1 | 1 |

Four steps got it there: a portable `PPU_THREAD_LOCAL` that the scaffold can
actually reach (the lifter already had one, but put it in the generated `.cpp`
rather than the header); `win32_backtrace.h` mapping
`RtlCaptureStackBackTrace`/`GetModuleHandleA` onto `backtrace(3)`/`dladdr(3)`;
Win32 scalar types and interlocked intrinsics in `win32_compat.h`; and a POSIX
port of the guest-pointer trap using `mmap(PROT_NONE)` + `sigaction`.

The ratchet caught three regressions during the work, all mine — including a
`sed` that removed a declaration by deleting a whole line, when that line also
opened its block with `{`.

Windows stays at 1 because `ppu_fs.cpp` includes `<dirent.h>` unguarded, which
MSVC does not ship; every game port privately vendors a shim for it. Left for a
follow-up, since putting a third-party compat header in the SDK is a project
decision rather than a side effect.

## What this does not do

It does not make macOS or Linux run a game. `boot_main.cpp` still starts its
vblank ticker, hang watchdog and profiler inside `#ifdef _WIN32` with no
`#else`, so a POSIX host has no frame clock, and nothing in the repo links the
scaffold — that needs a lifted title. Compiling clean is the precondition, not
the finish line, and `docs/BUILDING.md` now says so rather than implying
otherwise.

**The Metal and macOS changes are reasoned, not run.** There is no Darwin on
the machine this was written on, so the macOS job in this PR is their first
real test — including the two vertex-fetch fixes above. The macOS scaffold has
no recorded baseline yet; its first run will report the numbers to record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WHFeSQJFeF141pFkYmKN5
