### PR TITLE
ppu: LBP_WV -- watch PPU stores by value, not by address

### DIFF
--- a/runtime/ppu/ppu_loader.cpp
+++ b/runtime/ppu/ppu_loader.cpp
@@ -967,7 +967,16 @@ void vm_write32(uint64_t a, uint32_t v) { barrier_watch_hit((uint32_t)a, v, 4, _
         fprintf(stderr,"%s\n",ln); } } }
 #endif
     v = __builtin_bswap32(v); memcpy(vm_base + (uint32_t)a, &v, 4); }
-void vm_write64(uint64_t a, uint64_t v) { if (vm_oob((uint32_t)a,8)) return;
+void vm_write64(uint64_t a, uint64_t v) {
+    /* A 64-bit std used to be invisible to LBP_WW / LBP_WV: only write8/16/32
+     * fed the watch, so "nothing writes this field" was a routine false
+     * negative. GT5P's PDI task flag at 0x0107B798 reads back as 1 with no
+     * store in the log, and the store that sets it is a std covering it.
+     * Report both halves at their own addresses, so a watch on either word
+     * sees it and the printed value is the word that landed there. */
+    barrier_watch_hit((uint32_t)a,     (uint32_t)(v >> 32), 8, __builtin_return_address(0));
+    barrier_watch_hit((uint32_t)a + 4, (uint32_t)v,         8, __builtin_return_address(0));
+    if (vm_oob((uint32_t)a,8)) return;
     { static int64_t w=-2; if (w==-2) { const char* e=getenv("YDKJ_WWATCH"); w = e?(int64_t)strtoul(e,0,0):-1; }
       if (w>=0) { uint32_t ea=(uint32_t)a; if (ea>=(uint32_t)w && ea<(uint32_t)w+0x40) {
         void* ra=__builtin_return_address(0); char* mb=(char*)GetModuleHandleA(NULL);

--- a/runtime/ppu/ppu_loader.cpp
+++ b/runtime/ppu/ppu_loader.cpp
@@ -15,19 +15,11 @@
  * Game-agnostic: works on any decrypted PS3 PPU ELF. `vm_base` is owned by the
  * host (allocated large enough to cover the highest segment vaddr+memsz).
  *
- * Compiled as C++ to match the lifted output's `extern "C"` / PPU_THREAD_LOCAL.
+ * Compiled as C++ to match the lifted output's `extern "C"` / __declspec(thread).
  */
 
-#include "ppu_tls.h"   /* PPU_THREAD_LOCAL, without a second ppu_context */
 #include "ppu_recomp.h"     /* ppu_context, func decls, ppu_recomp_register */
 #include "../memory/vm.h"   /* vm_commit -- sys_mmapper_search_and_map maps for real */
-#include "../platform/win32_compat.h"      /* Win32 types, interlocked ops, Sleep/QPC on POSIX */
-#include "../platform/win32_backtrace.h"   /* RtlCaptureStackBackTrace / GetModuleHandleA on POSIX */
-#ifndef _WIN32
-#include <sys/mman.h>   /* the guest-pointer trap reserves the low 4 GB */
-#include <signal.h>
-#include <unistd.h>
-#endif
 extern "C" uint32_t ppu_prof_resolve_host(void* ra);
 
 /* Resolve the GUEST function on the host stack (closest lifted entry below
@@ -72,40 +64,26 @@ extern "C" void ppu_guest_caller(char* out, size_t n)
  * Deliberately does NOT swallow the exception: it reports and lets the normal
  * handling proceed, so a real bug still stops the run.
  * -----------------------------------------------------------------------*/
-/* The report is identical on both platforms; only the trap mechanism differs
- * (vectored exception handler vs sigaction, VirtualAlloc vs mmap). Written
- * once so the two cannot drift apart. */
-static void ps3_report_guest_ptr(uintptr_t at, const char* how)
-{
-    static LONG n = 0;
-    if (InterlockedIncrement(&n) > 32) return;
-    char who[64]; ppu_guest_caller(who, sizeof who);
-    fprintf(stderr,
-            "\n[ps3] UNTRANSLATED GUEST POINTER: %s of guest 0x%08X as a host "
-            "address\n      (an HLE function dereferenced a pointer parameter without "
-            "vm_base)\n      guest caller: %s\n", how, (uint32_t)at, who);
-    fflush(stderr);
-}
-
-/* Guest addresses worth reporting: above the first page (a plain NULL deref is
- * someone else's bug) and below 4 GB. */
-static inline int ps3_is_guest_ptr_fault(uintptr_t at)
-{
-    return at >= 0x10000u && at < 0x100000000ull;
-}
-
-#ifdef _WIN32
-
 static LONG WINAPI ps3_guest_ptr_veh(EXCEPTION_POINTERS* ep)
 {
     const EXCEPTION_RECORD* er = ep->ExceptionRecord;
     if (er->ExceptionCode != EXCEPTION_ACCESS_VIOLATION ||
         er->NumberParameters < 2) return EXCEPTION_CONTINUE_SEARCH;
     uintptr_t at = (uintptr_t)er->ExceptionInformation[1];
-    if (!ps3_is_guest_ptr_fault(at)) return EXCEPTION_CONTINUE_SEARCH;
+    if (at >= 0x100000000ull) return EXCEPTION_CONTINUE_SEARCH;   /* not a guest addr */
+    if (at < 0x10000u) return EXCEPTION_CONTINUE_SEARCH;          /* a plain NULL deref */
 
-    ps3_report_guest_ptr(at, er->ExceptionInformation[0] == 0 ? "read"
-                           : er->ExceptionInformation[0] == 1 ? "write" : "execute");
+    static LONG n = 0;
+    if (InterlockedIncrement(&n) <= 32) {
+        char who[64]; ppu_guest_caller(who, sizeof who);
+        const char* how = er->ExceptionInformation[0] == 0 ? "read"
+                        : er->ExceptionInformation[0] == 1 ? "write" : "execute";
+        fprintf(stderr,
+                "\n[ps3] UNTRANSLATED GUEST POINTER: %s of guest 0x%08X as a host "
+                "address\n      (an HLE function dereferenced a pointer parameter without "
+                "vm_base)\n      guest caller: %s\n", how, (uint32_t)at, who);
+        fflush(stderr);
+    }
     return EXCEPTION_CONTINUE_SEARCH;
 }
 
@@ -125,86 +103,6 @@ extern "C" void ps3_install_guest_ptr_trap(void)
     fprintf(stderr, "[ps3] guest-pointer trap armed (%zu MB of the low 4 GB reserved)\n",
             got >> 20);
 }
-
-#else  /* POSIX */
-
-static struct sigaction s_prev_segv;
-static int              s_prev_segv_valid = 0;
-
-/* Not async-signal-safe, and deliberately so: this runs on a path that is about
- * to end the process anyway, and the whole value of the report is the guest
- * function name -- which means walking the stack and formatting. The Windows
- * handler makes exactly the same trade. */
-static void ps3_guest_ptr_sigsegv(int sig, siginfo_t* si, void* uctx)
-{
-    if (si && ps3_is_guest_ptr_fault((uintptr_t)si->si_addr)) {
-        /* si_code separates unmapped from protected, not read from write, so
-         * unlike the Windows report this cannot name the direction without
-         * decoding a machine-specific trap frame. The address and the guest
-         * caller are what actually locate the bug. */
-        ps3_report_guest_ptr((uintptr_t)si->si_addr, "access");
-    }
-
-    /* Do NOT swallow it, matching the Windows handler: hand back to whoever was
-     * installed before, or restore the default so the faulting instruction
-     * re-runs and the process dies exactly as it would have. */
-    if (s_prev_segv_valid) {
-        if ((s_prev_segv.sa_flags & SA_SIGINFO) && s_prev_segv.sa_sigaction) {
-            s_prev_segv.sa_sigaction(sig, si, uctx);
-            return;
-        }
-        if (s_prev_segv.sa_handler && s_prev_segv.sa_handler != SIG_DFL &&
-            s_prev_segv.sa_handler != SIG_IGN) {
-            s_prev_segv.sa_handler(sig);
-            return;
-        }
-    }
-    struct sigaction dfl;
-    memset(&dfl, 0, sizeof dfl);
-    dfl.sa_handler = SIG_DFL;
-    sigemptyset(&dfl.sa_mask);
-    sigaction(sig, &dfl, NULL);
-}
-
-extern "C" void ps3_install_guest_ptr_trap(void)
-{
-    if (getenv("PS3_NO_GUEST_PTR_TRAP")) return;
-
-    /* Leave the chunk holding the program break alone. Reserving the space just
-     * above it would stop brk from ever growing and silently push every small
-     * allocation onto mmap -- a steep price for a diagnostic. */
-    uintptr_t brk_now = (uintptr_t)sbrk(0);
-
-    size_t got = 0;
-    for (uintptr_t a = 0x10000u; a < 0x100000000ull; a += 0x10000000ull) {
-        size_t len = 0x10000000u;
-        if (a == 0x10000u) len -= 0x10000u;
-        if (brk_now >= a && brk_now < a + len) continue;
-
-        int flags = MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE;
-#ifdef MAP_FIXED_NOREPLACE
-        flags |= MAP_FIXED_NOREPLACE;   /* fail rather than evict a live mapping */
-#endif
-        void* at = mmap((void*)a, len, PROT_NONE, flags, -1, 0);
-        if (at == MAP_FAILED) continue;                 /* chunk already in use */
-        if ((uintptr_t)at != a) { munmap(at, len); continue; }  /* hint ignored */
-        got += len;
-    }
-
-    /* PROT_NONE faults arrive as SIGSEGV on both Linux and Darwin; SIGBUS is for
-     * mapped-but-unbacked access, which this scheme never produces. */
-    struct sigaction sa;
-    memset(&sa, 0, sizeof sa);
-    sa.sa_sigaction = ps3_guest_ptr_sigsegv;
-    sa.sa_flags     = SA_SIGINFO;
-    sigemptyset(&sa.sa_mask);
-    if (sigaction(SIGSEGV, &sa, &s_prev_segv) == 0) s_prev_segv_valid = 1;
-
-    fprintf(stderr, "[ps3] guest-pointer trap armed (%zu MB of the low 4 GB reserved)\n",
-            got >> 20);
-}
-
-#endif /* _WIN32 */
 
 /* PS3_SCTRACE=1: every lv2 syscall with its arguments and RETURN VALUE.
  * An unimplemented syscall is loud (it logs "(stub)") but an IMPLEMENTED one
@@ -282,7 +180,7 @@ extern "C" void ppu_log_host_chain(const char* tag);  /* fwd decl (defined below
  * reservation semantics. stwcx is a sync point (rare vs vm_write), so a single
  * lock is cheap enough; shard by address later if it shows up in a profile.
  * -----------------------------------------------------------------------*/
-extern "C" PPU_THREAD_LOCAL ppu_context* g_active_ctx;   /* fwd (defined below) */
+extern "C" __declspec(thread) ppu_context* g_active_ctx;   /* fwd (defined below) */
 #define PPU_RESV_MAX 128
 #define PPU_RESV_INVALID 0x100000000ull   /* out of (uint32_t) ea range */
 static ppu_context* g_resv_ctxs[PPU_RESV_MAX];
@@ -440,6 +338,23 @@ static LONG WINAPI ppu_guard_veh(EXCEPTION_POINTERS* ep)
                                 (uint32_t)g_active_ctx->gpr[5], (uint32_t)g_active_ctx->gpr[6],
                                 (uint32_t)g_active_ctx->gpr[30], (uint32_t)g_active_ctx->gpr[31],
                                 (uint32_t)g_active_ctx->lr);
+                    /* On the first hit, every GPR. A bulk fill keeps its
+                     * destination and remaining count in registers the ABI
+                     * argument slots say nothing about, and those two numbers
+                     * are what identify the range. */
+                    if (_cs == 1 && g_active_ctx) {
+                        for (int r = 0; r < 32; r += 8)
+                            fprintf(stderr, "[GUARD]   r%-2d: %08X %08X %08X %08X"
+                                            " %08X %08X %08X %08X\n", r,
+                                    (uint32_t)g_active_ctx->gpr[r + 0],
+                                    (uint32_t)g_active_ctx->gpr[r + 1],
+                                    (uint32_t)g_active_ctx->gpr[r + 2],
+                                    (uint32_t)g_active_ctx->gpr[r + 3],
+                                    (uint32_t)g_active_ctx->gpr[r + 4],
+                                    (uint32_t)g_active_ctx->gpr[r + 5],
+                                    (uint32_t)g_active_ctx->gpr[r + 6],
+                                    (uint32_t)g_active_ctx->gpr[r + 7]);
+                    }
                     ppu_guest_callstack("guard-clear");
                 }
             }
@@ -574,11 +489,11 @@ static void vm_hotmap(uint32_t ea, int width)
         for (uint32_t i = 0; i < NB; i++) cnt[i] = 0;
     }
 }
-extern "C" PPU_THREAD_LOCAL ppu_context* g_active_ctx;  /* fwd decl (defined below) */
+extern "C" __declspec(thread) ppu_context* g_active_ctx;  /* fwd decl (defined below) */
 /* Tracks the most recent vm_read32 {addr,value} on this thread, so FLOW_WVAL can
  * report the SOURCE a copied value came from (poison propagation vs true origin). */
-static PPU_THREAD_LOCAL uint32_t g_last_rd_addr = 0;
-static PPU_THREAD_LOCAL uint32_t g_last_rd_val  = 0;
+static __declspec(thread) uint32_t g_last_rd_addr = 0;
+static __declspec(thread) uint32_t g_last_rd_val  = 0;
 /* PT=<hex>: persistent high-byte truncation detector. A write8 that turns the word
  * at some addr into <hex> (e.g. a heap ptr 0x471057A0 zeroed to 0x001057A0) is BENIGN
  * if the word is later restored to a full pointer; it is the BUG if the truncated
@@ -607,8 +522,8 @@ static void pt_restore(uint32_t addr) { for (int i=0;i<g_pt_n;i++) if (g_pt_addr
 #endif
 /* Stack of currently-executing indirect-call (vtable) targets on this thread, so a
  * write hook can name the virtual method that is running when it writes a value. */
-static PPU_THREAD_LOCAL uint32_t g_vcall_stk[128];
-static PPU_THREAD_LOCAL int      g_vcall_sp = 0;
+static __declspec(thread) uint32_t g_vcall_stk[128];
+static __declspec(thread) int      g_vcall_sp = 0;
 extern "C" {
 uint8_t  vm_read8 (uint64_t a) { if (vm_oob((uint32_t)a,1)) return 0; vm_hotmap((uint32_t)a,1);
     /* YDKJ_LV2_SAT (diagnostic): the game polls 0x00543580 ("Continue... (Lv-2 is
@@ -620,7 +535,7 @@ uint8_t  vm_read8 (uint64_t a) { if (vm_oob((uint32_t)a,1)) return 0; vm_hotmap(
 #ifdef VM_SAMPLE_READS
     { static uint64_t c=0; if ((++c % 2000000ull)==0) fprintf(stderr, "[sample] read8  0x%08X ra0=%p ra1=%p\n", (uint32_t)a, __builtin_return_address(0), __builtin_return_address(1)); }
 #endif
-    { static PPU_THREAD_LOCAL uint32_t last=0xFFFFFFFFu; static PPU_THREAD_LOCAL uint32_t n=0;
+    { static __declspec(thread) uint32_t last=0xFFFFFFFFu; static __declspec(thread) uint32_t n=0;
       if ((uint32_t)a==last) { if (++n==200000) {
           fprintf(stderr, "[HOTREAD8] spinning on 0x%08X val=0x%02X tid=%lu guest-fn=0x%08X\n",
                   (uint32_t)a, vm_base[(uint32_t)a], GetCurrentThreadId(),
@@ -629,7 +544,7 @@ uint8_t  vm_read8 (uint64_t a) { if (vm_oob((uint32_t)a,1)) return 0; vm_hotmap(
       else { last=(uint32_t)a; n=0; } }
     return vm_base[(uint32_t)a]; }
 uint16_t vm_read16(uint64_t a) { if (vm_oob((uint32_t)a,2)) return 0; vm_hotmap((uint32_t)a,2); uint16_t v; memcpy(&v, vm_base + (uint32_t)a, 2);
-    { static PPU_THREAD_LOCAL uint32_t last=0xFFFFFFFFu; static PPU_THREAD_LOCAL uint32_t n=0;
+    { static __declspec(thread) uint32_t last=0xFFFFFFFFu; static __declspec(thread) uint32_t n=0;
       if ((uint32_t)a==last) { if (++n==200000) { fprintf(stderr, "[HOTREAD16] spinning on 0x%08X\n", (uint32_t)a); n=0; } } else { last=(uint32_t)a; n=0; } }
     return __builtin_bswap16(v); }
 uint32_t vm_read32(uint64_t a) { if (vm_oob((uint32_t)a,4)) return 0;
@@ -725,7 +640,7 @@ uint32_t vm_read32(uint64_t a) { if (vm_oob((uint32_t)a,4)) return 0;
           for(uint32_t i=0;i<NB;i++) cnt[i]=0; } } }
     /* Hot-poll detector: a thread spinning on the same address (e.g. a GCM FIFO
      * get-pointer / label waiting on RSX) reads it thousands of times in a row. */
-    { static PPU_THREAD_LOCAL uint32_t last=0xFFFFFFFFu; static PPU_THREAD_LOCAL uint32_t n=0;
+    { static __declspec(thread) uint32_t last=0xFFFFFFFFu; static __declspec(thread) uint32_t n=0;
       if ((uint32_t)a==last) { if (++n==200000) { if (((uint32_t)a & ~0xFFFu) == (VM_HLE_INJECT_BASE + 0x2000u)) {
               /* A spin on the GCM control block is a fence/FIFO wait. Print the
                * WHOLE block: put vs get says whether the RSX side is behind or
@@ -763,7 +678,7 @@ uint64_t vm_read64(uint64_t a) { if (vm_oob((uint32_t)a,8)) return 0; vm_hotmap(
 #ifdef VM_SAMPLE_READS
     { static uint64_t c=0; if ((++c % 2000000ull)==0) fprintf(stderr, "[sample] read64 0x%08X\n", (uint32_t)a); }
 #endif
-    { static PPU_THREAD_LOCAL uint32_t last=0xFFFFFFFFu; static PPU_THREAD_LOCAL uint32_t n=0;
+    { static __declspec(thread) uint32_t last=0xFFFFFFFFu; static __declspec(thread) uint32_t n=0;
       if ((uint32_t)a==last) { if (++n==200000) { fprintf(stderr, "[HOTREAD64] spinning on 0x%08X (=0x%016llX)\n", (uint32_t)a, (unsigned long long)__builtin_bswap64(v)); n=0;
 #ifdef _WIN32
         { static int64_t wa=-2; if(wa==-2){const char*e=getenv("YDKJ_SPINBT"); wa=e?(int64_t)strtoul(e,0,0):-1;}
@@ -821,6 +736,38 @@ static void ww_arm_inline_window(uint32_t ww)
 }
 static inline void barrier_watch_hit(uint32_t a, uint32_t v, int width, void* ra)
 {
+    /* LBP_WV=<hexvalue>: log every PPU store that WRITES this value, wherever
+     * it lands. LBP_WW answers "who writes this address"; when a bad value is
+     * copied from node to node down a list, that only ever catches the copy.
+     * GT5P's heap carries a free-block end of 0x42C80000 (= 100.0f) that each
+     * split propagates to the next node, so the address watch reported a
+     * different innocent writer every run. Watching the value finds the first
+     * one instead. */
+    { static uint32_t s_wv = 0xFFFFFFFFu, s_wvlo, s_wvhi;
+      if (s_wv == 0xFFFFFFFFu) { const char* e = getenv("LBP_WV");
+                                 s_wv = e ? (uint32_t)strtoul(e, 0, 0) : 0;
+                                 /* LBP_WV_LO/HI: restrict to a destination
+                                  * range. A distinctive value is usually also a
+                                  * common constant -- 100.0f lands in .data
+                                  * dozens of times before it ever reaches the
+                                  * heap -- so without this the interesting hit
+                                  * is past the print cap before it happens. */
+                                 const char* lo = getenv("LBP_WV_LO");
+                                 const char* hi = getenv("LBP_WV_HI");
+                                 s_wvlo = lo ? (uint32_t)strtoul(lo, 0, 0) : 0;
+                                 s_wvhi = hi ? (uint32_t)strtoul(hi, 0, 0) : 0xFFFFFFFFu; }
+      if (s_wv && v == s_wv && a >= s_wvlo && a < s_wvhi) {
+          static int _n = 0;
+          if (_n++ < 24) {
+              fprintf(stderr, "[wv] 0x%08X <- 0x%X (w%d) guest-fn=0x%08X\n",
+                      a, v, width, ppu_prof_resolve_host(ra));
+              extern __declspec(thread) ppu_context* g_active_ctx;
+              extern void ppu_dump_guest_stack(ppu_context*, const char*);
+              if (_n <= 3 && g_active_ctx) ppu_dump_guest_stack(g_active_ctx, "wv");
+              fflush(stderr);
+          }
+      } }
+
     /* LBP_WW=<hexEA>: log every PPU store into the 16-byte line at that EA,
      * with the writing guest function -- to find who fills (or fails to fill)
      * a struct field (e.g. FMOD's overlay descriptor source at 0x94F680). */
@@ -856,7 +803,7 @@ static inline void barrier_watch_hit(uint32_t a, uint32_t v, int width, void* ra
                       a, v, width, ppu_prof_resolve_host(ra));
               /* On the first write to the watched word, dump the guest caller
                * chain so the origin of a null field can be walked up-stack. */
-              extern PPU_THREAD_LOCAL ppu_context* g_active_ctx;
+              extern __declspec(thread) ppu_context* g_active_ctx;
               extern void ppu_dump_guest_stack(ppu_context*, const char*);
               if (_n == 1 && g_active_ctx) ppu_dump_guest_stack(g_active_ctx, "ww");
           }
@@ -1074,11 +1021,11 @@ void flow_lookup_alloc(unsigned int p) {
 }
 
 /* Cross-fragment trampoline pointer (matches the lifted header's TLS decl). */
-extern "C" PPU_THREAD_LOCAL void (*g_trampoline_fn)(void*) = nullptr;
+extern "C" __declspec(thread) void (*g_trampoline_fn)(void*) = nullptr;
 
 /* Per-thread active guest context, for the crash handler to report the guest PC
  * (ctx->pc, updated by lifted code at block boundaries) of a host AV. */
-extern "C" PPU_THREAD_LOCAL ppu_context* g_active_ctx = nullptr;
+extern "C" __declspec(thread) ppu_context* g_active_ctx = nullptr;
 
 /* Caller LR of the guest function currently in an HLE call (for HLE-side
  * diagnostics: pin which lifted function invoked us). 0 if none. */
@@ -2235,7 +2182,7 @@ extern "C" uint64_t ppu_guest_call(uint32_t opd_addr,
 
     /* Private scratch stack high in the guest stack region, distinct from the
      * main + ppu_thread stacks. One callback at a time per caller thread. */
-    static PPU_THREAD_LOCAL uint32_t s_cb_sp = 0;
+    static __declspec(thread) uint32_t s_cb_sp = 0;
     if (!s_cb_sp) s_cb_sp = 0xCFFE0000u;
 
     ppu_context ctx;
@@ -2280,7 +2227,7 @@ extern "C" uint64_t ppu_guest_call_ct(uint32_t code, uint32_t toc,
     ppu_fn fn = ppu_lookup(code);
     if (!fn) { fprintf(stderr, "[ppu] guest_call_ct: code 0x%08X not registered\n", code); return 0; }
 
-    static PPU_THREAD_LOCAL uint32_t s_cb_sp = 0;
+    static __declspec(thread) uint32_t s_cb_sp = 0;
     if (!s_cb_sp) s_cb_sp = 0xCFFE0000u;
 
     ppu_context ctx;


### PR DESCRIPTION
`LBP_WW` answers *"who writes this address"*. That is the wrong question when a
bad value is copied from node to node down a list: every run names a different
innocent writer, because each one only ever propagates what it read.

GT5P's CRT heap picks up `0x42C80000` as a free-list `next` pointer, and the
address watch reported a different copier each boot. `LBP_WV=<hexvalue>` logs
every store of that value, wherever it lands, with a guest stack for the first
few — which found the origin immediately.

`LBP_WV_LO` / `LBP_WV_HI` restrict it to a destination range. A value
distinctive enough to be worth searching for is usually also a common constant —
`0x42C80000` is `100.0f`, and it lands in `.data` dozens of times during static
init — so without a range filter the interesting hit is past the print cap
before it ever happens.

```
LBP_WV=0x42C80000 LBP_WV_LO=0x20000000 LBP_WV_HI=0x2AE00000 ./game
[wv] 0x20089E04 <- 0x42C80000 (w4) guest-fn=0x006C2CC8
[GSTACK:wv] sp=0xFFFFEA70 lr=0x006C30CC r30=0x20089DF8
```

Off unless set; two compares on the store path when it is.


---

## Second commit: 64-bit stores were invisible to the watch

Only `vm_write8/16/32` called `barrier_watch_hit`, so a 64-bit `std` never
reached `LBP_WW` or `LBP_WV`. *"Nothing writes this field"* was a routine false
negative, and the tree already records chasing it twice — flOw loses a render
config exactly that way, and a downstream port's `GT5P_GUARD` probe exists
verbatim because *"a 64-bit `std` ... lands invisibly"*.

GT5P's PDI task flag at `0x0107B798` reads back as `1` with no store in the log.
A page guard on it caught 2,221 writes into its page and **none** at that
offset — the guard's single-step re-arm window loses stores when fifteen threads
are running. With this commit the setter shows up on the first run.

Both halves are reported at their own addresses, so a watch on either word sees
the store and the printed value is the word that actually landed there.
