### PR TITLE
vm: let the port choose the HLE-visible GCM window base

### DIFF
--- a/libs/video/cellGcmSys.c
+++ b/libs/video/cellGcmSys.c
@@ -123,6 +123,10 @@ static CellGcmControl s_control;
  * and control blocks, published on each call. 4096 pages covers the 4 GiB
  * address space at 1 MiB granularity, 8 KiB a side, and this is not a hot path.
  * 0xFFFF means "not mapped", as it does in the host tables. */
+/* Default home for the HLE-visible GCM window; a port overrides it before
+ * running guest code when its title claims this address range. */
+uint32_t ppu_hle_inject_base = 0x20000000u;
+
 static u16 s_io_address_table[65536];
 static u16 s_ea_address_table[65536];
 

--- a/runtime/memory/vm.h
+++ b/runtime/memory/vm.h
@@ -62,7 +62,26 @@ extern "C" {
  * below the raw-SPU windows (0x30000000). The title only ever learns these
  * addresses through cellGcmGetLabelAddress / cellGcmGetControlRegister, so the
  * value is free to move as long as every user goes through this base. */
-#define VM_HLE_INJECT_BASE  0x20000000u
+/* No fixed value works for every title. 0x03000000 was the original home until
+ * flOw's heap grew over it; 0x20000000 replaced it and Gran Turismo 5 Prologue
+ * maps its own 174 MB heap there (cellGcmMapMainMemory(0x20000000, 0xAE00000)),
+ * so the GCM window and its 16 KB of offset tables landed on the game's own
+ * allocations and quietly destroyed them. The same failure, one address along.
+ *
+ * So it is a variable, not a constant: a port that knows its title's memory map
+ * assigns ppu_hle_inject_base before it runs any guest code, and everything
+ * derived from VM_HLE_INJECT_BASE follows. The default is the historical value.
+ * The window needs 0x8000 bytes and the title only ever learns these addresses
+ * through cellGcmGetLabelAddress / cellGcmGetControlRegister /
+ * cellGcmGetOffsetTable, so it is free to move. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+extern uint32_t ppu_hle_inject_base;
+#ifdef __cplusplus
+}
+#endif
+#define VM_HLE_INJECT_BASE  ppu_hle_inject_base
 
 #define VM_PAGE_SIZE        0x00001000u      /* 4 KB page size */
 


### PR DESCRIPTION
`VM_HLE_INJECT_BASE` is where `cellGcmSys` publishes the label block, the control
register, and the two 4096-entry offset tables the guest reads through
`cellGcmGetOffsetTable` — **0x8000 bytes of guest address space the runtime
writes without the title's knowledge.**

## No fixed value works

`0x03000000` was the original home until flOw's heap grew over it. `0x20000000`
replaced it — and Gran Turismo 5 Prologue maps its own 174 MB heap exactly
there:

```
[cellGcmSys] MapMainMemory(ea=0x20000000, size=0xAE00000)
```

So every `gcm_publish_offset_tables()` wrote 16 KB of `0xFFFF` straight through
the game's own allocations, at `0x20003000..0x20007000`.

## What that cost

In GT5P it landed on the CRT allocator's size-class table. Entry 5's `size`
field read `-1` instead of `0x18`, and `func_008B0920`'s only test is
`size == 0` ("class unused, fall back to the general allocator"). With `-1` it
never took that branch: it popped from a free list whose links were garbage,
returned poisoned pointers, and the main thread livelocked for the entire boot
about two million iterations deep.

Nothing in any log said why. The write is host-side, so no store watch sees it —
it took a page guard armed at a known-good instant to catch it, and then the
range `0x20003000..0x20007000` with halfword granularity named it on sight.

## The fix

Make it a variable. A port that knows its title's memory map assigns
`ppu_hle_inject_base` before running any guest code, and everything derived from
`VM_HLE_INJECT_BASE` follows:

```c
ppu_hle_inject_base = 0x03000000u;   /* before vm_init() */
```

The default is unchanged, so existing ports behave exactly as before. The title
only ever learns these addresses through `cellGcmGetLabelAddress` /
`cellGcmGetControlRegister` / `cellGcmGetOffsetTable`, so the window is free to
move.

## Verified

With GT5P's port setting the base, the allocator pool survives the whole boot
(a canary on the corrupted word never fires) and the main thread progresses past
the livelock instead of spinning there forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMAcq6gVEVdf6qLaLTKyZd