### PR TITLE
spu: reject MFC PUTs into the null page

### DIFF
--- a/runtime/spu/spu_dma.h
+++ b/runtime/spu/spu_dma.h
@@ -214,9 +214,19 @@ static inline int mfc_do_transfer(spu_context* spu, uint32_t lsa, uint64_t ea,
      * SPU_DMA_LAX=1 restores the old permissive behaviour. */
     { static int s_lax = -1; if (s_lax < 0) s_lax = getenv("SPU_DMA_LAX") ? 1 : 0;
       if (!s_lax) {
+          /* A PUT into the null page is the same class of accident: lv2 reserves
+           * the low 64 KB and no title DMAs there on purpose, so an EA that
+           * small means the descriptor field holding the real destination came
+           * through as zero. GT5P's second audio job spills its whole local
+           * store (0x0000/0x4000/0x8000, 34 KB) to EA 0 on every pass --
+           * 363,577 of 364,600 PUTs in a 40 s boot. Performing them writes
+           * nothing useful and buries the real destinations in the histogram.
+           * GETs from low EAs stay allowed: they only read garbage, and
+           * LBP_SKIP_NULL_DMA already exists to test zeroing them instead. */
           int malformed = (size == 0) || (size > 0x4000)
                        || (size >= 16 && (size & 15))
-                       || (((lsa ^ (uint32_t)ea) & 15) != 0);
+                       || (((lsa ^ (uint32_t)ea) & 15) != 0)
+                       || (mfc_is_put(cmd) && (uint32_t)ea < 0x10000u);
           if (malformed) {
               static int _n = 0;
               if (_n++ < 8)


### PR DESCRIPTION
lv2 reserves the low 64 KB, so no title DMAs there on purpose. A PUT with an EA
that small means the descriptor field holding the real destination came through
as zero — the same class of accident as the malformed transfers rejected just
above this check, and the same fix: don't perform it.

GT5P's second audio job (SPURS job chain, image fingerprint
`0xBE66D8D2210CDCD4`) spills its entire local store on every pass — LS
`0x0000`/`0x4000`/`0x8000` to EA `0x0000`/`0x4000`/`0x8000`, 34 KB a lap. That
was **363,577 of the 364,600 PUTs** in a 40 s boot, and it buried the three real
destinations in the `SPU_PUTHIST` histogram:

| before | | after | |
|---|---|---|---|
| `ea 0x00000000` | 363577 | `ea 0x01000000` | 197 |
| `ea 0x01000000` | 1020 | `ea 0x20000000` | 3 |
| `ea 0x20000000` | 3 | | |

GETs from low EAs are left alone: they only read garbage, and
`LBP_SKIP_NULL_DMA` already exists to test zeroing them instead. `SPU_DMA_LAX=1`
restores the permissive behaviour for both.
