### PR TITLE
lv2: implement sys_mmapper_allocate_memory (341/342)

### DIFF
--- a/runtime/syscalls/sys_memory.c
+++ b/runtime/syscalls/sys_memory.c
@@ -389,6 +389,75 @@ int64_t sys_mmapper_allocate_shared_memory(ppu_context* ctx)
 }
 
 /* ---------------------------------------------------------------------------
+ * sys_mmapper_allocate_memory (lv2 341)
+ *
+ * r3 = pointer to receive the allocated address (u32*)
+ * r4 = size
+ *
+ * The ABI here was read off the caller rather than a header. GT5P's PDI device
+ * worker calls this the moment it starts -- func_00941808 loads r3 with a
+ * pointer and r4 with 0x300000, issues the syscall, retries on any non-zero
+ * result, and on success immediately does `lwz r29, 0(r29)`, reading back
+ * through the pointer it passed in r3.
+ *
+ * Answering CELL_OK without writing anything is the worst of both worlds: the
+ * worker believes it has three megabytes, reads a null buffer back, and exits
+ * on the spot -- which leaves the packed-filesystem device with no worker at
+ * all and stalls asset loading. Answering an error is worse still, because the
+ * caller retries forever.
+ *
+ * The flat VM has no distinction between reserving and mapping, so this hands
+ * back committed guest memory directly and sys_mmapper_allocate_memory_from_
+ * container below accepts it as already mapped.
+ * -----------------------------------------------------------------------*/
+int64_t sys_mmapper_allocate_memory(ppu_context* ctx)
+{
+    uint32_t addr_out = LV2_ARG_PTR(ctx, 0);
+    uint32_t size     = LV2_ARG_U32(ctx, 1);
+
+    if (size == 0)
+        return (int64_t)(int32_t)CELL_EINVAL;
+
+    size = VM_ALIGN_UP(size, VM_PAGE_SIZE);
+
+    bump_lock();
+    if (g_sys_mem_bump_ptr == 0)
+        g_sys_mem_bump_ptr = SYS_MEM_ALLOC_BASE;
+    g_sys_mem_bump_ptr = VM_ALIGN_UP(g_sys_mem_bump_ptr, VM_PAGE_SIZE);
+    if (g_sys_mem_bump_ptr + size > SYS_MEM_ALLOC_END) {
+        bump_unlock();
+        return (int64_t)(int32_t)CELL_ENOMEM;
+    }
+    uint32_t addr = g_sys_mem_bump_ptr;
+    g_sys_mem_bump_ptr += size;
+    bump_unlock();
+
+    vm_commit(addr, size);
+
+    if (addr_out != 0)
+        write_be32(addr_out, addr);
+
+    { static int n = 0; if (n++ < 4)
+        fprintf(stderr, "[sys_memory] mmapper_allocate_memory size=0x%X -> 0x%08X\n",
+                size, addr); }
+
+    return CELL_OK;
+}
+
+/* ---------------------------------------------------------------------------
+ * sys_mmapper_allocate_memory_from_container (lv2 342)
+ *
+ * The same allocation charged to a container. GT5P calls it straight after 341
+ * with the address 341 handed back, so with a flat VM there is nothing further
+ * to do -- the memory is already committed and addressable.
+ * -----------------------------------------------------------------------*/
+int64_t sys_mmapper_allocate_memory_from_container(ppu_context* ctx)
+{
+    (void)ctx;
+    return CELL_OK;
+}
+
+/* ---------------------------------------------------------------------------
  * sys_mmapper_map_shared_memory
  *
  * r3 = address (where to map)
@@ -441,4 +510,6 @@ void sys_memory_init(lv2_syscall_table* tbl)
     lv2_syscall_register(tbl, SYS_MMAPPER_FREE_ADDRESS,        sys_mmapper_free_address);
     lv2_syscall_register(tbl, SYS_MMAPPER_ALLOCATE_SHARED_MEMORY, sys_mmapper_allocate_shared_memory);
     lv2_syscall_register(tbl, SYS_MMAPPER_MAP_SHARED_MEMORY,  sys_mmapper_map_shared_memory);
+    lv2_syscall_register(tbl, 341, sys_mmapper_allocate_memory);
+    lv2_syscall_register(tbl, 342, sys_mmapper_allocate_memory_from_container);
 }


### PR DESCRIPTION
Both syscalls were unimplemented and fell through to the catch-all, which answers `CELL_OK`. For an allocation request that is the worst possible answer: the caller believes it has the memory, gets no address written back, and proceeds on a null buffer.

GT5P hits this on every boot — its PDI worker asks for 3 MB the moment it starts, and spent the whole run using memory it had never been given.

### ABI

Read off the caller, since no header here covers these. `func_00941808`:

```
loop:  mr    r3, r29          ; pointer to receive the address
       mr    r4, r31          ; size (0x300000)
       li    r11, 341
       sc
       cmpwi cr4, r3, 0
       bne   cr4, .backoff    ; retries on ANY non-zero result
       ...
       lwz   r29, 0(r29)      ; reads back through the r3 pointer
```

So `r3` receives the address and `r4` is the size.

Note the retry loop: **reporting an error is not a safe fallback**, it spins the caller forever. Measured on GT5P — answering `ENOMEM` drops it from 7 assets loaded to 1.

342 is the same allocation charged to a container. GT5P calls it immediately after with the address 341 returned, and on a flat VM there is nothing left to do, so it accepts and returns `CELL_OK`.

Allocation comes from the existing `sys_memory` bump region and is committed before the address is handed back, matching `sys_mmapper_allocate_address`.

### Honest scope

This did **not** fix the loader stall it was found while chasing — GT5P's asset counts are unchanged. It is here because answering `CELL_OK` to an allocation that never happened is wrong on its own terms.