### PR TITLE
ppu: inline the guest bounds check

### DIFF
--- a/runtime/ppu/ppu_loader.cpp
+++ b/runtime/ppu/ppu_loader.cpp
@@ -517,9 +517,9 @@ static uint32_t g_tls_vaddr = 0, g_tls_filesz = 0, g_tls_memsz = 0;
 #ifdef _WIN32
 #include <windows.h>
 #endif
-static int vm_oob(uint32_t a, uint32_t n)
+static int vm_oob_report(uint32_t a, uint32_t n)
 {
-    if (ppu_vm_size && (uint64_t)a + n > ppu_vm_size) {
+    {
         static int logged = 0;
         if (logged < 40) {
             fprintf(stderr, "[vm] OOB access 0x%08X (+%u)\n", a, n);
@@ -531,7 +531,7 @@ static int vm_oob(uint32_t a, uint32_t n)
                 HMODULE self = NULL;
                 GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
                                    GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-                                   (LPCSTR)&vm_oob, &self);
+                                   (LPCSTR)&vm_oob_report, &self);
                 for (USHORT i = 0; i < m; i++) {
                     HMODULE mm = NULL;
                     GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
@@ -547,6 +547,27 @@ static int vm_oob(uint32_t a, uint32_t n)
         return 1;
     }
     return 0;
+}
+
+/* The bounds check on every guest load and store, so the check itself has to
+ * inline.
+ *
+ * It used to be one function whose cold half captures a stack backtrace and
+ * prints it -- far too big to inline -- so every guest memory access paid a
+ * call. Sampling the recompiled main thread of a title that is CPU bound in
+ * lifted code (The Simpsons Arcade Game runs an arcade emulator there) made
+ * vm_oob the single hottest symbol in the whole process at 5.4% of samples,
+ * ahead of every vm_read/vm_write and every ppc_* helper.
+ *
+ * Splitting the reporting half out and leaving an inlinable check behind was
+ * worth ~19% of frame rate on that title. Windows backs the whole 32-bit guest
+ * space, so ppu_vm_size is 0 there and this reduces to one predictable
+ * compare; POSIX keeps the real range check. */
+static inline int vm_oob(uint32_t a, uint32_t n)
+{
+    if (__builtin_expect(ppu_vm_size == 0, 1)) return 0;
+    if (__builtin_expect((uint64_t)a + n <= ppu_vm_size, 1)) return 0;
+    return vm_oob_report(a, n);
 }
 
 /* ---------------------------------------------------------------------------
@@ -870,7 +891,7 @@ static inline void barrier_watch_hit(uint32_t a, uint32_t v, int width, void* ra
                     a - b, v, width, ppu_prof_resolve_host(ra));
     }
 }
-void vm_write8 (uint64_t a, uint8_t  v) { barrier_watch_hit((uint32_t)a, v, 1, __builtin_return_address(0)); if (vm_oob((uint32_t)a,1)) return; if (vm_oob((uint32_t)a,1)) return;
+void vm_write8 (uint64_t a, uint8_t  v) { barrier_watch_hit((uint32_t)a, v, 1, __builtin_return_address(0)); if (vm_oob((uint32_t)a,1)) return;
 #ifdef _WIN32
     /* FLOW_TRUNC=<hex>: catch the byte-write that clobbers the word currently
      * holding <hex> (e.g. a null-terminator overflow zeroing a pointer's high byte). */


### PR DESCRIPTION
`vm_oob` runs on **every guest load and store**, and it was one function whose cold half captures a stack backtrace and prints it — far too big for the compiler to inline. So every guest memory access in every recompiled title paid a call to it.

Sampling the recompiled main thread of a title that is CPU bound in lifted code (The Simpsons Arcade Game runs a Konami arcade emulator there, so its main thread is almost entirely guest code) put `vm_oob` at the top of the profile:

| symbol | % of samples |
|---|---|
| **`vm_oob`** | **5.4** |
| `vm_read32` / `read8` / `read16` | ~5 |
| `vm_write64` / `write16` | ~2.5 |
| `ppc_rlwinm` / `ppc_rldicl` | ~3 |

Ahead of every accessor it is called *from*.

## The change

Split the reporting half into `vm_oob_report` and leave an inlinable check behind:

```c
static inline int vm_oob(uint32_t a, uint32_t n)
{
    if (__builtin_expect(ppu_vm_size == 0, 1)) return 0;
    if (__builtin_expect((uint64_t)a + n <= ppu_vm_size, 1)) return 0;
    return vm_oob_report(a, n);
}
```

Windows backs the whole 32-bit guest space, so `ppu_vm_size` is 0 there and this reduces to one predictable compare. POSIX keeps the real range check. The reporting path is byte-for-byte what it was.

Also: `vm_write8` called `vm_oob` twice on the same access — dropped the duplicate.

## Result

~19% frame rate on that title (16 → 19 fps), no behaviour change.

Worth saying plainly: this was **not** that title's main performance problem. The build was defaulting to Debug, and fixing that took it 16 → 49 fps. This is a real and separate win on top, and it helps any title whose hot path is lifted code.

## Testing

Compiles clean at `/O2`. Measured on The Simpsons Arcade Game against ps3recomp at 4d53f34.