### PR TITLE
rsx: one primitive truth table, and a draw record that is not a D3D structure

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -125,7 +125,9 @@ jobs:
       # RSX texture layout -- format class, row sizes, Morton addressing. Pure
       # arithmetic with no host API in it, so it runs everywhere, and it is the
       # regression net for having lifted that maths out of the D3D12 uploader.
-      - name: Run self-contained RSX texture layout tests
+      - name: Run self-contained RSX tests
         run: |
           ${{ matrix.compiler == 'clang' && 'clang' || 'gcc' }} -std=gnu17 -Wall -Wextra -I include -I libs/video -o /tmp/test_texture_layout libs/video/tests/test_texture_layout.c libs/video/rsx_texture_layout.c
           /tmp/test_texture_layout
+          ${{ matrix.compiler == 'clang' && 'clang' || 'gcc' }} -std=gnu17 -Wall -Wextra -I include -I libs/video -o /tmp/test_rsx_primitives libs/video/tests/test_rsx_primitives.c
+          /tmp/test_rsx_primitives

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -88,7 +88,9 @@ jobs:
       # RSX texture layout -- format class, row sizes, Morton addressing. Pure
       # arithmetic with no host API in it, so it runs everywhere, and it is the
       # regression net for having lifted that maths out of the D3D12 uploader.
-      - name: Run self-contained RSX texture layout tests
+      - name: Run self-contained RSX tests
         run: |
           clang -std=gnu17 -Wall -Wextra -I include -I libs/video -o /tmp/test_texture_layout libs/video/tests/test_texture_layout.c libs/video/rsx_texture_layout.c
           /tmp/test_texture_layout
+          clang -std=gnu17 -Wall -Wextra -I include -I libs/video -o /tmp/test_rsx_primitives libs/video/tests/test_rsx_primitives.c
+          /tmp/test_rsx_primitives

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -92,7 +92,7 @@ jobs:
       # RSX texture layout -- format class, row sizes, Morton addressing. Pure
       # arithmetic with no host API in it, so it runs everywhere, and it is the
       # regression net for having lifted that maths out of the D3D12 uploader.
-      - name: Run self-contained RSX texture layout tests
+      - name: Run self-contained RSX tests
         # NOT shell: bash. Git Bash rewrites a leading-slash argument into a
         # Windows path, so /nologo arrived at the linker as an .obj under the
         # Git install directory. PowerShell leaves MSVC-style flags alone.
@@ -100,4 +100,8 @@ jobs:
           clang-cl /nologo /W0 /D_CRT_SECURE_NO_WARNINGS /I include /I libs/video /Fe:test_texture_layout.exe libs/video/tests/test_texture_layout.c libs/video/rsx_texture_layout.c
           if ($LASTEXITCODE -ne 0) { exit 1 }
           .\test_texture_layout.exe
+          if ($LASTEXITCODE -ne 0) { exit 1 }
+          clang-cl /nologo /W0 /D_CRT_SECURE_NO_WARNINGS /I include /I libs/video /Fe:test_rsx_primitives.exe libs/video/tests/test_rsx_primitives.c
+          if ($LASTEXITCODE -ne 0) { exit 1 }
+          .\test_rsx_primitives.exe
           if ($LASTEXITCODE -ne 0) { exit 1 }

--- a/libs/video/rsx_d3d12_backend.c
+++ b/libs/video/rsx_d3d12_backend.c
@@ -71,7 +71,7 @@
 typedef struct {
     u32 vb_byte_offset; /* offset into vb_mapped where this draw's verts live */
     u32 vertex_count;
-    u32 topology;       /* D3D_PRIMITIVE_TOPOLOGY_* */
+    u32 topology;       /* rsx_topology (NOT a D3D value; see topo_to_d3d) */
     int textured;       /* 1 = sample the bound font/atlas texture (dbgfont) */
     int is_vp;          /* 1 = real VP path: vb_byte_offset indexes vp_vb (float4) */
     /* VP path per-draw shader/texture state, captured at draw_arrays time. */
@@ -3486,6 +3486,22 @@ static void screen_copy_capture(u32 fi)
 
 }
 
+/* rsx_topology -> D3D_PRIMITIVE_TOPOLOGY. Spelled out rather than relying on
+ * the two enums happening to agree: the draw record carries the neutral value
+ * so a second backend can read it, and this is the one place it becomes a D3D
+ * one. */
+static D3D12_PRIMITIVE_TOPOLOGY topo_to_d3d(u32 t)
+{
+    switch (t) {
+    case RSX_TOPOLOGY_POINTS:         return D3D_PRIMITIVE_TOPOLOGY_POINTLIST;
+    case RSX_TOPOLOGY_LINES:          return D3D_PRIMITIVE_TOPOLOGY_LINELIST;
+    case RSX_TOPOLOGY_LINE_STRIP:     return D3D_PRIMITIVE_TOPOLOGY_LINESTRIP;
+    case RSX_TOPOLOGY_TRIANGLE_STRIP: return D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP;
+    case RSX_TOPOLOGY_TRIANGLES:      return D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST;
+    default:                          return D3D_PRIMITIVE_TOPOLOGY_UNDEFINED;
+    }
+}
+
 static void render_frame(void)
 {
     double _rf0 = perf_on() ? perf_now() : 0.0;
@@ -4081,11 +4097,11 @@ static void render_frame(void)
             ID3D12PipelineState* target_pso = s_d3d.pipeline_state; /* default triangle */
             if (dr->textured && s_d3d.tex_ready && s_d3d.pipeline_state_tex) {
                 target_pso = s_d3d.pipeline_state_tex;
-            } else if (dr->topology == D3D_TOPOLOGY_POINTLIST) {
+            } else if (dr->topology == RSX_TOPOLOGY_POINTS) {
                 target_pso = s_d3d.pipeline_state_points
                              ? s_d3d.pipeline_state_points : s_d3d.pipeline_state;
-            } else if (dr->topology == D3D_TOPOLOGY_LINELIST ||
-                       dr->topology == D3D_TOPOLOGY_LINESTRIP) {
+            } else if (dr->topology == RSX_TOPOLOGY_LINES ||
+                       dr->topology == RSX_TOPOLOGY_LINE_STRIP) {
                 target_pso = s_d3d.pipeline_state_lines
                              ? s_d3d.pipeline_state_lines : s_d3d.pipeline_state;
             }
@@ -4094,7 +4110,7 @@ static void render_frame(void)
                 last_pso = target_pso;
             }
             if (dr->topology != last_topo) {
-                s_d3d.cmd_list->lpVtbl->IASetPrimitiveTopology(s_d3d.cmd_list, dr->topology);
+                s_d3d.cmd_list->lpVtbl->IASetPrimitiveTopology(s_d3d.cmd_list, topo_to_d3d(dr->topology));
                 last_topo = dr->topology;
             }
             u32 start_vert = dr->vb_byte_offset / VERTEX_STRIDE;
@@ -4129,7 +4145,7 @@ static void render_frame(void)
         if (any && vpso) {
             s_d3d.cmd_list->lpVtbl->SetGraphicsRootSignature(s_d3d.cmd_list, s_d3d.vp_root_sig);
             s_d3d.cmd_list->lpVtbl->SetPipelineState(s_d3d.cmd_list, vpso);
-            s_d3d.cmd_list->lpVtbl->IASetPrimitiveTopology(s_d3d.cmd_list, D3D_TOPOLOGY_TRIANGLELIST);
+            s_d3d.cmd_list->lpVtbl->IASetPrimitiveTopology(s_d3d.cmd_list, D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
             s_d3d.cmd_list->lpVtbl->SetGraphicsRootConstantBufferView(s_d3d.cmd_list, 0,
                 s_d3d.vp_cb->lpVtbl->GetGPUVirtualAddress(s_d3d.vp_cb));
             ID3D12DescriptorHeap* heaps[] = { s_d3d.srv_heap };
@@ -5598,7 +5614,7 @@ static void d3d12_draw_arrays(void* ud, u32 primitive, u32 first, u32 count)
      * (exact position + texcoord): upload raw float4 attrib0 into vp_vb and
      * mark the draw is_vp; render_frame compiles the VP and draws it. Fall
      * back to the frac-approximation textured path if VP resources are absent. */
-    if (primitive == 8 /* CELL_GCM_PRIMITIVE_QUADS */) {
+    if (primitive == RSX_PRIMITIVE_QUADS) {
         /* Prefer the real vertex-program path whenever VP resources exist --
          * NOT only when a texture is bound. Requiring tex_bound routed vkcube's
          * UNtextured cube to the fixed-function fallback, which never applies the
@@ -5611,7 +5627,7 @@ static void d3d12_draw_arrays(void* ud, u32 primitive, u32 first, u32 count)
                 D3D12DrawRecord* dr = &s_d3d.draws[s_d3d.draw_count];
                 dr->vb_byte_offset = rec;
                 dr->vertex_count   = emitted;
-                dr->topology       = D3D_TOPOLOGY_TRIANGLELIST;
+                dr->topology       = RSX_TOPOLOGY_TRIANGLES;
                 dr->textured       = s_d3d.tex_bound;
                 dr->is_vp          = 1;
                 dr->fp_addr = s_d3d.current_rsx_state ? s_d3d.current_rsx_state->shader_program : 0;
@@ -5676,7 +5692,7 @@ static void d3d12_draw_arrays(void* ud, u32 primitive, u32 first, u32 count)
         if (s_d3d.draw_count < MAX_DRAWS) {
             s_d3d.draws[s_d3d.draw_count].vb_byte_offset = record_offset;
             s_d3d.draws[s_d3d.draw_count].vertex_count   = emitted;
-            s_d3d.draws[s_d3d.draw_count].topology       = D3D_TOPOLOGY_TRIANGLELIST;
+            s_d3d.draws[s_d3d.draw_count].topology       = RSX_TOPOLOGY_TRIANGLES;
             s_d3d.draws[s_d3d.draw_count].textured       = s_d3d.tex_bound;
             s_d3d.draws[s_d3d.draw_count].is_vp          = 0;
             s_d3d.draws[s_d3d.draw_count].is_clear       = 0;
@@ -5697,14 +5713,14 @@ static void d3d12_draw_arrays(void* ud, u32 primitive, u32 first, u32 count)
      * zero pixels (it also uploads to vp_vb, leaving the fixed-function vb empty).
      * Geometry already in clip space with no VP -- flOw's injected scene -- must
      * go down the fixed-function passthrough below instead. */
-    if ((primitive == 5 /* TRIANGLES */ || primitive == 6 /* TRIANGLE_STRIP */
-         || primitive == 7 /* TRIANGLE_FAN */) &&
+    if ((primitive == RSX_PRIMITIVE_TRIANGLES || primitive == RSX_PRIMITIVE_TRIANGLE_STRIP
+         || primitive == RSX_PRIMITIVE_TRIANGLE_FAN) &&
         s_d3d.vp_vb_mapped && s_d3d.vp_root_sig &&
         s_d3d.current_rsx_state && s_d3d.current_rsx_state->vp_ucode_bytes >= 16) {
         u32 rec = s_d3d.vp_vb_offset;
-        u32 emitted = (primitive == 5)
+        u32 emitted = (primitive == RSX_PRIMITIVE_TRIANGLES)
             ? upload_tris_vp(s_d3d.current_rsx_state, first, count)
-            : upload_strip_vp(s_d3d.current_rsx_state, first, count, primitive == 7);
+            : upload_strip_vp(s_d3d.current_rsx_state, first, count, primitive == RSX_PRIMITIVE_TRIANGLE_FAN);
         /* RSX splits one primitive stream across several DRAW_ARRAYS entries
          * inside a single BEGIN/END (each carries at most 256 vertices), and the
          * hardware concatenates them before assembling primitives. Recording a
@@ -5719,8 +5735,8 @@ static void d3d12_draw_arrays(void* ud, u32 primitive, u32 first, u32 count)
             D3D12DrawRecord* pv = &s_d3d.draws[s_d3d.draw_count - 1];
             u32 fpnow = s_d3d.current_rsx_state
                         ? s_d3d.current_rsx_state->shader_program : 0;
-            if (pv->is_vp && pv->topology == D3D_TOPOLOGY_TRIANGLELIST &&
-                pv->fp_addr == fpnow && primitive == 5 &&
+            if (pv->is_vp && pv->topology == RSX_TOPOLOGY_TRIANGLES &&
+                pv->fp_addr == fpnow && primitive == RSX_PRIMITIVE_TRIANGLES &&
                 pv->begin_epoch == (s_d3d.current_rsx_state
                                     ? s_d3d.current_rsx_state->begin_epoch : 0) &&
                 pv->vb_byte_offset + pv->vertex_count * VP_VERT_STRIDE == rec) {
@@ -5733,7 +5749,7 @@ static void d3d12_draw_arrays(void* ud, u32 primitive, u32 first, u32 count)
             D3D12DrawRecord* dr = &s_d3d.draws[s_d3d.draw_count];
             dr->vb_byte_offset = rec;
             dr->vertex_count   = emitted;
-            dr->topology       = D3D_TOPOLOGY_TRIANGLELIST;
+            dr->topology       = RSX_TOPOLOGY_TRIANGLES;
             dr->textured       = s_d3d.tex_bound;
             dr->is_vp          = 1;
             dr->fp_addr = s_d3d.current_rsx_state ? s_d3d.current_rsx_state->shader_program : 0;
@@ -5784,15 +5800,15 @@ static void d3d12_draw_arrays(void* ud, u32 primitive, u32 first, u32 count)
                 vp_record_cb(s_d3d.draw_count, dr->vs_idx, dr);
             s_d3d.draw_count++;
             /* Anchor for merging the next DRAW_ARRAYS batch of this stream. */
-            s_d3d.merge_prev_draw  = (primitive == 5);
+            s_d3d.merge_prev_draw  = (primitive == RSX_PRIMITIVE_TRIANGLES);
             s_d3d.merge_first_end  = first + count;
         }
         return;
     }
     s_d3d.merge_prev_draw = 0;   /* any other primitive breaks the stream */
 
-    u32 topo = rsx_to_d3d12_topology(primitive);
-    if (topo == D3D_TOPOLOGY_UNDEFINED) {
+    u32 topo = (u32)rsx_primitive_topology(primitive);
+    if (topo == RSX_TOPOLOGY_UNSUPPORTED) {
         /* Other primitives still needing index-buffer conversion
          * (line loops, triangle fans) — skip rather than draw wrong. */
         static int s_skipped_nontri = 0;
@@ -5838,10 +5854,10 @@ static void d3d12_draw_indexed(void* ud, u32 primitive, u32 first, u32 count)
      * list. Other primitives are skipped rather than drawn wrong. */
     u32 emitted = 0;
     u32 rec = s_d3d.vp_vb_offset;
-    if (primitive == 8)      emitted = upload_quads_vp_indexed(s_d3d.current_rsx_state, first, count);
-    else if (primitive == 5) emitted = upload_tris_vp_indexed(s_d3d.current_rsx_state, first, count);
-    else if (primitive == 6) emitted = upload_strip_vp_indexed(s_d3d.current_rsx_state, first, count, 0);
-    else if (primitive == 7) emitted = upload_strip_vp_indexed(s_d3d.current_rsx_state, first, count, 1);
+    if (primitive == RSX_PRIMITIVE_QUADS)             emitted = upload_quads_vp_indexed(s_d3d.current_rsx_state, first, count);
+    else if (primitive == RSX_PRIMITIVE_TRIANGLES)    emitted = upload_tris_vp_indexed(s_d3d.current_rsx_state, first, count);
+    else if (primitive == RSX_PRIMITIVE_TRIANGLE_STRIP) emitted = upload_strip_vp_indexed(s_d3d.current_rsx_state, first, count, 0);
+    else if (primitive == RSX_PRIMITIVE_TRIANGLE_FAN)   emitted = upload_strip_vp_indexed(s_d3d.current_rsx_state, first, count, 1);
     else {
         static int _skip = 0;
         if (_skip++ < 3)
@@ -5852,11 +5868,11 @@ static void d3d12_draw_indexed(void* ud, u32 primitive, u32 first, u32 count)
      * fluid arrives as ~3000 DRAW_INDEX_ARRAY batches of 256, and 256 is not a
      * multiple of 3, so every batch after the first assembled out of phase. */
     if (emitted && s_d3d.merge_prev_draw && s_d3d.draw_count > 0 &&
-        s_d3d.merge_first_end == first && primitive == 5) {
+        s_d3d.merge_first_end == first && primitive == RSX_PRIMITIVE_TRIANGLES) {
         D3D12DrawRecord* pv = &s_d3d.draws[s_d3d.draw_count - 1];
         u32 fpnow = s_d3d.current_rsx_state
                     ? s_d3d.current_rsx_state->shader_program : 0;
-        if (pv->is_vp && pv->topology == D3D_TOPOLOGY_TRIANGLELIST &&
+        if (pv->is_vp && pv->topology == RSX_TOPOLOGY_TRIANGLES &&
             pv->fp_addr == fpnow &&
             pv->begin_epoch == (s_d3d.current_rsx_state
                                 ? s_d3d.current_rsx_state->begin_epoch : 0) &&
@@ -5870,7 +5886,7 @@ static void d3d12_draw_indexed(void* ud, u32 primitive, u32 first, u32 count)
         D3D12DrawRecord* dr = &s_d3d.draws[s_d3d.draw_count];
         dr->vb_byte_offset = rec;
         dr->vertex_count   = emitted;
-        dr->topology       = D3D_TOPOLOGY_TRIANGLELIST;
+        dr->topology       = RSX_TOPOLOGY_TRIANGLES;
         dr->textured       = s_d3d.tex_bound;
         dr->is_vp          = 1;
         dr->fp_addr = s_d3d.current_rsx_state ? s_d3d.current_rsx_state->shader_program : 0;
@@ -5920,7 +5936,7 @@ static void d3d12_draw_indexed(void* ud, u32 primitive, u32 first, u32 count)
                 vp_record_cb(s_d3d.draw_count, dr->vs_idx, dr);
         s_d3d.draw_count++;
         /* Anchor for merging the next batch of this indexed stream. */
-        s_d3d.merge_prev_draw = (primitive == 5);
+        s_d3d.merge_prev_draw = (primitive == RSX_PRIMITIVE_TRIANGLES);
         s_d3d.merge_first_end = first + count;
     }
 }

--- a/libs/video/rsx_metal_backend.m
+++ b/libs/video/rsx_metal_backend.m
@@ -243,7 +243,6 @@ static MTLPrimitiveType topo_to_metal(rsx_topology t)
     default:                          return MTLPrimitiveTypeTriangle;
     }
 }
-}
 
 /* Emit `count` vertices starting at `first`, expanding fans/quads/polygons.
  * `resolve` maps a sequence position to a guest vertex index, so the same code

--- a/libs/video/rsx_metal_backend.m
+++ b/libs/video/rsx_metal_backend.m
@@ -25,6 +25,7 @@
 #include "rsx_commands.h"
 #include "rsx_metal_backend.h"
 #include "rsx_vertex_fetch.h"
+#include "rsx_primitives.h"
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -228,22 +229,20 @@ static void fetch_vertex(const rsx_state* st, u32 vi, MtlVertex* out)
  * fetched. Everything else maps directly.
  * --------------------------------------------------------------------------*/
 
-static int prim_needs_expansion(u32 prim)
+/* Which primitives need CPU expansion, and what they end up drawn as, both
+ * come from rsx_primitives.h now -- this file used to answer the first
+ * question with its own list, which disagreed with the one in that header
+ * about LINE_LOOP and POLYGON. Only the Metal enum mapping stays here. */
+static MTLPrimitiveType topo_to_metal(rsx_topology t)
 {
-    return prim == RSX_PRIMITIVE_QUADS      || prim == RSX_PRIMITIVE_QUAD_STRIP ||
-           prim == RSX_PRIMITIVE_TRIANGLE_FAN || prim == RSX_PRIMITIVE_POLYGON;
-}
-
-static MTLPrimitiveType prim_to_metal(u32 prim)
-{
-    switch (prim) {
-    case RSX_PRIMITIVE_POINTS:         return MTLPrimitiveTypePoint;
-    case RSX_PRIMITIVE_LINES:          return MTLPrimitiveTypeLine;
-    case RSX_PRIMITIVE_LINE_LOOP:      /* approximated as a strip */
-    case RSX_PRIMITIVE_LINE_STRIP:     return MTLPrimitiveTypeLineStrip;
-    case RSX_PRIMITIVE_TRIANGLE_STRIP: return MTLPrimitiveTypeTriangleStrip;
-    default:                           return MTLPrimitiveTypeTriangle;
+    switch (t) {
+    case RSX_TOPOLOGY_POINTS:         return MTLPrimitiveTypePoint;
+    case RSX_TOPOLOGY_LINES:          return MTLPrimitiveTypeLine;
+    case RSX_TOPOLOGY_LINE_STRIP:     return MTLPrimitiveTypeLineStrip;
+    case RSX_TOPOLOGY_TRIANGLE_STRIP: return MTLPrimitiveTypeTriangleStrip;
+    default:                          return MTLPrimitiveTypeTriangle;
     }
+}
 }
 
 /* Emit `count` vertices starting at `first`, expanding fans/quads/polygons.
@@ -314,8 +313,8 @@ static void record_draw(const rsx_state* st, u32 prim, u32 base, u32 count,
     d->base  = first_vert;
     d->count = wrote;
     /* Expanded primitives always come out as a triangle list. */
-    d->topology = prim_needs_expansion(prim) ? MTLPrimitiveTypeTriangle
-                                             : prim_to_metal(prim);
+    d->topology = rsx_primitive_needs_expansion(prim) ? MTLPrimitiveTypeTriangle
+                                             : topo_to_metal(rsx_primitive_topology(prim));
     d->blend_enable   = st->blend_enable;
     d->blend_sfactor  = st->blend_sfactor;
     d->blend_dfactor  = st->blend_dfactor;

--- a/libs/video/rsx_primitives.h
+++ b/libs/video/rsx_primitives.h
@@ -1,11 +1,22 @@
 /*
- * ps3recomp - RSX Primitive Type Mapping
+ * ps3recomp - RSX primitive types
  *
- * Maps RSX GPU primitive types to host API topologies.
- * Some RSX types (triangle fans, quads, line loops) don't have direct
- * D3D12/Vulkan equivalents and need index buffer conversion.
+ * Two questions every backend has to answer about a primitive, and neither is
+ * host-API business:
+ *
+ *   - can the hardware draw it directly, or must the CPU expand it first?
+ *   - which of the topologies every modern API does have does it become?
+ *
+ * Both were being answered separately in three places, and the three did not
+ * agree. The D3D12 backend dispatched on bare numbers (`primitive == 8`) with
+ * the name only in a comment. The Metal backend had its own prim_to_metal and
+ * prim_needs_expansion. This header had a third set that nothing called at all
+ * -- and which counted LINE_LOOP as needing conversion while leaving POLYGON
+ * out, the opposite of what Metal did. Those dead helpers generated index
+ * buffers, which is not how either backend actually works: both expand
+ * vertices on the CPU. They are gone rather than reconciled; a third backend
+ * following them would have written the wrong thing.
  */
-
 #ifndef PS3RECOMP_RSX_PRIMITIVES_H
 #define PS3RECOMP_RSX_PRIMITIVES_H
 
@@ -15,95 +26,56 @@
 extern "C" {
 #endif
 
-/* D3D12 topology values (from d3dcommon.h) */
-#define D3D_TOPOLOGY_UNDEFINED          0
-#define D3D_TOPOLOGY_POINTLIST          1
-#define D3D_TOPOLOGY_LINELIST           2
-#define D3D_TOPOLOGY_LINESTRIP          3
-#define D3D_TOPOLOGY_TRIANGLELIST       4
-#define D3D_TOPOLOGY_TRIANGLESTRIP      5
+/* The topologies every modern host API has. A backend maps these to its own
+ * enum; nothing here assumes any particular API's numbering. */
+typedef enum {
+    RSX_TOPOLOGY_UNSUPPORTED = 0,
+    RSX_TOPOLOGY_POINTS,
+    RSX_TOPOLOGY_LINES,
+    RSX_TOPOLOGY_LINE_STRIP,
+    RSX_TOPOLOGY_TRIANGLES,
+    RSX_TOPOLOGY_TRIANGLE_STRIP
+} rsx_topology;
 
-/* Map RSX primitive type to D3D12 topology.
- * Returns 0 (undefined) for types that need index conversion. */
-static inline u32 rsx_to_d3d12_topology(u32 rsx_prim)
+/* Does drawing this primitive require the CPU to expand it into triangles
+ * first?
+ *
+ * Quads, quad strips, triangle fans and polygons have no equivalent on any
+ * modern API, so their vertices must be re-emitted as a triangle list.
+ *
+ * LINE_LOOP is deliberately NOT in that set. It is a line strip plus one
+ * closing edge, which is a smaller fix than a full expansion, and both
+ * backends currently approximate it as a plain strip -- so saying "yes" here
+ * would claim an expansion that neither performs. Whoever closes the loop
+ * should revisit this, and the test says so. */
+static inline int rsx_primitive_needs_expansion(u32 rsx_prim)
+{
+    return rsx_prim == RSX_PRIMITIVE_QUADS      ||
+           rsx_prim == RSX_PRIMITIVE_QUAD_STRIP ||
+           rsx_prim == RSX_PRIMITIVE_TRIANGLE_FAN ||
+           rsx_prim == RSX_PRIMITIVE_POLYGON;
+}
+
+/* The topology this primitive is DRAWN as, after any expansion above.
+ *
+ * So the expandable types report TRIANGLES: that is what comes out of the
+ * expansion, not a claim the hardware understands them. LINE_LOOP reports
+ * LINE_STRIP, matching the approximation described above. */
+static inline rsx_topology rsx_primitive_topology(u32 rsx_prim)
 {
     switch (rsx_prim) {
-    case RSX_PRIMITIVE_POINTS:         return D3D_TOPOLOGY_POINTLIST;
-    case RSX_PRIMITIVE_LINES:          return D3D_TOPOLOGY_LINELIST;
-    case RSX_PRIMITIVE_LINE_STRIP:     return D3D_TOPOLOGY_LINESTRIP;
-    case RSX_PRIMITIVE_TRIANGLES:      return D3D_TOPOLOGY_TRIANGLELIST;
-    case RSX_PRIMITIVE_TRIANGLE_STRIP: return D3D_TOPOLOGY_TRIANGLESTRIP;
-    /* These need index buffer conversion: */
-    case RSX_PRIMITIVE_LINE_LOOP:      return D3D_TOPOLOGY_LINESTRIP;  /* + extra edge */
-    case RSX_PRIMITIVE_TRIANGLE_FAN:   return D3D_TOPOLOGY_TRIANGLELIST; /* expand */
-    case RSX_PRIMITIVE_QUADS:          return D3D_TOPOLOGY_TRIANGLELIST; /* 2 tris/quad */
-    case RSX_PRIMITIVE_QUAD_STRIP:     return D3D_TOPOLOGY_TRIANGLELIST; /* expand */
-    default:                           return D3D_TOPOLOGY_UNDEFINED;
+    case RSX_PRIMITIVE_POINTS:         return RSX_TOPOLOGY_POINTS;
+    case RSX_PRIMITIVE_LINES:          return RSX_TOPOLOGY_LINES;
+    case RSX_PRIMITIVE_LINE_LOOP:      /* approximated: no closing edge yet */
+    case RSX_PRIMITIVE_LINE_STRIP:     return RSX_TOPOLOGY_LINE_STRIP;
+    case RSX_PRIMITIVE_TRIANGLE_STRIP: return RSX_TOPOLOGY_TRIANGLE_STRIP;
+    case RSX_PRIMITIVE_TRIANGLES:
+    case RSX_PRIMITIVE_TRIANGLE_FAN:   /* expanded to a list */
+    case RSX_PRIMITIVE_QUADS:
+    case RSX_PRIMITIVE_QUAD_STRIP:
+    case RSX_PRIMITIVE_POLYGON:        return RSX_TOPOLOGY_TRIANGLES;
+    default:                           return RSX_TOPOLOGY_UNSUPPORTED;
     }
-}
-
-/* Check if a primitive type needs index conversion.
- * Returns 1 if indices need to be generated. */
-static inline int rsx_prim_needs_conversion(u32 rsx_prim)
-{
-    return (rsx_prim == RSX_PRIMITIVE_LINE_LOOP ||
-            rsx_prim == RSX_PRIMITIVE_TRIANGLE_FAN ||
-            rsx_prim == RSX_PRIMITIVE_QUADS ||
-            rsx_prim == RSX_PRIMITIVE_QUAD_STRIP);
-}
-
-/* Convert a triangle fan (N vertices) to triangle list indices.
- * Writes (N-2)*3 indices to out_indices.
- * Returns the number of indices written. */
-static inline u32 rsx_convert_triangle_fan(u32 first, u32 count,
-                                            u32* out_indices, u32 max_indices)
-{
-    if (count < 3) return 0;
-    u32 num_tris = count - 2;
-    u32 num_indices = num_tris * 3;
-    if (num_indices > max_indices) return 0;
-
-    for (u32 i = 0; i < num_tris; i++) {
-        out_indices[i * 3]     = first;         /* center vertex */
-        out_indices[i * 3 + 1] = first + i + 1;
-        out_indices[i * 3 + 2] = first + i + 2;
-    }
-    return num_indices;
-}
-
-/* Convert quads (N vertices, N/4 quads) to triangle list indices.
- * Writes (N/4)*6 indices.
- * Returns the number of indices written. */
-static inline u32 rsx_convert_quads(u32 first, u32 count,
-                                     u32* out_indices, u32 max_indices)
-{
-    u32 num_quads = count / 4;
-    u32 num_indices = num_quads * 6;
-    if (num_indices > max_indices) return 0;
-
-    for (u32 i = 0; i < num_quads; i++) {
-        u32 base = first + i * 4;
-        out_indices[i * 6]     = base;
-        out_indices[i * 6 + 1] = base + 1;
-        out_indices[i * 6 + 2] = base + 2;
-        out_indices[i * 6 + 3] = base;
-        out_indices[i * 6 + 4] = base + 2;
-        out_indices[i * 6 + 5] = base + 3;
-    }
-    return num_indices;
-}
-
-/* Convert line loop (N vertices) to line strip + closing edge.
- * Returns the original count (line strip renders N-1 segments,
- * caller needs to add one extra segment from last to first). */
-static inline u32 rsx_convert_line_loop(u32 first, u32 count,
-                                         u32* out_indices, u32 max_indices)
-{
-    if (count < 2 || count + 1 > max_indices) return 0;
-    for (u32 i = 0; i < count; i++)
-        out_indices[i] = first + i;
-    out_indices[count] = first; /* close the loop */
-    return count + 1;
 }
 
 #ifdef __cplusplus

--- a/libs/video/tests/test_rsx_primitives.c
+++ b/libs/video/tests/test_rsx_primitives.c
@@ -1,0 +1,107 @@
+/*
+ * ps3recomp - self-contained tests for RSX primitive classification
+ *
+ *   cc -I include -I libs/video -o /tmp/t libs/video/tests/test_rsx_primitives.c && /tmp/t
+ *
+ * rsx_primitives.h is header-only, so there is nothing to link.
+ *
+ * This pins a truth table that three places in the tree previously answered
+ * differently: the D3D12 backend (bare numbers), the Metal backend (its own
+ * list), and a set of helpers in this header that nothing called. The two that
+ * were live disagreed about LINE_LOOP and POLYGON.
+ */
+#include "rsx_primitives.h"
+
+#include <stdio.h>
+
+static int g_fail = 0;
+
+#define CHECK(cond)                                                            \
+    do { if (!(cond)) { printf("FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+                        g_fail++; } } while (0)
+
+#define CHECK_EQ(got, want)                                                    \
+    do { long _g = (long)(got), _w = (long)(want);                             \
+         if (_g != _w) { printf("FAIL %s:%d  %s = %ld, want %ld\n",            \
+                                __FILE__, __LINE__, #got, _g, _w);             \
+                         g_fail++; } } while (0)
+
+/* Every primitive the RSX defines, and what each must come out as. Written as
+ * a table so a disagreement is visible rather than buried in control flow. */
+static const struct {
+    u32          prim;
+    const char*  name;
+    int          expand;
+    rsx_topology topo;
+} k_expected[] = {
+    { RSX_PRIMITIVE_POINTS,         "POINTS",         0, RSX_TOPOLOGY_POINTS         },
+    { RSX_PRIMITIVE_LINES,          "LINES",          0, RSX_TOPOLOGY_LINES          },
+    /* LINE_LOOP is a strip plus a closing edge. Neither backend draws that edge
+     * yet, so it is NOT reported as needing expansion -- claiming otherwise
+     * would promise work nobody does. */
+    { RSX_PRIMITIVE_LINE_LOOP,      "LINE_LOOP",      0, RSX_TOPOLOGY_LINE_STRIP     },
+    { RSX_PRIMITIVE_LINE_STRIP,     "LINE_STRIP",     0, RSX_TOPOLOGY_LINE_STRIP     },
+    { RSX_PRIMITIVE_TRIANGLES,      "TRIANGLES",      0, RSX_TOPOLOGY_TRIANGLES      },
+    { RSX_PRIMITIVE_TRIANGLE_STRIP, "TRIANGLE_STRIP", 0, RSX_TOPOLOGY_TRIANGLE_STRIP },
+    { RSX_PRIMITIVE_TRIANGLE_FAN,   "TRIANGLE_FAN",   1, RSX_TOPOLOGY_TRIANGLES      },
+    { RSX_PRIMITIVE_QUADS,          "QUADS",          1, RSX_TOPOLOGY_TRIANGLES      },
+    { RSX_PRIMITIVE_QUAD_STRIP,     "QUAD_STRIP",     1, RSX_TOPOLOGY_TRIANGLES      },
+    { RSX_PRIMITIVE_POLYGON,        "POLYGON",        1, RSX_TOPOLOGY_TRIANGLES      },
+};
+
+static void test_truth_table(void)
+{
+    for (unsigned i = 0; i < sizeof k_expected / sizeof k_expected[0]; i++) {
+        int  e = rsx_primitive_needs_expansion(k_expected[i].prim);
+        rsx_topology t = rsx_primitive_topology(k_expected[i].prim);
+        if (e != k_expected[i].expand)
+            { printf("FAIL %s: needs_expansion = %d, want %d\n",
+                     k_expected[i].name, e, k_expected[i].expand); g_fail++; }
+        if (t != k_expected[i].topo)
+            { printf("FAIL %s: topology = %d, want %d\n",
+                     k_expected[i].name, (int)t, (int)k_expected[i].topo); g_fail++; }
+    }
+}
+
+/* The contract between the two functions: if a primitive needs expanding, the
+ * expansion produces a triangle list, so its topology MUST be TRIANGLES.
+ * Anything else would have a backend expand into one topology and then draw
+ * with another. */
+static void test_expansion_implies_triangles(void)
+{
+    for (u32 p = 0; p < 16; p++)
+        if (rsx_primitive_needs_expansion(p))
+            CHECK_EQ(rsx_primitive_topology(p), RSX_TOPOLOGY_TRIANGLES);
+}
+
+/* Nothing outside the defined range may claim to be drawable: an unknown
+ * primitive that reported TRIANGLES would be silently drawn as garbage rather
+ * than skipped. */
+static void test_unknown_is_unsupported(void)
+{
+    CHECK_EQ(rsx_primitive_topology(0),   RSX_TOPOLOGY_UNSUPPORTED);
+    CHECK_EQ(rsx_primitive_topology(11),  RSX_TOPOLOGY_UNSUPPORTED);
+    CHECK_EQ(rsx_primitive_topology(255), RSX_TOPOLOGY_UNSUPPORTED);
+    CHECK(!rsx_primitive_needs_expansion(0));
+    CHECK(!rsx_primitive_needs_expansion(11));
+    CHECK(!rsx_primitive_needs_expansion(255));
+}
+
+/* UNSUPPORTED must stay 0: the D3D12 backend's legacy path tests the returned
+ * topology for falsity to decide whether it can draw at all. */
+static void test_unsupported_is_zero(void)
+{
+    CHECK_EQ(RSX_TOPOLOGY_UNSUPPORTED, 0);
+}
+
+int main(void)
+{
+    test_truth_table();
+    test_expansion_implies_triangles();
+    test_unknown_is_unsupported();
+    test_unsupported_is_zero();
+
+    if (g_fail) { printf("\nRSX primitives: %d FAILED\n", g_fail); return 1; }
+    printf("RSX primitive tests: all passed\n");
+    return 0;
+}


### PR DESCRIPTION
﻿Two questions every backend asks about a primitive — can the hardware draw it directly, and which topology does it become — were answered in **three places that did not agree**.

- The D3D12 backend dispatched on bare numbers: `primitive == 8`, with the name only in a trailing comment.
- The Metal backend had its own `prim_needs_expansion` and `prim_to_metal`.
- `rsx_primitives.h` had a third set that **nothing called**. Its `rsx_prim_needs_conversion` counted LINE_LOOP as needing conversion and left POLYGON out — the opposite of Metal on both.

Those dead helpers generated *index buffers*, which is not how either backend works: both expand vertices on the CPU. Deleted rather than reconciled, since a third backend following them would have written the wrong thing.

| | LINE_LOOP | TRIANGLE_FAN | QUADS | QUAD_STRIP | POLYGON |
|---|---|---|---|---|---|
| dead helper | yes | yes | yes | yes | **no** |
| Metal | **no** | yes | yes | yes | yes |
| now (shared) | no | yes | yes | yes | yes |

The shared answers match what the live backends already do, so **no rendering changes**.

LINE_LOOP is deliberately reported as *not* needing expansion. It's a strip plus a closing edge, and neither backend draws that edge yet — claiming otherwise would promise work nobody performs. The test records it as a known approximation rather than leaving it to be rediscovered.

## The draw record stops being a D3D structure

Its `topology` field held `D3D_PRIMITIVE_TOPOLOGY` values, so any other backend reading a recorded draw would have had to decode D3D's enum first. It now holds `rsx_topology`, and each backend converts at the single point it talks to its own API — `topo_to_d3d()` and `topo_to_metal()`, both spelled out rather than relying on the two enums happening to number their members identically (which they currently do).

D3D12's bare primitive numbers become `RSX_PRIMITIVE_*` names. Same values; a reader no longer needs the comment to know 7 is a triangle fan.

## Tests

`test_rsx_primitives.c` pins the table for all ten primitives plus out-of-range input, and asserts two things the table alone doesn't:

- anything needing expansion must report TRIANGLES — otherwise a backend expands into one topology and draws with another
- `UNSUPPORTED` stays 0, which the D3D12 legacy path relies on to decide it cannot draw

Checked for teeth: dropping POLYGON from the expansion set, or mapping LINE_LOOP to LINES, each fails it.

## Verification

Both tests pass under GCC, Clang and clang-cl. `rsx_d3d12_backend.c` compiles warning-free under clang-cl. The Metal call site compiles in its new shape — there's no Objective-C compiler here, so **the macOS job is the real check on that file**. Library, `ps3recomp_host`, scaffold ratchet and 9/9 lifter suites green on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WHFeSQJFeF141pFkYmKN5
