### PR TITLE
ppu: start the frame clock on POSIX, and check the file it lives in

### DIFF
--- a/runtime/ppu/tests/boot_main.cpp
+++ b/runtime/ppu/tests/boot_main.cpp
@@ -24,6 +24,7 @@
  * qualifier existed do not define it, so the scaffold must carry its own
  * reachable definition. */
 #include "../ppu_tls.h"
+#include "../../platform/win32_compat.h"      /* Sleep, GetTickCount64, threads on POSIX */
 #include "../../platform/win32_backtrace.h"   /* RtlCaptureStackBackTrace / GetModuleHandleA on POSIX */
 /* The lifted ppu_recomp.h already defines `struct ppu_context` (identical to
  * runtime/ppu/ppu_context.h by design -- "keep the two in sync"). A syscall
@@ -178,13 +179,32 @@ static void harness_guest_caller(uint32_t opd, uint64_t a0, uint64_t a1,
                                  uint64_t a5, uint64_t a6, uint64_t a7)
 { ppu_guest_call(opd, a0, a1, a2, a3, a4, a5, a6, a7); }
 
-#ifdef _WIN32
-/* RSX present backend (libs/video/rsx_d3d12_backend.c). Driven on the vblank
- * thread so the D3D12 device + window message pump live on one thread. */
+/* RSX present backend. D3D12 on Windows, Metal on Apple, and the null
+ * backend's headless software path anywhere else -- the same selection
+ * runtime/host/host_posix.c makes, so the ticker below is backend-agnostic
+ * and a POSIX host gets a frame clock instead of no clock at all. */
+#if defined(_WIN32)
 extern "C" int  rsx_d3d12_backend_init(uint32_t w, uint32_t h, const char* title);
 extern "C" void rsx_d3d12_backend_present(void);
-extern "C" int cellGcm_take_flip_pending(void);
 extern "C" int  rsx_d3d12_backend_pump_messages(void);
+#  define rsx_backend_init    rsx_d3d12_backend_init
+#  define rsx_backend_present rsx_d3d12_backend_present
+#  define rsx_backend_pump    rsx_d3d12_backend_pump_messages
+#elif defined(__APPLE__)
+extern "C" int  rsx_metal_backend_init(uint32_t w, uint32_t h, const char* title);
+extern "C" void rsx_metal_backend_present(void);
+extern "C" int  rsx_metal_backend_pump_messages(void);
+#  define rsx_backend_init    rsx_metal_backend_init
+#  define rsx_backend_present rsx_metal_backend_present
+#  define rsx_backend_pump    rsx_metal_backend_pump_messages
+#else
+extern "C" int  rsx_null_backend_init(uint32_t w, uint32_t h, const char* title);
+extern "C" void rsx_null_backend_present(void);
+extern "C" int  rsx_null_backend_pump_messages(void);
+#  define rsx_backend_init    rsx_null_backend_init
+#  define rsx_backend_present rsx_null_backend_present
+#  define rsx_backend_pump    rsx_null_backend_pump_messages
+#endif
 extern "C" void cellGcm_rsx_process_fifo(void);   /* cellGcmSys.c: drain get->put */
 extern "C" unsigned cellGcm_flip_request_count(void);
 extern "C" int sys_event_queue_inject(unsigned int, unsigned long long, unsigned long long, unsigned long long, unsigned long long);
@@ -243,7 +263,7 @@ static DWORD WINAPI vblank_ticker(LPVOID)
 {
     const char* _title = getenv("PS3_TITLE");
     if (!_title || !*_title) _title = "You Don't Know Jack (ps3recomp)";
-    int rsx_ok = (rsx_d3d12_backend_init(1280, 720, _title) == 0);
+    int rsx_ok = (rsx_backend_init(1280, 720, _title) == 0);
     fprintf(stderr, "[rsx] backend init %s\n", rsx_ok ? "OK -- window open" : "FAILED");
     unsigned last_flip = 0;
     /* The game's frame pacing (vblank/flip handlers -> display frame counter) must
@@ -266,7 +286,7 @@ static DWORD WINAPI vblank_ticker(LPVOID)
              * writes and showed empty or mixed batches. */
             {
                 if (rsx_ok && cellGcm_take_flip_pending()) {
-                    rsx_d3d12_backend_present();
+                    rsx_backend_present();
                     last_flip = cellGcm_flip_request_count();
                 }
             }
@@ -285,7 +305,7 @@ static DWORD WINAPI vblank_ticker(LPVOID)
          * The real RSX writes those fences in microseconds. */
         if (rsx_ok) {
             if (cellGcm_take_flip_pending()) {
-                rsx_d3d12_backend_present();
+                rsx_backend_present();
                 last_flip = cellGcm_flip_request_count();
             }
             cellGcm_rsx_process_fifo();
@@ -299,11 +319,11 @@ static DWORD WINAPI vblank_ticker(LPVOID)
             if(++s_q3 % 8 == 0){ int r=sys_event_queue_inject(qid, 0x1234, 0, 0, 0);
               static int _n=0; if(_n++<12) fprintf(stderr,"[INJQ3] injected q%u event rc=%d\n",qid,r); } }
         if (rsx_ok) {
-            if (rsx_d3d12_backend_pump_messages() != 0) { rsx_ok = 0; }
+            if (rsx_backend_pump() != 0) { rsx_ok = 0; }
             if (getenv("YDKJ_PACETRACE")) {
                 static ULONGLONG s_win=0; static int s_pf=0, s_pres=0; static ULONGLONG s_presms=0;
                 s_pf += fired; s_pres++;
-                ULONGLONG t0=GetTickCount64(); rsx_d3d12_backend_present(); ULONGLONG t1=GetTickCount64();
+                ULONGLONG t0=GetTickCount64(); rsx_backend_present(); ULONGLONG t1=GetTickCount64();
                 s_presms += (t1-t0);
                 if (s_win==0) s_win=now;
                 if (now - s_win >= 1000) {
@@ -320,7 +340,7 @@ static DWORD WINAPI vblank_ticker(LPVOID)
                  * during boot. */
                 unsigned fc = cellGcm_flip_request_count();
                 if (fc != last_flip || fc == 0) {
-                    rsx_d3d12_backend_present();
+                    rsx_backend_present();
                     last_flip = fc;
                 }
             }
@@ -331,6 +351,13 @@ static DWORD WINAPI vblank_ticker(LPVOID)
 
 extern "C" uint32_t    g_last_hle_nid;
 extern "C" const char* g_last_hle_name;
+
+/* Windows-only from here to the end of hang_watchdog. Snapshotting every
+ * OTHER thread and reading its instruction pointer needs tlhelp32 plus
+ * SuspendThread/GetThreadContext; POSIX has no equivalent that does not
+ * amount to writing a debugger. The vblank ticker above, which is what the
+ * frame loop actually depends on, is deliberately outside this. */
+#ifdef _WIN32
 #include <tlhelp32.h>
 /* When the boot wedges, snapshot every other thread's instruction pointer as a
  * module RVA (symbolize with llvm-symbolizer) so a guest spin/wait is pinned to
@@ -583,11 +610,14 @@ int main(int argc, char** argv)
      * so the game's frame loop advances (it no-ops until the game registers its
      * vblank/flip handlers during init). */
     g_ps3_guest_caller = harness_guest_caller;
-#ifdef _WIN32
+    /* CreateThread is a pthread wrapper off Windows (win32_compat.h), so the
+     * frame clock now runs everywhere. Without it a POSIX host never ticks
+     * vblank or drains the FIFO, and the guest waits on fences forever. */
     CreateThread(NULL, 4u * 1024 * 1024, vblank_ticker, NULL, 0, NULL);
-    CreateThread(NULL, 0, hang_watchdog, NULL, 0, NULL);
     if (getenv("PS3_GUEST_PROF"))
         CreateThread(NULL, 0, guest_prof_thread, NULL, 0, NULL);
+#ifdef _WIN32
+    CreateThread(NULL, 0, hang_watchdog, NULL, 0, NULL);   /* tlhelp32-based */
 #endif
 
     printf("\n[boot] dispatching entry OPD 0x%08X (stack top 0x%08X)\n\n", entry, STACK_TOP);

--- a/runtime/syscalls/lv2_syscall_table.h
+++ b/runtime/syscalls/lv2_syscall_table.h
@@ -289,11 +289,18 @@ static inline void lv2_syscall_dispatch(lv2_syscall_table* tbl, ppu_context* ctx
     ctx->gpr[3] = (uint64_t)handler(ctx);
 }
 
-/* Convenience wrapper using the global table */
-static inline void lv2_syscall(ppu_context* ctx)
-{
-    lv2_syscall_dispatch(&g_lv2_syscalls, ctx);
-}
+/* No lv2_syscall() wrapper here on purpose. The real one lives in the PPU
+ * boot harness (ppu_loader.cpp) and does considerably more than dispatch:
+ * it arms the page guard, tracks which lv2 call each guest thread is
+ * inside, handles the boot-critical calls inline and stamps the profiler.
+ * A convenience wrapper used to sit here, static inline, calling
+ * lv2_syscall_dispatch directly -- nothing called it, but any translation
+ * unit including both this header and the lifter-generated one bound the
+ * name to the stripped-down version instead of the real one, and the two
+ * declarations (extern there, static here) are contradictory besides.
+ * GCC rejects the combination outright; Clang accepted it. Call
+ * lv2_syscall_dispatch(&g_lv2_syscalls, ctx) if that is genuinely what
+ * you want. */
 
 /* ---------------------------------------------------------------------------
  * Argument extraction macros for syscall handlers

--- a/tools/check_ppu_scaffold.py
+++ b/tools/check_ppu_scaffold.py
@@ -45,14 +45,18 @@ import tempfile
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASELINE = os.path.join(ROOT, "tools", "ppu_scaffold_baseline.json")
 
-# The scaffold translation units. boot_main.cpp is deliberately absent: it also
-# includes the per-game SPU recomp header and pulls in the generated function
-# table, so a stub cannot stand in for it.
+# The scaffold translation units.
+#
+# boot_main.cpp used to be excluded here on the grounds that it needed the
+# per-game SPU recomp header too. It does not -- ppu_recomp.h is the only
+# generated header it wants, and the stub covers that. Leaving it out meant
+# the file the frame clock lives in was the one file nothing checked.
 SOURCES = [
     "runtime/ppu/ppu_loader.cpp",
     "runtime/ppu/ppu_hle.cpp",
     "runtime/ppu/ppu_fs.cpp",
     "runtime/ppu/ppu_sysprx.cpp",
+    "runtime/ppu/tests/boot_main.cpp",
 ]
 
 INCLUDE_DIRS = [
@@ -60,6 +64,7 @@ INCLUDE_DIRS = [
     "runtime/ppu",
     "runtime/spu",
     "runtime/memory",
+    "runtime/syscalls",
     "libs/video",
 ]
 

--- a/tools/ppu_scaffold_baseline.json
+++ b/tools/ppu_scaffold_baseline.json
@@ -3,24 +3,28 @@
     "runtime/ppu/ppu_fs.cpp": 0,
     "runtime/ppu/ppu_hle.cpp": 0,
     "runtime/ppu/ppu_loader.cpp": 0,
-    "runtime/ppu/ppu_sysprx.cpp": 0
+    "runtime/ppu/ppu_sysprx.cpp": 0,
+    "runtime/ppu/tests/boot_main.cpp": 0
   },
   "linux-clang": {
     "runtime/ppu/ppu_fs.cpp": 0,
     "runtime/ppu/ppu_hle.cpp": 0,
     "runtime/ppu/ppu_loader.cpp": 0,
-    "runtime/ppu/ppu_sysprx.cpp": 0
+    "runtime/ppu/ppu_sysprx.cpp": 0,
+    "runtime/ppu/tests/boot_main.cpp": 0
   },
   "linux-gcc": {
     "runtime/ppu/ppu_fs.cpp": 0,
     "runtime/ppu/ppu_hle.cpp": 0,
     "runtime/ppu/ppu_loader.cpp": 0,
-    "runtime/ppu/ppu_sysprx.cpp": 0
+    "runtime/ppu/ppu_sysprx.cpp": 0,
+    "runtime/ppu/tests/boot_main.cpp": 0
   },
   "windows-clang-cl": {
     "runtime/ppu/ppu_fs.cpp": 0,
     "runtime/ppu/ppu_hle.cpp": 0,
     "runtime/ppu/ppu_loader.cpp": 0,
-    "runtime/ppu/ppu_sysprx.cpp": 0
+    "runtime/ppu/ppu_sysprx.cpp": 0,
+    "runtime/ppu/tests/boot_main.cpp": 0
   }
 }


### PR DESCRIPTION
﻿The boot harness started its vblank ticker inside `#ifdef _WIN32` with **no `#else`**, so a POSIX host had no frame clock at all: nothing ticked vblank, nothing drained the GCM FIFO, and a guest waiting on an RSX fence label waited forever. That's the gap between *"the scaffold compiles off Windows"* and *"a title could run there"*.

## Two things had to be true first — and I had the second one wrong

**The ticker presents through the render backend**, naming `rsx_d3d12_backend_*` directly, which doesn't exist off Windows. It now selects a backend the way `runtime/host/host_posix.c` already does — D3D12 on Windows, Metal on Apple, the null backend's headless software path elsewhere — leaving the ticker body backend-agnostic.

**The file was never checked.** I excluded `boot_main.cpp` from the scaffold ratchet when I added it, claiming it also needed the per-game SPU recomp header. It doesn't — `ppu_recomp.h` is the only generated header it wants, and the stub already covered it. So the one file the frame clock lives in was the one file nothing compiled: exactly the hole the ratchet exists to close. It's in the list now, at zero on every toolchain.

## What that immediately surfaced

`lv2_syscall_table.h` carried a `static inline void lv2_syscall(ppu_context*)` convenience wrapper. Nothing called it. The real `lv2_syscall` lives in `ppu_loader.cpp` with external linkage and does considerably more than dispatch — arming the page guard, tracking which lv2 call each guest thread is inside, handling boot-critical calls inline, stamping the profiler.

Any translation unit including both that header and the generated one **bound the name to the stripped-down version**. The two declarations (extern there, static here) are contradictory besides: GCC rejects the combination, Clang accepted it, which is why it survived. Deleted, with a pointer to `lv2_syscall_dispatch` for anyone who wants the bare dispatch.

## Split by what is portable, not by file

| | runs on POSIX | why |
|---|---|---|
| `vblank_ticker` | **yes** | only `Sleep` + `GetTickCount64`, both shimmed; `CreateThread` is a pthread wrapper |
| `guest_prof_thread` | **yes** | same |
| `dump_threads` / `hang_watchdog` | no | tlhelp32 + `SuspendThread` + `GetThreadContext`; no POSIX equivalent short of writing a debugger |

## What this does NOT do

It does not make a title run on Linux or macOS. Nothing in the repository links this harness — that needs a lifted game — so the frame clock is verified to **compile and be reachable**, not to have ticked. The honest claim is that the structural blocker is gone.

## Verification

Ratchet at zero on linux-gcc, linux-clang and windows-clang-cl with `boot_main.cpp` now included. Library and `ps3recomp_host` green under both Linux compilers, 9/9 lifter suites, both RSX test binaries pass.

The `darwin-clang` entry for `boot_main.cpp` is recorded as zero **without a local Darwin compiler** — every other toolchain reports zero and its Darwin-relevant code sits outside the `_WIN32` guards. A wrong guess fails the macOS job loudly rather than recording something worse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WHFeSQJFeF141pFkYmKN5
