### PR TITLE
rsx: sample a real guest texture in CI, with no GPU anywhere

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -121,6 +121,11 @@ jobs:
           # the draw path, not just the clear.
           ./build/ps3recomp_host --draw
           ./build/ps3recomp_host --draw --frames=60
+          # Bind a texture and sample it: the quad is green, the texture is
+          # not, so a path that dropped the texture still draws something
+          # plausible and still fails here. Exercises rsx_texture_layout and
+          # rsx_texture_decode end to end with no GPU involved.
+          ./build/ps3recomp_host --tex
 
       # RSX texture layout -- format class, row sizes, Morton addressing. Pure
       # arithmetic with no host API in it, so it runs everywhere, and it is the

--- a/libs/video/rsx_null_backend.c
+++ b/libs/video/rsx_null_backend.c
@@ -309,6 +309,7 @@ int rsx_null_backend_pump_messages(void)
  * -----------------------------------------------------------------------*/
 
 #include "rsx_vertex_fetch.h"
+#include "rsx_texture_layout.h"
 #include <stdlib.h>
 
 typedef struct {
@@ -318,6 +319,13 @@ typedef struct {
     u32  last_present;      /* centre pixel of the last presented frame */
     int  presented;
     const rsx_state* state; /* live state, for the draw path       */
+
+    /* One decoded texture unit. The point is not to be a sampler but to
+     * prove the shared RSX texture path end to end -- layout, deswizzle,
+     * channel order -- on a platform with no GPU at all. */
+    u8*  tex;               /* decoded RGBA rows, tex_pitch * tex_h  */
+    u32  tex_w, tex_h, tex_pitch;
+    int  tex_ready;
 } NullSoftState;
 
 static NullSoftState s_soft;
@@ -361,10 +369,79 @@ static u32 colour_of(const float c[4])
             (u32)(b * 255.0f + 0.5f);
 }
 
+/* Decode the bound guest texture once, through the same rsx_texture_layout /
+ * rsx_texture_decode the D3D12 backend uses. Only unit 0 is kept: this exists
+ * to check that path produces the right pixels, not to be a texture cache. */
+static void nullsw_bind_texture(void* ud, u32 unit, const rsx_texture_state* t)
+{
+    (void)ud;
+    if (unit != 0 || !t) return;
+
+    /* CONTROL0 bit 31 is the unit enable. A disabled unit unbinds. */
+    if (!(t->control0 & 0x80000000u) || !t->offset) { s_soft.tex_ready = 0; return; }
+
+    u32 w = (t->image_rect >> 16) & 0xFFFFu;
+    u32 h =  t->image_rect        & 0xFFFFu;
+    if (!w || !h || w > 4096u || h > 4096u) { s_soft.tex_ready = 0; return; }
+
+    /* Bit 31 of the offset selects MAIN vs LOCAL, same as a vertex array. */
+    u32 ea = (t->offset & 0x80000000u)
+                 ? cellGcmResolveLocated(0, t->offset & 0x7FFFFFFFu)
+                 : cellGcmResolveLocated(1, t->offset & 0x7FFFFFFFu);
+    if (!vm_base) { s_soft.tex_ready = 0; return; }
+
+    rsx_tex_layout tl;
+    rsx_texture_layout(t->format, w, h, &tl);
+    if (tl.compressed) { s_soft.tex_ready = 0; return; }   /* no BC decode here */
+
+    u32 pitch = w * 4u;
+    u8* buf = (u8*)realloc(s_soft.tex, (size_t)pitch * h);
+    if (!buf) { s_soft.tex_ready = 0; return; }
+    s_soft.tex = buf;
+
+    if (tl.fmt == RSX_TEXFMT_R8G8B8A8) {
+        rsx_texture_decode(buf, pitch, vm_base + ea, w, h, &tl,
+                           rsx_texture_argb_is_rgba());
+    } else {
+        /* Narrower formats decode to their own width; splay them to RGBA so
+         * sampling below has one layout to read. */
+        u32 srcp = tl.row_bytes;
+        u8* tmp = (u8*)malloc((size_t)srcp * h);
+        if (!tmp) { s_soft.tex_ready = 0; return; }
+        rsx_texture_decode(tmp, srcp, vm_base + ea, w, h, &tl, 0);
+        for (u32 y = 0; y < h; y++)
+            for (u32 x = 0; x < w; x++) {
+                const u8* sp = tmp + (size_t)y * srcp + (size_t)x * tl.bytes_per_texel;
+                u8* dp = buf + (size_t)y * pitch + (size_t)x * 4u;
+                dp[0] = sp[0];
+                dp[1] = tl.bytes_per_texel > 1 ? sp[1] : sp[0];
+                dp[2] = tl.bytes_per_texel > 2 ? sp[2] : sp[0];
+                dp[3] = 255;
+            }
+        free(tmp);
+    }
+
+    s_soft.tex_w = w; s_soft.tex_h = h; s_soft.tex_pitch = pitch;
+    s_soft.tex_ready = 1;
+}
+
+/* Nearest-neighbour point sample, wrapping. No filtering, no mip levels, no
+ * addressing modes: the guest UVs in the harness land inside [0,1). */
+static u32 sample_tex(float u, float v)
+{
+    if (!s_soft.tex_ready) return 0xFF00FFu;         /* magenta = not bound */
+    long sx = (long)(u * (float)s_soft.tex_w);
+    long sy = (long)(v * (float)s_soft.tex_h);
+    sx %= (long)s_soft.tex_w; if (sx < 0) sx += (long)s_soft.tex_w;
+    sy %= (long)s_soft.tex_h; if (sy < 0) sy += (long)s_soft.tex_h;
+    const u8* px = s_soft.tex + (size_t)sy * s_soft.tex_pitch + (size_t)sx * 4u;
+    return ((u32)px[0] << 16) | ((u32)px[1] << 8) | (u32)px[2];
+}
+
 /* Bounding-box scan with the three edge functions; fills when a pixel centre
  * is on the same side of all three edges, so winding does not matter. */
 static void fill_triangle(const float a[4], const float b[4], const float c[4],
-                          u32 rgb)
+                          u32 rgb, const float uv[3][4], int textured)
 {
     float ax, ay, bx, by, cx, cy;
     ndc_to_px(a, &ax, &ay); ndc_to_px(b, &bx, &by); ndc_to_px(c, &cx, &cy);
@@ -396,7 +473,20 @@ static void fill_triangle(const float a[4], const float b[4], const float c[4],
             int neg = (w0 < 0) || (w1 < 0) || (w2 < 0);
             int pos = (w0 > 0) || (w1 > 0) || (w2 > 0);
             if (neg && pos) continue;               /* outside */
-            s_soft.fb[(u32)y * s_soft.width + (u32)x] = rgb;
+
+            u32 out = rgb;
+            if (textured) {
+                /* Barycentric weights fall out of the same edge functions, so
+                 * interpolating costs nothing extra. Screen-space rather than
+                 * perspective-correct: the harness draws in the z=0 plane,
+                 * where the two agree. */
+                float inv = 1.0f / area;
+                float la = w1 * inv, lb = w2 * inv, lc = w0 * inv;
+                float u = la * uv[0][0] + lb * uv[1][0] + lc * uv[2][0];
+                float v = la * uv[0][1] + lb * uv[1][1] + lc * uv[2][1];
+                out = sample_tex(u, v);
+            }
+            s_soft.fb[(u32)y * s_soft.width + (u32)x] = out;
         }
     }
 }
@@ -411,13 +501,21 @@ static void draw_prim(u32 prim, u32 first, u32 count)
 
     /* Position is attribute 0 and diffuse colour attribute 3 -- the same slots
      * the D3D12 and Metal fallback paths assume. */
+    /* Texture coordinates are attribute 8 (texcoord0), the slot the D3D12 and
+     * Metal fetch paths also read. A draw is textured when a texture is bound
+     * AND that attribute is actually supplied. */
+    const int textured = s_soft.tex_ready && st->vertex_attribs[8].enabled;
+
     #define TRI(i0, i1, i2) do {                                        \
-        float p0[4], p1[4], p2[4], col[4];                              \
+        float p0[4], p1[4], p2[4], col[4], uv[3][4];                    \
         rsx_fetch_attrib(st, 0, (i0), p0);                              \
         rsx_fetch_attrib(st, 0, (i1), p1);                              \
         rsx_fetch_attrib(st, 0, (i2), p2);                              \
         rsx_fetch_attrib(st, 3, (i0), col);                             \
-        fill_triangle(p0, p1, p2, colour_of(col));                      \
+        rsx_fetch_attrib(st, 8, (i0), uv[0]);                           \
+        rsx_fetch_attrib(st, 8, (i1), uv[1]);                           \
+        rsx_fetch_attrib(st, 8, (i2), uv[2]);                           \
+        fill_triangle(p0, p1, p2, colour_of(col), uv, textured);        \
     } while (0)
 
     switch (prim) {
@@ -479,6 +577,7 @@ static rsx_backend s_nullsw_backend = {
     .set_render_target = nullsw_set_render_target,
     .set_vertex_attribs= nullsw_set_vertex_attribs,
     .clear             = nullsw_clear,
+    .bind_texture      = nullsw_bind_texture,
     .draw_arrays       = nullsw_draw_arrays,
     .draw_indexed      = nullsw_draw_indexed,
     .present           = nullsw_present,
@@ -500,8 +599,9 @@ int rsx_null_backend_init(u32 width, u32 height, const char* title)
 void rsx_null_backend_shutdown(void)
 {
     rsx_set_backend(NULL);
-    free(s_soft.fb);
-    s_soft.fb = NULL;
+    free(s_soft.fb);   s_soft.fb  = NULL;
+    free(s_soft.tex);  s_soft.tex = NULL;
+    s_soft.tex_ready = 0;
 }
 
 /* Headless has no event queue and no window to close. */

--- a/runtime/host/host_posix.c
+++ b/runtime/host/host_posix.c
@@ -66,6 +66,10 @@ uint8_t* vm_base = NULL;
 
 #define CLEAR_ARGB  0xFF101830u          /* what we expect to come out again  */
 #define VTX_OFFSET  0x00010000u          /* RSX offset of our vertex buffer   */
+#define TEX_OFFSET  0x00020000u          /* RSX offset of our test texture    */
+#define TEX_W       4u
+#define TEX_H       4u
+#define TEX_ARGB    0xFF20C040u          /* what a textured pixel must read   */
 
 /* Functions the RSX side exports but does not declare in a public header. */
 extern void cellGcm_rsx_process_fifo(void);
@@ -131,6 +135,47 @@ static void upload_triangle(void)
             guest_f32(IO_ADDR + VTX_OFFSET + (uint32_t)(i * 32 + k * 4), v[i][k]);
 }
 
+/* A 4x4 texture, every texel the same colour, written as the guest would:
+ * A8R8G8B8 means the bytes land A,R,G,B in that order on a big-endian PPU.
+ *
+ * Uniform on purpose: this asserts the pixel VALUE survives the whole path --
+ * bind, layout, decode, channel reorder, sample -- and a single centre-pixel
+ * readback is what the harness can observe.
+ *
+ * It therefore does NOT detect swizzling, and cannot: reordering identical
+ * texels changes nothing. Nor can a non-uniform texture fix that here. The
+ * centre lands somewhere in the four texels around (2,2) of a 4x4, and Morton
+ * order maps those to offsets {3,6,9,12} against linear's {5,6,9,10} -- the
+ * two agree at 6 and 9, so a centre sample can land on a texel where swizzled
+ * and linear read the same byte. Swizzling is covered instead by
+ * libs/video/tests/test_texture_layout.c, which asserts Morton addressing is a
+ * bijection and that a swizzled read differs from a linear one over the same
+ * bytes. Verified: breaking the swizzle decision fails those and not this. */
+static void upload_texture(void)
+{
+    for (uint32_t i = 0; i < TEX_W * TEX_H; i++)
+        guest_w32(IO_ADDR + TEX_OFFSET + i * 4u, TEX_ARGB);
+}
+
+/* The textured draw uses its own vertex block: two triangles covering the
+ * screen, with texcoord0 (attribute 8) alongside position and colour.
+ * Layout per vertex: float4 pos, float4 colour, float4 uv -- stride 48. */
+#define TVTX_OFFSET (VTX_OFFSET + 0x1000u)
+static void upload_textured_quad(void)
+{
+    static const float v[6][12] = {
+        { -1,-1,0,1,  0,1,0,1,  0,0,0,0 },
+        {  1,-1,0,1,  0,1,0,1,  1,0,0,0 },
+        {  1, 1,0,1,  0,1,0,1,  1,1,0,0 },
+        { -1,-1,0,1,  0,1,0,1,  0,0,0,0 },
+        {  1, 1,0,1,  0,1,0,1,  1,1,0,0 },
+        { -1, 1,0,1,  0,1,0,1,  0,1,0,0 },
+    };
+    for (int i = 0; i < 6; i++)
+        for (int k = 0; k < 12; k++)
+            guest_f32(IO_ADDR + TVTX_OFFSET + (uint32_t)(i * 48 + k * 4), v[i][k]);
+}
+
 /* type[3:0]=2 (float32), size[7:4], stride[15:8] */
 #define VFMT(size, stride) (2u | ((u32)(size) << 4) | ((u32)(stride) << 8))
 
@@ -153,6 +198,32 @@ static void emit_triangle_draw(void)
     emit(NV4097_SET_BEGIN_END, 0u);                       /* end              */
 }
 
+/* Bind the test texture on unit 0 and draw the quad. The vertex colour is
+ * deliberately GREEN while the texture is a different colour, so a pass that
+ * ignored the texture would still produce a plausible-looking frame -- and
+ * the assertion would catch it. */
+static void emit_textured_draw(void)
+{
+    /* NV4097_SET_TEXTURE_* are 0x20 apart per unit; unit 0 is the base. */
+    emit(NV4097_SET_TEXTURE_OFFSET     + 0, VTX_MAIN(TEX_OFFSET));
+    /* format: A8R8G8B8 (0x85) | LN (0x20) -- linear, not swizzled. */
+    emit(NV4097_SET_TEXTURE_FORMAT     + 0, 0x85u | 0x20u);
+    emit(NV4097_SET_TEXTURE_CONTROL0   + 0, 0x80000000u);   /* unit enable */
+    emit(NV4097_SET_TEXTURE_CONTROL1   + 0, 0xAAE4u);       /* identity crossbar */
+    emit(NV4097_SET_TEXTURE_IMAGE_RECT + 0, (TEX_W << 16) | TEX_H);
+
+    emit(NV4097_SET_VERTEX_DATA_ARRAY_OFFSET + 0 * 4, VTX_MAIN(TVTX_OFFSET +  0));
+    emit(NV4097_SET_VERTEX_DATA_ARRAY_FORMAT + 0 * 4, VFMT(4, 48));
+    emit(NV4097_SET_VERTEX_DATA_ARRAY_OFFSET + 3 * 4, VTX_MAIN(TVTX_OFFSET + 16));
+    emit(NV4097_SET_VERTEX_DATA_ARRAY_FORMAT + 3 * 4, VFMT(4, 48));
+    emit(NV4097_SET_VERTEX_DATA_ARRAY_OFFSET + 8 * 4, VTX_MAIN(TVTX_OFFSET + 32));
+    emit(NV4097_SET_VERTEX_DATA_ARRAY_FORMAT + 8 * 4, VFMT(4, 48));
+
+    emit(NV4097_SET_BEGIN_END, 5u);                       /* TRIANGLES       */
+    emit(NV4097_DRAW_ARRAYS,   0u | ((6u - 1u) << 24));   /* first=0 count=6 */
+    emit(NV4097_SET_BEGIN_END, 0u);
+}
+
 /* Append this frame's commands to the ring and advance `put`, exactly as a
  * title does. The RSX's `get` pointer lives inside cellGcmSys and chases `put`;
  * it is never rewound, so each frame must occupy fresh ring space rather than
@@ -161,7 +232,8 @@ static void submit_frame(int with_draw)
 {
     emit(NV4097_SET_COLOR_CLEAR_VALUE, CLEAR_ARGB);
     emit(NV4097_CLEAR_SURFACE,         0xF0u);
-    if (with_draw) emit_triangle_draw();
+    if (with_draw == 2)      emit_textured_draw();
+    else if (with_draw == 1) emit_triangle_draw();
 
     guest_w32(CTRL_ADDR + 0, g_fifo_len);   /* put */
     cellGcm_rsx_process_fifo();
@@ -175,6 +247,11 @@ int main(int argc, char** argv)
     for (int i = 1; i < argc; i++) {
         if (strncmp(argv[i], "--frames=", 9) == 0) frames = atoi(argv[i] + 9);
         else if (strcmp(argv[i], "--draw") == 0)   do_draw = 1;
+        /* --tex: bind a texture and sample it, which exercises the shared
+         * rsx_texture_layout/decode path end to end rather than in a unit
+         * test. The vertex colour differs from the texture colour, so a
+         * backend that ignored the texture fails the assertion below. */
+        else if (strcmp(argv[i], "--tex") == 0)    do_draw = 2;
     }
 
     vm_base = (uint8_t*)calloc(1, VM_SIZE);
@@ -195,7 +272,8 @@ int main(int argc, char** argv)
     cellGcmSetDisplayBuffer(0, 0, 1280 * 4, 1280, 720);
 
     guest_w32(CTRL_ADDR + 4, 0);            /* get: start of ring */
-    if (do_draw) upload_triangle();
+    if (do_draw == 1) upload_triangle();
+    if (do_draw == 2) { upload_texture(); upload_textured_quad(); }
     submit_frame(do_draw);
 
     u32 got = host_backend_color();
@@ -224,8 +302,13 @@ int main(int argc, char** argv)
          * RSX ARGB -> Metal BGRA8Unorm keeps R, G and B in the same bytes. */
         /* Without a draw the centre pixel is the clear colour; with the test
          * triangle it is the triangle's red, which proves the vertex fetch,
-         * primitive path, pipeline state and draw all worked. */
-        u32 want = do_draw ? 0xFFFF0000u : CLEAR_ARGB;
+         * primitive path, pipeline state and draw all worked. With --tex it is
+         * the TEXTURE's colour, not the quad's green -- so it also proves the
+         * texture reached the sampler through layout, decode and the crossbar.
+         */
+        u32 want = (do_draw == 2) ? TEX_ARGB
+                 : (do_draw == 1) ? 0xFFFF0000u
+                                  : CLEAR_ARGB;
         printf("[host] presented pixel: 0x%08X (expected 0x%08X) %s\n",
                back, want, (back & 0x00FFFFFFu) == (want & 0x00FFFFFFu) ? "OK" : "MISMATCH");
         if ((back & 0x00FFFFFFu) != (want & 0x00FFFFFFu)) rc = 3;


### PR DESCRIPTION
﻿The shared texture code — `rsx_texture_layout`, `rsx_texture_decode` and the `TEXTURE_CONTROL1` crossbar — had unit tests and mutation coverage, but **nothing had ever pushed a guest texture through the whole path and looked at the resulting pixel**. Layout, bind, decode, channel order and sampling were each checked in isolation and never together.

The null backend now decodes a bound texture through exactly the functions the D3D12 backend uses, and samples it while filling triangles — nearest-neighbour, wrapping, barycentric UVs from the edge functions it already computes. It isn't trying to be a sampler. It exists so the RSX side of texturing has a reference implementation that runs **anywhere**, including a CI box with no GPU, no display and no driver.

`ps3recomp_host --tex` builds the guest side by hand — an A8R8G8B8 texture in the IO window, the NV4097 bind methods, a screen-covering quad carrying texcoord0 — and asserts the centre pixel is the **texture's** colour. The quad's vertex colour is deliberately green and the texture is not, so a backend that silently dropped the texture would still draw a plausible frame and still fail.

## Checked by mutation, not assumed

| deliberate break | result | |
|---|---|---|
| sampling ignored | `0xFF00FF00` — the quad's green | **caught** |
| ARGB rotation removed | `0xFFFF2040` — channels permuted | **caught** |
| linear texture read as swizzled | unchanged | **not caught** |

The third is a real limit of this test, and it's written into the harness rather than left to be discovered.

Reordering identical texels changes nothing — and a non-uniform texture wouldn't rescue it. The centre lands somewhere among the four texels around (2,2) of a 4x4, and Morton maps those to offsets `{3,6,9,12}` against linear's `{5,6,9,10}`. They overlap at 6 and 9, so a centre sample can legitimately land where both readings agree.

Swizzling stays covered by `test_texture_layout.c`, which asserts Morton addressing is a bijection and that a swizzled read differs from a linear one over the same bytes. Confirmed directly: breaking the swizzle decision fails **six** of those assertions and none of this one.

## Linux only, deliberately

macOS runs the same harness but reaches Metal, which has no texture support yet — adding `--tex` there would assert against a backend that cannot answer. That's the next piece of work, and **this is the assertion it will be held to**.

## Verification

gcc and clang; `clear`/`draw`/`tex`/60-frame all exit 0; no new warnings in the touched files; scaffold ratchet at zero; 9/9 lifter suites; both RSX test binaries pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WHFeSQJFeF141pFkYmKN5
