### PR TITLE
rsx: lift the TEXTURE_CONTROL1 crossbar decode out of the D3D12 backend

### DIFF
--- a/libs/video/rsx_d3d12_backend.c
+++ b/libs/video/rsx_d3d12_backend.c
@@ -2334,36 +2334,17 @@ static ID3D12PipelineState* vp_get_fp_pso(int vs_idx, u32 fp_addr, u32 blend, in
  * Returns the slot index (SRV at heap 1+slot) or -1. Must run while the
  * command list is open, before the draw passes. */
 /* NV4097 TEXTURE_CONTROL1 component remap -> D3D12 Shader4ComponentMapping.
- * Low byte = crossbar: bits[1:0] select the SOURCE (0=A,1=R,2=G,3=B) for
- * output A, [3:2] for R, [5:4] for G, [7:6] for B. Next byte = per-output op:
- * 0 = force ZERO, 1 = force ONE, 2 = use crossbar (identity word = 0xAAE4).
- * Our uploaded resource holds guest R,G,B,A at comps 0,1,2,3. */
+ * The crossbar decode itself is RSX semantics and lives in
+ * rsx_texture_layout.c; all that is left here is packing the four selectors
+ * into D3D12's word. Its force-zero/force-one encodings are 4 and 5, which is
+ * what RSX_REMAP_ZERO/ONE already are, so the selectors pass straight through.
+ *
+ * out[] arrives in the crossbar's field order A,R,G,B; D3D12 wants
+ * destR | destG<<3 | destB<<6 | destA<<9 | valid<<12. */
 static u32 rsx_remap_to_d3d(u32 c1, u32 basef)
 {
-    /* Crossbar field order LSB->MSB is A,R,G,B -- the order the header
-     * describes, and the one that makes RSX's documented identity word 0xAAE4
-     * actually decode to an identity mapping. The body used to run the fields
-     * backwards (B,G,R,A), which made 0xAAE4 a channel rotation and 0xAA1B the
-     * "identity"; lanes_dxt was then bent to {2,1,0,3} to cancel the reversal
-     * on DXT, so DXT looked right while every A8R8G8B8 texture sampled a
-     * permuted vector. Rubber Ducky sets 0xAAE4 on its lightmaps and 0xAA93 on
-     * its bump maps: the wall's normal map came back as (R,A,A), which is what
-     * drove the green channel to an extreme and gave the scene its magenta and
-     * green casts.
-     *
-     * Source codes index the presented vector {A,R,G,B}; our uploaded resource
-     * holds guest R,G,B,A at comps 0,1,2,3, and BC decodes to RGBA the same
-     * way, so both use {3,0,1,2}.
-     * Ops byte (same field order): 0 = force ZERO, 1 = force ONE, 2 = remap. */
-    static const u8 lanes_argb[4] = {3, 0, 1, 2};
-    static const u8 lanes_g8b8[4] = {1, 0, 1, 0};
-    const u8* src2res = (basef == 0x8B) ? lanes_g8b8 : lanes_argb;
-    if (!(c1 & 0xFFFF)) c1 = 0xAAE4;               /* unset -> identity */
-    u32 out[4];                                    /* outputs in field order A,R,G,B */
-    for (int i = 0; i < 4; i++) {
-        u32 s = (c1 >> (i * 2)) & 3, op = (c1 >> (8 + i * 2)) & 3;
-        out[i] = (op == 0) ? 4u : (op == 1) ? 5u : (u32)src2res[s];
-    }
+    u8 out[4];
+    rsx_texture_component_remap(c1, basef, out);
     /* TEX_REMAP_ID=<n>: override the derived crossbar with a fixed mapping, to
      * test channel order directly. The resource holds the guest's A8R8G8B8
      * bytes straight through, so its components are (R=A, G=R, B=G, A=B) and

--- a/libs/video/rsx_texture_layout.c
+++ b/libs/video/rsx_texture_layout.c
@@ -138,3 +138,27 @@ void rsx_texture_decode(void* dst, u32 dst_pitch,
         }
     }
 }
+
+void rsx_texture_component_remap(u32 control1, u32 rsx_fmt, u8 out[4])
+{
+    if (!out) return;
+
+    /* Source codes index the presented vector {A,R,G,B}. The uploaded resource
+     * holds R,G,B,A at components 0..3, so A is component 3 and R,G,B are
+     * 0,1,2 -- that is what lanes_argb says. G8B8 only has two real channels,
+     * and the sampler presents them as {G,R,G,R}. */
+    static const u8 lanes_argb[4] = {3, 0, 1, 2};
+    static const u8 lanes_g8b8[4] = {1, 0, 1, 0};
+    const u8* src2res = ((rsx_fmt & 0x9Fu) == 0x8Bu) ? lanes_g8b8 : lanes_argb;
+
+    if (!(control1 & 0xFFFFu)) control1 = 0xAAE4u;   /* unset -> identity */
+
+    /* i runs A, R, G, B -- the crossbar's field order, LSB first. */
+    for (int i = 0; i < 4; i++) {
+        u32 s  = (control1 >> (i * 2)) & 3u;
+        u32 op = (control1 >> (8 + i * 2)) & 3u;
+        out[i] = (op == 0) ? (u8)RSX_REMAP_ZERO
+               : (op == 1) ? (u8)RSX_REMAP_ONE
+                           : src2res[s];
+    }
+}

--- a/libs/video/rsx_texture_layout.h
+++ b/libs/video/rsx_texture_layout.h
@@ -88,6 +88,42 @@ void rsx_texture_decode(void* dst, u32 dst_pitch,
                         const u8* src, u32 w, u32 h,
                         const rsx_tex_layout* tl, int argb_as_rgba);
 
+/* --- component remap (NV4097 TEXTURE_CONTROL1 crossbar) ------------------
+ *
+ * Each of the texture's four outputs is either a channel of the sampled
+ * resource or a forced constant. These are the selector values
+ * rsx_texture_component_remap() writes.
+ *
+ * 0..3 index the UPLOADED RESOURCE's components, which rsx_texture_decode()
+ * always lays out as R,G,B,A -- BC1/2/3 decode to RGBA the same way, so both
+ * paths agree. (D3D12 happens to encode force-zero and force-one as 4 and 5
+ * too, so its backend can pass these through; that is a convenience, not the
+ * reason for the values.) */
+#define RSX_REMAP_ZERO 4u   /* force 0.0 */
+#define RSX_REMAP_ONE  5u   /* force 1.0 */
+
+/* Decode TEXTURE_CONTROL1's crossbar for `rsx_fmt`.
+ *
+ * `out` receives the selector for each output IN THE CROSSBAR'S OWN FIELD
+ * ORDER: out[0] = A, out[1] = R, out[2] = G, out[3] = B. A backend reorders
+ * them into whatever its API wants.
+ *
+ * Layout of control1: the low byte is the crossbar, two bits per output,
+ * selecting the source from the presented vector {A,R,G,B}; the next byte is
+ * the per-output operation, 0 = force zero, 1 = force one, 2 = use the
+ * crossbar. A control word of 0 means "unset" and is treated as the hardware
+ * identity, 0xAAE4.
+ *
+ * The field order is load-bearing and has been got wrong before. Running the
+ * fields backwards (B,G,R,A) makes 0xAAE4 -- the documented identity -- decode
+ * to a channel rotation, and makes 0xAA1B look like the identity instead. That
+ * bug was then papered over by bending the DXT lane table to cancel it, so DXT
+ * sampled correctly while every A8R8G8B8 texture came back permuted: Rubber
+ * Ducky's bump maps returned (R,A,A) and drove the scene's magenta and green
+ * casts. test_texture_layout.c asserts 0xAAE4 is the identity and 0xAA1B is
+ * not, which is precisely that regression. */
+void rsx_texture_component_remap(u32 control1, u32 rsx_fmt, u8 out[4]);
+
 /* TEX_RGBA: treat A8R8G8B8 source bytes as already R,G,B,A and copy them
  * straight through.
  *

--- a/libs/video/tests/test_texture_layout.c
+++ b/libs/video/tests/test_texture_layout.c
@@ -302,6 +302,116 @@ static void test_decode_rejects_nonsense(void)
     for (u32 i = 0; i < sizeof dst; i++) CHECK_EQ(dst[i], 0xA5);
 }
 
+/* --- component remap (TEXTURE_CONTROL1 crossbar) ------------------------ */
+
+/* out[] is in the crossbar's field order: A, R, G, B. */
+#define A_ 0
+#define R_ 1
+#define G_ 2
+#define B_ 3
+
+/* The uploaded resource is always R,G,B,A at components 0..3, so the identity
+ * mapping is R->0, G->1, B->2, A->3. */
+static void test_remap_identity(void)
+{
+    u8 m[4];
+    rsx_texture_component_remap(0xAAE4u, FMT_A8R8G8B8, m);
+    CHECK_EQ(m[R_], 0); CHECK_EQ(m[G_], 1);
+    CHECK_EQ(m[B_], 2); CHECK_EQ(m[A_], 3);
+
+    /* An unset control word means identity, not "all channels read A". */
+    u8 z[4];
+    rsx_texture_component_remap(0u, FMT_A8R8G8B8, z);
+    for (int i = 0; i < 4; i++) CHECK_EQ(z[i], m[i]);
+}
+
+/* Packed the way D3D12 wants it, the identity must equal
+ * D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING (0x1688). That constant is not
+ * available here, so it is spelled out -- it is what makes this assertion
+ * meaningful rather than self-referential. */
+static void test_remap_identity_packs_to_d3d_default(void)
+{
+    u8 m[4];
+    rsx_texture_component_remap(0xAAE4u, FMT_A8R8G8B8, m);
+    u32 packed = m[R_] | (m[G_] << 3) | (m[B_] << 6) | (m[A_] << 9) | (1u << 12);
+    CHECK_EQ(packed, 0x1688u);
+}
+
+/* THE regression this file exists for. Reading the crossbar fields backwards
+ * (B,G,R,A instead of A,R,G,B) makes 0xAA1B decode as the identity and 0xAAE4
+ * as a rotation -- the exact inversion that permuted every A8R8G8B8 texture
+ * and gave Rubber Ducky its magenta and green casts. */
+static void test_remap_field_order_is_not_reversed(void)
+{
+    u8 e4[4], b1[4];
+    rsx_texture_component_remap(0xAAE4u, FMT_A8R8G8B8, e4);
+    rsx_texture_component_remap(0xAA1Bu, FMT_A8R8G8B8, b1);
+
+    /* 0xAA1B is the REVERSE mapping, so it must not be the identity... */
+    int is_identity = (b1[R_] == 0 && b1[G_] == 1 && b1[B_] == 2 && b1[A_] == 3);
+    CHECK(!is_identity);
+    /* ...and it must differ from the real identity somewhere. */
+    int differs = 0;
+    for (int i = 0; i < 4; i++) if (e4[i] != b1[i]) differs = 1;
+    CHECK(differs);
+
+    /* Spelled out: 0x1B selects sources 3,2,1,0 for A,R,G,B. */
+    CHECK_EQ(b1[A_], 2);   /* source 3 (B) -> resource comp 2 */
+    CHECK_EQ(b1[R_], 1);   /* source 2 (G) -> comp 1 */
+    CHECK_EQ(b1[G_], 0);   /* source 1 (R) -> comp 0 */
+    CHECK_EQ(b1[B_], 3);   /* source 0 (A) -> comp 3 */
+}
+
+/* The high byte forces constants per output, overriding the crossbar. */
+static void test_remap_force_zero_and_one(void)
+{
+    u8 m[4];
+    rsx_texture_component_remap(0x00E4u, FMT_A8R8G8B8, m);      /* all ops = 0 */
+    for (int i = 0; i < 4; i++) CHECK_EQ(m[i], RSX_REMAP_ZERO);
+
+    rsx_texture_component_remap(0x55E4u, FMT_A8R8G8B8, m);      /* all ops = 1 */
+    for (int i = 0; i < 4; i++) CHECK_EQ(m[i], RSX_REMAP_ONE);
+
+    /* Mixed: ops byte 0xA1 is, from the low bits up, 01 00 10 10 --
+     * force ONE for A, force ZERO for R, crossbar for G and B. Forcing is
+     * per-output, not all-or-nothing. */
+    rsx_texture_component_remap(0xA1E4u, FMT_A8R8G8B8, m);
+    CHECK_EQ(m[A_], RSX_REMAP_ONE);
+    CHECK_EQ(m[R_], RSX_REMAP_ZERO);
+    CHECK_EQ(m[G_], 1);
+    CHECK_EQ(m[B_], 2);
+}
+
+/* G8B8 has two real channels, presented as {G,R,G,R}. */
+static void test_remap_g8b8_lanes(void)
+{
+    u8 m[4];
+    rsx_texture_component_remap(0xAAE4u, FMT_G8B8, m);
+    CHECK_EQ(m[A_], 1); CHECK_EQ(m[R_], 0);
+    CHECK_EQ(m[G_], 1); CHECK_EQ(m[B_], 0);
+
+    /* The LN flag must not change the crossbar decode. */
+    u8 n[4];
+    rsx_texture_component_remap(0xAAE4u, FMT_G8B8 | FMT_LN, n);
+    for (int i = 0; i < 4; i++) CHECK_EQ(n[i], m[i]);
+}
+
+/* Compressed formats decode to RGBA, so they use the same lanes as A8R8G8B8 --
+ * NOT a bent table cancelling a reversed crossbar, which is how the old bug
+ * hid on DXT while breaking everything else. */
+static void test_remap_dxt_matches_argb(void)
+{
+    u8 a[4], d[4];
+    rsx_texture_component_remap(0xAAE4u, FMT_A8R8G8B8, a);
+    rsx_texture_component_remap(0xAAE4u, FMT_DXT1,     d);
+    for (int i = 0; i < 4; i++) CHECK_EQ(d[i], a[i]);
+}
+
+static void test_remap_rejects_null(void)
+{
+    rsx_texture_component_remap(0xAAE4u, FMT_A8R8G8B8, NULL);   /* must not crash */
+}
+
 int main(void)
 {
     test_argb();
@@ -315,6 +425,13 @@ int main(void)
     test_decode_g8b8_swizzled();
     test_decode_compressed_is_verbatim();
     test_decode_rejects_nonsense();
+    test_remap_identity();
+    test_remap_identity_packs_to_d3d_default();
+    test_remap_field_order_is_not_reversed();
+    test_remap_force_zero_and_one();
+    test_remap_g8b8_lanes();
+    test_remap_dxt_matches_argb();
+    test_remap_rejects_null();
 
     if (g_fail) { printf("\nRSX texture layout: %d FAILED\n", g_fail); return 1; }
     printf("RSX texture layout tests: all passed\n");


### PR DESCRIPTION
﻿Third step of the renderer hoist, and the one with the worst history.

Decoding the `TEXTURE_CONTROL1` component crossbar — which channel of the sampled resource each texture output reads, or whether it is forced to 0 or 1 — is RSX semantics. Packing the answer into a `Shader4ComponentMapping` word is D3D12's. Only the second half belongs in that file.

## Why this one especially shouldn't exist twice

It has already been wrong once, in a way that hid.

Running the crossbar's fields backwards (B,G,R,A rather than A,R,G,B) makes `0xAAE4` — the hardware identity — decode to a channel rotation, and makes `0xAA1B` look like the identity instead. That was then papered over by bending the DXT lane table to `{2,1,0,3}` to cancel the reversal, so compressed textures sampled correctly **while every A8R8G8B8 one came back permuted**. Rubber Ducky's bump maps returned (R,A,A), which drove the scene's magenta and green casts.

A second backend re-deriving this from the register docs has an excellent chance of reproducing exactly that.

## Shape

`rsx_texture_component_remap()` returns the four selectors in the crossbar's own field order and lets the backend reorder them. `RSX_REMAP_ZERO`/`ONE` are 4 and 5, which is what D3D12 encodes force-zero and force-one as, so its packing is a pass-through — a convenience, and the header says so rather than leaving it looking like the reason for the values.

Staying behind: the D3D12 word, `TEX_REMAP_ID`, `REMAPDBG`.

## The tests were checked for teeth

Five deliberate mutations, each caught:

| deliberate break | assertions that fail |
|---|---|
| crossbar fields read backwards (**the original bug**) | 17 |
| `lanes_argb` bent to `{2,1,0,3}` (**the paper-over**) | 13 |
| force-zero/force-one ops ignored | 11 |
| unset control word no longer means identity | 5 |
| G8B8 lanes replaced with the ARGB ones | 3 |

Two assertions are worth calling out:

- The identity, packed the D3D12 way, must equal **0x1688** — `D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING`, spelled out because that header isn't available to a portable test. That's what keeps the check from being self-referential.
- DXT must produce the **same** lanes as A8R8G8B8, since a divergence there is precisely the shape the old bug took.

Writing them caught an error of mine too: the mixed force/crossbar case used an ops byte of `0xA9`, which forces ONE for A but leaves R on the crossbar rather than forced to ZERO. `0xA1` is the case meant.

## Verification

Tests pass under GCC, Clang and clang-cl. `rsx_d3d12_backend.c` compiles warning-free under clang-cl. Library, `ps3recomp_host` (clear and draw), scaffold ratchet and all 9 lifter suites green on Linux.

No behaviour change intended: same decode, one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WHFeSQJFeF141pFkYmKN5
