### PR TITLE
Runtime fixes and diagnostics from driving Virtua Fighter 5

### DIFF
--- a/libs/audio/cellAudio.c
+++ b/libs/audio/cellAudio.c
@@ -972,6 +972,40 @@ s32 cellAudioPortGetStatus(u32 portNum, u32* status)
     return CELL_OK;
 }
 
+/* cellAudioGetPortBlockTag(portNum, blockNo, tag) -- the monotonically rising
+ * tag of one block in a port's ring. A title uses it to tell whether the block
+ * it is about to fill has already been consumed: it reads the tag, writes the
+ * block, and compares again. Left unimplemented the call returns the
+ * unresolved-NID default and the mixer thread has no way to advance, which is
+ * where Virtua Fighter 5's boot stops once it is past the game-data dialog.
+ *
+ * read_index counts blocks consumed, so it IS the tag counter. Same
+ * normalisation the hardware does: round the counter down to the start of the
+ * current ring pass, and if the requested block has already gone by this pass,
+ * report it on the next one. */
+s32 cellAudioGetPortBlockTag(u32 portNum, u64 blockNo, u64* tag)
+{
+    if (!s_audio_initialized)
+        return (s32)CELL_AUDIO_ERROR_NOT_INIT;
+    if (portNum >= CELL_AUDIO_PORT_MAX || !s_ports[portNum].in_use)
+        return (s32)CELL_AUDIO_ERROR_PARAM;
+    if (!tag)
+        return (s32)CELL_AUDIO_ERROR_PARAM;
+
+    u64 nblock = s_ports[portNum].param.nBlock;
+    if (!nblock || blockNo >= nblock)
+        return (s32)CELL_AUDIO_ERROR_PARAM;
+
+    u64 base = s_ports[portNum].read_index;
+    u64 pos  = base % nblock;
+    base -= pos;
+    if (pos > blockNo)
+        base += nblock;
+
+    vm_write64((u32)(uintptr_t)tag, base + blockNo);
+    return CELL_OK;
+}
+
 s32 cellAudioSetPersonalDevice(s32 iPersonalStream, s32 iDevice)
 {
     (void)iPersonalStream;

--- a/libs/audio/cellAudio.h
+++ b/libs/audio/cellAudio.h
@@ -103,6 +103,7 @@ s32 cellAudioGetPortConfig(u32 portNum, CellAudioPortConfig* config);
 s32 cellAudioPortGetStatus(u32 portNum, u32* status);
 
 /* NID: 0x5676F81C */
+s32 cellAudioGetPortBlockTag(u32 portNum, u64 blockNo, u64* tag);
 s32 cellAudioSetPersonalDevice(s32 iPersonalStream, s32 iDevice);
 
 /* NID: 0x28BC1409 */

--- a/libs/input/cellPad.c
+++ b/libs/input/cellPad.c
@@ -649,6 +649,40 @@ skip_inject: ;
           }
       } }
 
+    /* PAD_FILE=<path> -- closed-loop input. Each poll, if the file holds a
+     * button mask (same encoding as PAD_SCRIPT), press it for a fixed number
+     * of polls and empty the file. A driver outside the process can then look
+     * at the log or a frame dump, decide which screen the title is on, and
+     * write the next button -- which a fixed time schedule cannot do, because
+     * a menu system with several screens wanders when driven blind.
+     *
+     *   echo 0x0008 > pad.txt    # START
+     *   echo 0x4000 > pad.txt    # CROSS
+     */
+    { static int s_pf = -1; static char pf_path[512];
+      static unsigned held_mask = 0; static int held_n = 0;
+      if (s_pf < 0) { const char* e = getenv("PAD_FILE");
+                      s_pf = (e && *e) ? 1 : 0;
+                      if (s_pf) { strncpy(pf_path, e, sizeof pf_path - 1); pf_path[sizeof pf_path - 1] = 0; } }
+      if (s_pf && port_no == 0) {
+          if (held_n <= 0) {
+              FILE* f = fopen(pf_path, "rb");
+              if (f) {
+                  char buf[64]; buf[0] = 0;
+                  if (fgets(buf, sizeof buf, f)) {
+                      unsigned m = (unsigned)strtoul(buf, 0, 0);
+                      if (m) { held_mask = m; held_n = 40;
+                               printf("[cellPad] PAD_FILE press 0x%04X\n", m); fflush(stdout); }
+                  }
+                  fclose(f);
+                  if (held_n > 0) { FILE* w = fopen(pf_path, "wb"); if (w) fclose(w); }
+              }
+          }
+          if (held_n > 0) { held_n--;
+              data->button[CELL_PAD_BTN_OFFSET_DIGITAL1] |= (u16)(held_mask & 0xFF);
+              data->button[CELL_PAD_BTN_OFFSET_DIGITAL2] |= (u16)((held_mask >> 8) & 0xFF); }
+      } }
+
     /* Analog sticks */
     /* PAD_STICK="lx,ly,rx,ry" (0-255, 128 = centred): hold the analog sticks at
      * fixed positions. Rubber Ducky drives its camera from the sticks and never

--- a/libs/input/cellPad.c
+++ b/libs/input/cellPad.c
@@ -78,6 +78,8 @@ static int           s_pad_initialized = 0;
 static u32           s_max_connect = 0;
 static u32           s_port_setting[CELL_PAD_MAX_PORT_NUM];
 static PadHostState  s_host_state[PAD_MAX_HOST_PORTS];
+/* Per-port "a report has arrived since your last read" flag; see cellPadGetData. */
+static int s_data_fresh[PAD_MAX_HOST_PORTS];
 
 #if PAD_BACKEND_SDL2
 static SDL_GameController* s_sdl_controllers[PAD_MAX_HOST_PORTS];
@@ -110,6 +112,80 @@ static u8 pad_xinput_stick_to_u8(short raw, short deadzone)
     if (val > 255) val = 255;
     return (u8)val;
 }
+
+/* Keyboard fallback for port 0.
+ *
+ * The only backend here is XInput, so on a machine with no controller plugged
+ * in a title gets a pad that is reported present and never presses anything --
+ * it can be watched but not played. That is what The Simpsons Arcade Game hit:
+ * it reached its attract loop and no input existed to start a game.
+ *
+ * Only fills in for port 0, only when XInput found nothing there, so a real
+ * controller always wins and nothing changes for a port that has one. Keys are
+ * read only while a window of THIS process is in the foreground, so typing in
+ * another application does not drive the game. Set PAD_NO_KEYBOARD=1 to
+ * disable it entirely.
+ *
+ * Arrows = d-pad, Z/X/A/S = cross/circle/square/triangle, Q/W = L1/R1,
+ * 1/2 = L2/R2, Enter = START, Tab = SELECT. The left stick mirrors the d-pad
+ * so a title that reads the stick instead is playable too. */
+#ifdef _WIN32
+static int pad_host_window_focused(void)
+{
+    HWND fg = GetForegroundWindow();
+    if (!fg) return 0;
+    DWORD pid = 0;
+    GetWindowThreadProcessId(fg, &pid);
+    return pid == GetCurrentProcessId();
+}
+
+static void pad_poll_keyboard(void)
+{
+    static int off = -1;
+    if (off < 0) off = getenv("PAD_NO_KEYBOARD") ? 1 : 0;
+    if (off) return;
+
+    PadHostState* hs = &s_host_state[0];
+    if (!pad_host_window_focused()) {
+        /* Release everything on focus loss, or a key held while alt-tabbing
+         * would stay down forever. */
+        hs->buttons = 0;
+        hs->analog_lx = hs->analog_ly = 128;
+        hs->analog_rx = hs->analog_ry = 128;
+        hs->connected = 1;
+        return;
+    }
+
+    static const struct { int vk; u16 btn; } map[] = {
+        { VK_UP,     CELL_PAD_CTRL_UP },      { VK_DOWN,  CELL_PAD_CTRL_DOWN },
+        { VK_LEFT,   CELL_PAD_CTRL_LEFT },    { VK_RIGHT, CELL_PAD_CTRL_RIGHT },
+        { 'Z',       CELL_PAD_CTRL_CROSS },   { 'X',      CELL_PAD_CTRL_CIRCLE },
+        { 'A',       CELL_PAD_CTRL_SQUARE },  { 'S',      CELL_PAD_CTRL_TRIANGLE },
+        { 'Q',       CELL_PAD_CTRL_L1 },      { 'W',      CELL_PAD_CTRL_R1 },
+        { '1',       CELL_PAD_CTRL_L2 },      { '2',      CELL_PAD_CTRL_R2 },
+        { VK_RETURN, CELL_PAD_CTRL_START },   { VK_TAB,   CELL_PAD_CTRL_SELECT },
+    };
+
+    u16 btns = 0;
+    for (unsigned i = 0; i < sizeof map / sizeof map[0]; i++)
+        if (GetAsyncKeyState(map[i].vk) & 0x8000) btns |= map[i].btn;
+
+    hs->buttons   = btns;
+    hs->connected = 1;
+    hs->analog_lx = (u8)((btns & CELL_PAD_CTRL_LEFT) ? 0 :
+                         (btns & CELL_PAD_CTRL_RIGHT) ? 255 : 128);
+    hs->analog_ly = (u8)((btns & CELL_PAD_CTRL_UP) ? 0 :
+                         (btns & CELL_PAD_CTRL_DOWN) ? 255 : 128);
+    hs->analog_rx = hs->analog_ry = 128;
+    hs->trigger_l2 = (u8)((btns & CELL_PAD_CTRL_L2) ? 255 : 0);
+    hs->trigger_r2 = (u8)((btns & CELL_PAD_CTRL_R2) ? 255 : 0);
+
+    { static int said = 0;
+      if (!said && btns) { said = 1;
+          printf("[cellPad] keyboard fallback active on port 0 (no XInput device)\n");
+          fflush(stdout); } }
+}
+#endif
 
 static void pad_poll_xinput(void)
 {
@@ -317,12 +393,53 @@ static void pad_shutdown_backend(void)
  * Poll dispatcher
  * -----------------------------------------------------------------------*/
 
+/* Re-poll the host at most every PAD_POLL_INTERVAL_MS; serve cached state in
+ * between.
+ *
+ * XInputGetState is a driver call, and on a slot with nothing plugged in it is
+ * an expensive one: measured at 97.6 us for a sweep of the 7 host ports on a
+ * machine with no controller attached. cellPadGetData ran that sweep on EVERY
+ * call, and a guest that polls the pad from a spin loop -- The Simpsons Arcade
+ * Game does, in its input stage -- therefore spends its whole main thread
+ * inside the input driver.
+ *
+ * 4 ms is 250 Hz, well above the 60 Hz a title can actually observe (and above
+ * a real DualShock 3's own report rate), so no game can tell the difference,
+ * including one sampling for button-press edges. */
+#define PAD_POLL_INTERVAL_MS 4
+
+static unsigned long long pad_now_ms(void)
+{
+#ifdef _WIN32
+    return (unsigned long long)GetTickCount64();
+#else
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (unsigned long long)ts.tv_sec * 1000ull +
+           (unsigned long long)ts.tv_nsec / 1000000ull;
+#endif
+}
+
 static void pad_poll_backend(void)
 {
+    /* Benign race: two threads may poll in the same tick. That costs one extra
+     * sweep, never a missed or stale-forever read. */
+    static unsigned long long s_last_ms = 0;
+    unsigned long long now = pad_now_ms();
+    if (s_last_ms && now - s_last_ms < PAD_POLL_INTERVAL_MS) return;
+    s_last_ms = now;
+    /* A real pad streams reports at roughly this rate whether or not anything
+     * changed, and libpad buffers them; a fresh sweep is a fresh report for
+     * every port. cellPadGetData hands each one out exactly once. */
+    for (int _i = 0; _i < PAD_MAX_HOST_PORTS; _i++) s_data_fresh[_i] = 1;
+
 #if PAD_BACKEND_XINPUT
     pad_poll_xinput();
 #elif PAD_BACKEND_SDL2
     pad_poll_sdl2();
+#endif
+#ifdef _WIN32
+    if (!s_host_state[0].connected) pad_poll_keyboard();
 #endif
 }
 
@@ -483,6 +600,46 @@ skip_inject: ;
               data->button[CELL_PAD_BTN_OFFSET_DIGITAL1] |= 0x08;   /* START */
       } }
 
+    /* PAD_SCRIPT="<sec>:<mask>,<sec>:<mask>,..." -- press a NAMED button at a
+     * given wall-clock second, each held ~250 ms. LBP_AUTOPRESS only pulses
+     * CROSS and START, which is enough to clear a "press start" screen but not
+     * to navigate a menu: You Don't Know Jack needs DOWN to move off its name
+     * field before CROSS means anything. Masks are CELL_PAD_CTRL_* packed as
+     * (DIGITAL2 << 8) | DIGITAL1: START 0x0008, UP 0x0010, DOWN 0x0040,
+     * LEFT 0x0080, RIGHT 0x0020, CROSS 0x4000, CIRCLE 0x2000, TRIANGLE 0x1000.
+     * Legit input simulation on the same footing as LBP_AUTOPRESS/PAD_STICK. */
+    { static int s_sc = -1;
+      static struct { double t; unsigned mask; } ev[32]; static int n_ev = 0;
+      static ULONGLONG t0 = 0;
+      if (s_sc < 0) {
+          s_sc = 0;
+          const char* e = getenv("PAD_SCRIPT");
+          if (e && *e) {
+              s_sc = 1; t0 = GetTickCount64();
+              const char* p = e;
+              while (*p && n_ev < 32) {
+                  double t = strtod(p, (char**)&p);
+                  if (*p == ':') p++;
+                  unsigned m = (unsigned)strtoul(p, (char**)&p, 0);
+                  ev[n_ev].t = t; ev[n_ev].mask = m; n_ev++;
+                  while (*p == ',' || *p == ' ') p++;
+              }
+              printf("[cellPad] PAD_SCRIPT: %d event(s)\n", n_ev);
+          }
+      }
+      if (s_sc && port_no == 0) {
+          double now = (double)(GetTickCount64() - t0) / 1000.0;
+          for (int i = 0; i < n_ev; i++) {
+              if (now >= ev[i].t && now < ev[i].t + 0.25) {
+                  data->button[CELL_PAD_BTN_OFFSET_DIGITAL1] |= (u16)(ev[i].mask & 0xFF);
+                  data->button[CELL_PAD_BTN_OFFSET_DIGITAL2] |= (u16)((ev[i].mask >> 8) & 0xFF);
+                  static int said[32];
+                  if (!said[i]) { said[i] = 1;
+                      printf("[cellPad] PAD_SCRIPT t=%.1fs press 0x%04X\n", ev[i].t, ev[i].mask); }
+              }
+          }
+      } }
+
     /* Analog sticks */
     /* PAD_STICK="lx,ly,rx,ry" (0-255, 128 = centred): hold the analog sticks at
      * fixed positions. Rubber Ducky drives its camera from the sticks and never
@@ -559,6 +716,38 @@ skip_inject: ;
     }  /* end connected block */
 
 emit:
+    /* A non-zero len means "here is a CHANGE packet" -- the constant is literally
+     * named CELL_PAD_LEN_CHANGE_DEFAULT. Hardware reports len = 0 once the port
+     * has nothing new, and titles DRAIN on that: The Simpsons Arcade Game's
+     * input stage is
+     *
+     *     while (cellPadGetData(port, &d) == CELL_OK && d.len > 0) { ... }
+     *
+     * (func_0013CFA8, loop 0x13D648 -> 0x13D040). Reporting a change on every
+     * call made that loop infinite: the main thread pegged one core inside
+     * libpad and the title never got past its first rendered screen.
+     *
+     * So hand out one packet per host report and report len = 0 for any read
+     * after that until the next one arrives (pad_poll_backend sets the flag when
+     * it actually re-polls, every PAD_POLL_INTERVAL_MS). That is what the
+     * hardware does: a pad streams reports at a fixed rate whether or not
+     * anything changed, and libpad buffers them.
+     *
+     * Reporting only on CHANGE instead is wrong and was tried: a HELD button
+     * produces exactly one packet, so a title that reads button[] only when
+     * len > 0 sees the press for a single frame and then sees nothing. In this
+     * game that came out as jump being the only control that seemed to work and
+     * attack firing once.
+     *
+     * PAD_ALWAYS_CHANGE=1 restores the old always-a-packet behaviour. */
+    {
+        static int always = -1;
+        if (always < 0) always = getenv("PAD_ALWAYS_CHANGE") ? 1 : 0;
+        if (!always && port_no < PAD_MAX_HOST_PORTS && data->len) {
+            if (!s_data_fresh[port_no]) data->len = 0;   /* nothing new: end the drain */
+            else                        s_data_fresh[port_no] = 0;
+        }
+    }
     {
         unsigned int ea = (unsigned int)(uintptr_t)data_guest;
         vm_write32((unsigned long long)ea + 0, (unsigned int)data->len);   /* len (s32) */

--- a/libs/input/cellPad.c
+++ b/libs/input/cellPad.c
@@ -629,8 +629,17 @@ skip_inject: ;
       }
       if (s_sc && port_no == 0) {
           double now = (double)(GetTickCount64() - t0) / 1000.0;
+          /* Latch, do not window. A fixed time window is missed whenever the
+           * title stops polling the pad for longer than the window (it does
+           * exactly that on a loading screen), so the press silently never
+           * happens. Fire on the first poll at or after the event time and
+           * hold it for a fixed number of polls, which is what a real press
+           * looks like regardless of poll rate. */
+          static int fired[32], held[32];
           for (int i = 0; i < n_ev; i++) {
-              if (now >= ev[i].t && now < ev[i].t + 0.25) {
+              if (!fired[i] && now >= ev[i].t) { fired[i] = 1; held[i] = 40; }
+              if (held[i] > 0) {
+                  held[i]--;
                   data->button[CELL_PAD_BTN_OFFSET_DIGITAL1] |= (u16)(ev[i].mask & 0xFF);
                   data->button[CELL_PAD_BTN_OFFSET_DIGITAL2] |= (u16)((ev[i].mask >> 8) & 0xFF);
                   static int said[32];

--- a/libs/misc/cellAvconfExt.c
+++ b/libs/misc/cellAvconfExt.c
@@ -125,6 +125,36 @@ s32 cellAudioOutGetConfiguration(u32 audioOut,
     return CELL_OK;
 }
 
+/* cellAudioOutGetState(audioOut, deviceIndex, state) -- the audio sibling of
+ * cellVideoOutGetState. A title checks it before configuring output; Virtua
+ * Fighter 5 calls it once during boot and it was the last unresolved import in
+ * the whole title. The device is always present and enabled here: there is no
+ * "no audio device" case a recompiled port can be in.
+ *
+ * CellAudioOutState { u8 state; u8 encoder; u8 reserved[2]; u32 downMixer;
+ *                     CellAudioOutSoundMode soundMode; } -- written big-endian
+ * a byte at a time, which needs no struct definition to get right. */
+s32 cellAudioOutGetState(u32 audioOut, u32 deviceIndex, void* state)
+{
+    (void)deviceIndex;
+    uint32_t ea = (uint32_t)(uintptr_t)state;
+    printf("[cellAvconfExt] AudioOutGetState(audioOut=%u)\n", audioOut);
+    if (!ea)
+        return CELL_EINVAL;
+
+    vm_write8(ea + 0, 0);                                   /* ENABLED        */
+    vm_write8(ea + 1, CELL_AUDIO_OUT_CODING_TYPE_LPCM);
+    vm_write8(ea + 2, 0);
+    vm_write8(ea + 3, 0);
+    vm_write32(ea + 4, 0);                                  /* no down-mixer  */
+    vm_write8(ea + 8, CELL_AUDIO_OUT_CODING_TYPE_LPCM);     /* soundMode      */
+    vm_write8(ea + 9, CELL_AUDIO_OUT_CHNUM_2);
+    vm_write8(ea + 10, CELL_AUDIO_OUT_FS_48KHZ);
+    vm_write8(ea + 11, 0);
+    vm_write32(ea + 12, 0);
+    return CELL_OK;
+}
+
 s32 cellAudioOutSetCopyControl(u32 audioOut, u32 control)
 {
     (void)audioOut;

--- a/libs/misc/cellAvconfExt.h
+++ b/libs/misc/cellAvconfExt.h
@@ -78,6 +78,7 @@ s32 cellAudioOutGetDeviceInfo(u32 audioOut, u32 deviceIndex,
 s32 cellAudioOutGetConfiguration(u32 audioOut,
                                   CellAudioOutConfiguration* config,
                                   void* option, u32 optionSize);
+s32 cellAudioOutGetState(u32 audioOut, u32 deviceIndex, void* state);
 s32 cellAudioOutSetCopyControl(u32 audioOut, u32 control);
 
 /* HDMI/display audio */

--- a/libs/system/cellGame.c
+++ b/libs/system/cellGame.c
@@ -409,6 +409,21 @@ s32 cellGameDataCheckCreate2(u32 version, const char* dirName, u32 errDialog,
     return CELL_OK;
 }
 
+/* cellGameDataCheckCreate -- the pre-3.00 entry point. Same arguments and same
+ * behaviour as Create2 (RPCS3 forwards it the same way); the only difference is
+ * the size of CellGameDataStatGet in older SDKs, and a title that asks for the
+ * smaller one simply ignores the tail of ours.
+ *
+ * Registering only Create2 meant a title on the older API got the unresolved-NID
+ * default, its funcStat callback never fired, and its game-data check never
+ * completed. Virtua Fighter 5 calls this once during its load and stops there. */
+s32 cellGameDataCheckCreate(u32 version, const char* dirName, u32 errDialog,
+                            void* funcStat, u32 container)
+{
+    printf("[cellGame] DataCheckCreate -> Create2%c", 10);
+    return cellGameDataCheckCreate2(version, dirName, errDialog, funcStat, container);
+}
+
 s32 cellGameGetParamInt(s32 id, s32* value)
 {
     printf("[cellGame] GetParamInt(id=%d)\n", id);

--- a/libs/system/cellGame.h
+++ b/libs/system/cellGame.h
@@ -143,6 +143,8 @@ s32 cellGameContentPermit(char* contentInfoPath, char* usrdirPath);
 
 s32 cellGameDataCheck(u32 type, const char* dirName, CellGameContentSize* size);
 
+s32 cellGameDataCheckCreate(u32 version, const char* dirName, u32 errDialog,
+                            void* funcStat, u32 container);
 s32 cellGameDataCheckCreate2(u32 version, const char* dirName, u32 errDialog,
                              void* funcStat, u32 container);
 

--- a/libs/system/cellMsgDialog.c
+++ b/libs/system/cellMsgDialog.c
@@ -114,6 +114,18 @@ s32 cellMsgDialogOpen2(CellMsgDialogType type, const char* msgString,
     return CELL_OK;
 }
 
+/* cellMsgDialogOpen -- the pre-3.40 entry point, identical arguments and
+ * behaviour to Open2 (RPCS3 forwards it the same way). Registering only Open2
+ * meant a title on the older API got the unresolved-NID default and then waited
+ * forever for a callback that could never fire. Virtua Fighter 5 opens one
+ * during boot and stops dead there. */
+s32 cellMsgDialogOpen(CellMsgDialogType type, const char* msgString,
+                      CellMsgDialogCallback callback, void* userdata,
+                      void* extParam)
+{
+    return cellMsgDialogOpen2(type, msgString, callback, userdata, extParam);
+}
+
 s32 cellMsgDialogClose(float delayMs)
 {
     printf("[cellMsgDialog] Close(delay=%.1f ms)\n", delayMs);

--- a/libs/system/cellMsgDialog.c
+++ b/libs/system/cellMsgDialog.c
@@ -46,6 +46,22 @@ static CellMsgDialogCallback s_callback    = NULL;
 static void*                 s_userdata    = NULL;
 static CellMsgDialogType     s_type        = 0;
 
+/* Answer queued for the next cellSysutilCheckCallback (see Open2). */
+static int                   s_pending        = 0;
+static int32_t               s_pending_result = 0;
+static CellMsgDialogCallback s_pending_cb     = NULL;
+static void*                 s_pending_user   = NULL;
+
+extern int cellSysutil_pump_seen(void);
+
+/* Called from cellSysutilCheckCallback. */
+void cellMsgDialog_pump(void)
+{
+    if (!s_pending) return;
+    s_pending = 0;
+    invoke_dialog_callback(s_pending_cb, s_pending_result, s_pending_user);
+}
+
 /* Progress bar state */
 #define MAX_PROGRESS_BARS 2
 
@@ -112,10 +128,30 @@ s32 cellMsgDialogOpen2(CellMsgDialogType type, const char* msgString,
             printf("[cellMsgDialog] Auto-responding: NONE (no buttons)\n");
         }
 
-        /* Close and invoke callback */
+        /* Deliver the answer the way hardware does: from the title's own
+         * cellSysutilCheckCallback pump, not synchronously from inside Open.
+         * Firing it here runs the guest callback BEFORE Open has returned, so a
+         * title that arms its wait state after the call --
+         *
+         *     state = WAITING;
+         *     cellMsgDialogOpen(..., cb, &state);   // cb sets state = DONE
+         *     state = WAITING;                      // ...overwritten here
+         *
+         * -- loses the answer and waits forever. Queue it instead.
+         *
+         * A title that never pumps sysutil would then never see the answer at
+         * all, so fall back to the old synchronous call until a pump is
+         * actually observed. */
         s_dialog_open = 0;
         if (s_callback) {
-            invoke_dialog_callback(s_callback, result, s_userdata);
+            if (cellSysutil_pump_seen()) {
+                s_pending_result = result;
+                s_pending_cb     = s_callback;
+                s_pending_user   = s_userdata;
+                s_pending        = 1;
+            } else {
+                invoke_dialog_callback(s_callback, result, s_userdata);
+            }
         }
     } else {
         printf("[cellMsgDialog] Progress bar dialog opened (will close on explicit Close/Abort)\n");

--- a/libs/system/cellMsgDialog.c
+++ b/libs/system/cellMsgDialog.c
@@ -8,6 +8,7 @@
 #include "cellMsgDialog.h"
 #include "ps3emu/guest_call.h"
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
 #include "../../runtime/ppu/ppu_memory.h"   /* GUEST_PTR, vm_read/vm_write: guest EA -> host */
@@ -92,8 +93,17 @@ s32 cellMsgDialogOpen2(CellMsgDialogType type, const char* msgString,
         s32 result = CELL_MSGDIALOG_BUTTON_OK;
 
         if (button_type == CELL_MSGDIALOG_TYPE_BUTTON_TYPE_YESNO) {
-            result = CELL_MSGDIALOG_BUTTON_YES;
-            printf("[cellMsgDialog] Auto-responding: YES\n");
+            /* MSGDIALOG_ANSWER=no answers every yes/no prompt NO instead. The
+             * auto-answer is a guess about what the title wants, and yes is not
+             * always the boot-friendliest one: a "use game data?" prompt
+             * answered yes sends the title down an install/cache path a port may
+             * have nothing behind, where no just plays from disc. A knob costs
+             * less than a rebuild to try the other branch. */
+            static int no_ = -1;
+            if (no_ < 0) { const char* e = getenv("MSGDIALOG_ANSWER");
+                           no_ = (e && (e[0] == 'n' || e[0] == 'N')) ? 1 : 0; }
+            result = no_ ? CELL_MSGDIALOG_BUTTON_NO : CELL_MSGDIALOG_BUTTON_YES;
+            printf("[cellMsgDialog] Auto-responding: %s\n", no_ ? "NO" : "YES");
         } else if (button_type == CELL_MSGDIALOG_TYPE_BUTTON_TYPE_OK) {
             result = CELL_MSGDIALOG_BUTTON_OK;
             printf("[cellMsgDialog] Auto-responding: OK\n");

--- a/libs/system/cellMsgDialog.h
+++ b/libs/system/cellMsgDialog.h
@@ -60,6 +60,9 @@ typedef void (*CellMsgDialogCallback)(s32 buttonType, void* userdata);
  * Functions
  * -----------------------------------------------------------------------*/
 
+s32 cellMsgDialogOpen(CellMsgDialogType type, const char* msgString,
+                      CellMsgDialogCallback callback, void* userdata,
+                      void* extParam);
 s32 cellMsgDialogOpen2(CellMsgDialogType type, const char* msgString,
                         CellMsgDialogCallback callback, void* userdata,
                         void* extParam);

--- a/libs/system/cellSaveData.c
+++ b/libs/system/cellSaveData.c
@@ -243,6 +243,45 @@ static s32 dispatch_func_stat(uint32_t func_opd, int is_new, const char* dirName
     return result;
 }
 
+/* Dispatch a List/Fixed selection callback.
+ *
+ * The four List/Fixed entry points used to call the guest OPD as a HOST
+ * function pointer with HOST struct pointers -- `funcList(&cbResult, &listGet,
+ * &listSet)`. That is an immediate access violation the first time a title
+ * actually reaches one, and none did until Virtua Fighter 5 called
+ * cellSaveDataFixedLoad: rip == the guest OPD address, 0x00691F30.
+ *
+ * ponytail: this dispatches through the guest caller with ZEROED guest
+ * structures rather than marshalling the directory list. With no save data on
+ * the VFS the list is empty anyway, which is the honest answer, and a title
+ * sees "nothing to select" and proceeds with defaults. Marshal CellSaveData-
+ * ListGet/ListSet properly when a title needs to pick an existing save; the
+ * layouts are the only missing piece, and dispatch_func_stat next door is the
+ * shape to copy. */
+static s32 dispatch_func_select(uint32_t func_opd, uint32_t dirCount,
+                                uint32_t userdata_ea, const char* who)
+{
+    if (!g_ps3_guest_caller) return CELL_SAVEDATA_CBRESULT_ERR_FAILURE;
+
+    scratch_reset();
+    uint32_t cb_ea  = scratch_alloc(SAVEDATA_CBRESULT_SIZE);
+    uint32_t get_ea = scratch_alloc(SAVEDATA_STATGET_SIZE);
+    uint32_t set_ea = scratch_alloc(SAVEDATA_STATSET_SIZE);
+    if (!cb_ea || !get_ea || !set_ea) return CELL_SAVEDATA_CBRESULT_ERR_FAILURE;
+
+    marshal_cbresult_init(cb_ea, CELL_SAVEDATA_CBRESULT_OK_NEXT, userdata_ea);
+    vm_write32(get_ea + 0, dirCount);        /* dirNum     */
+    vm_write32(get_ea + 4, 0);               /* dirListNum: nothing marshalled */
+
+    printf("[cellSaveData] dispatching %s OPD=0x%08X (dirNum=%u)%c",
+           who, func_opd, dirCount, 10);
+    g_ps3_guest_caller(func_opd, cb_ea, get_ea, set_ea, 0, 0, 0, 0, 0);
+
+    s32 result = marshal_cbresult_read_result(cb_ea);
+    printf("[cellSaveData] %s returned cbResult.result=%d%c", who, result, 10);
+    return result;
+}
+
 /* Enumerate save directories matching a prefix. Returns count, fills dirList up to max. */
 static u32 enumerate_save_dirs(const char* prefix, CellSaveDataDirList* dirList, u32 max)
 {
@@ -716,7 +755,9 @@ s32 cellSaveDataListSave2(u32 version, CellSaveDataSetList* setList,
     CellSaveDataListSet listSet;
     memset(&listSet, 0, sizeof(listSet));
 
-    funcList(&cbResult, &listGet, &listSet);
+    cbResult.result = dispatch_func_select((uint32_t)(uintptr_t)funcList,
+                                          listGet.dirListNum,
+                                          (uint32_t)(uintptr_t)userdata, "funcList");
 
     if (cbResult.result < 0) {
         free(dirList);
@@ -781,7 +822,9 @@ s32 cellSaveDataListLoad2(u32 version, CellSaveDataSetList* setList,
     CellSaveDataListSet listSet;
     memset(&listSet, 0, sizeof(listSet));
 
-    funcList(&cbResult, &listGet, &listSet);
+    cbResult.result = dispatch_func_select((uint32_t)(uintptr_t)funcList,
+                                          listGet.dirListNum,
+                                          (uint32_t)(uintptr_t)userdata, "funcList");
 
     if (cbResult.result < 0) {
         free(dirList);
@@ -845,7 +888,9 @@ s32 cellSaveDataFixedSave2(u32 version, CellSaveDataSetList* setList,
     CellSaveDataListSet listSet;
     memset(&listSet, 0, sizeof(listSet));
 
-    funcFixed(&cbResult, &listGet, &listSet);
+    cbResult.result = dispatch_func_select((uint32_t)(uintptr_t)funcFixed,
+                                          listGet.dirListNum,
+                                          (uint32_t)(uintptr_t)userdata, "funcFixed");
 
     if (cbResult.result < 0) {
         free(dirList);
@@ -907,7 +952,9 @@ s32 cellSaveDataFixedLoad2(u32 version, CellSaveDataSetList* setList,
     CellSaveDataListSet listSet;
     memset(&listSet, 0, sizeof(listSet));
 
-    funcFixed(&cbResult, &listGet, &listSet);
+    cbResult.result = dispatch_func_select((uint32_t)(uintptr_t)funcFixed,
+                                          listGet.dirListNum,
+                                          (uint32_t)(uintptr_t)userdata, "funcFixed");
 
     if (cbResult.result < 0) {
         free(dirList);
@@ -942,10 +989,21 @@ s32 cellSaveDataAutoSave2(u32 version, const char* dirName,
     printf("[cellSaveData] AutoSave2(version=%u, dir='%s')\n",
            version, dirName ? dirName : "<null>");
 
-    if (!dirName || !setBuf || !funcStat)
-        return CELL_SAVEDATA_ERROR_PARAM;
-
-    return savedata_execute(dirName, 1, setBuf, funcStat, funcFile, userdata);
+    /* Delegate to the non-_2 entry, which marshals. This used to call
+     * savedata_execute(), which invokes funcStat as a HOST function pointer
+     * with HOST struct addresses -- but funcStat is a guest OPD and the structs
+     * must live in guest memory, so the callback wrote nothing the caller could
+     * read and the first dereference faulted. The Simpsons Arcade Game crashed
+     * exactly here on its first boot, creating its profile right after
+     * AutoLoad2 had correctly reported ERR_NODATA. The two entries take
+     * identical arguments; _2 is just the newer SDK name.
+     *
+     * savedata_execute() is still behind the List* and Fixed* entries and
+     * carries the same defect for each of them. Fixing those needs list/file
+     * marshalling that dispatch_func_stat does not do yet, so they are left
+     * alone until a title actually reaches one. */
+    return cellSaveDataAutoSave(version, dirName, errDialog, setBuf,
+                                funcStat, funcFile, container, userdata);
 }
 
 s32 cellSaveDataAutoLoad2(u32 version, const char* dirName,
@@ -1014,6 +1072,55 @@ s32 cellSaveDataDelete2(u32 container)
  * cellSaveDataAutoSave / AutoLoad / Delete instead of the _2 variants
  * RPCS3's flOw build uses. Same semantics, different NID.
  * -----------------------------------------------------------------------*/
+/* The pre-3.00 List/Fixed entry points. Identical to their "2" forms except
+ * that v2 added a trailing `userdata` the callbacks echo back; RPCS3 forwards
+ * v1 with userdata = NULL and so do we. Registering only the "2" forms left a
+ * title on the older API getting the unresolved-NID default, so its save-data
+ * callbacks never fired and whatever it was loading never completed. Virtua
+ * Fighter 5 calls FixedLoad during its boot and stops there.
+ *
+ * Same shape as cellMsgDialogOpen vs Open2 and cellGameDataCheckCreate vs
+ * Create2 -- three of the four v1/v2 pairs in this tree had the same gap. */
+s32 cellSaveDataListSave(u32 version, CellSaveDataSetList* setList,
+                         CellSaveDataSetBuf* setBuf,
+                         CellSaveDataListCallback funcList,
+                         CellSaveDataStatCallback funcStat,
+                         CellSaveDataFileCallback funcFile, u32 container)
+{
+    return cellSaveDataListSave2(version, setList, setBuf, funcList, funcStat,
+                                 funcFile, container, NULL);
+}
+
+s32 cellSaveDataListLoad(u32 version, CellSaveDataSetList* setList,
+                         CellSaveDataSetBuf* setBuf,
+                         CellSaveDataListCallback funcList,
+                         CellSaveDataStatCallback funcStat,
+                         CellSaveDataFileCallback funcFile, u32 container)
+{
+    return cellSaveDataListLoad2(version, setList, setBuf, funcList, funcStat,
+                                 funcFile, container, NULL);
+}
+
+s32 cellSaveDataFixedSave(u32 version, CellSaveDataSetList* setList,
+                          CellSaveDataSetBuf* setBuf,
+                          CellSaveDataFixedCallback funcFixed,
+                          CellSaveDataStatCallback funcStat,
+                          CellSaveDataFileCallback funcFile, u32 container)
+{
+    return cellSaveDataFixedSave2(version, setList, setBuf, funcFixed, funcStat,
+                                  funcFile, container, NULL);
+}
+
+s32 cellSaveDataFixedLoad(u32 version, CellSaveDataSetList* setList,
+                          CellSaveDataSetBuf* setBuf,
+                          CellSaveDataFixedCallback funcFixed,
+                          CellSaveDataStatCallback funcStat,
+                          CellSaveDataFileCallback funcFile, u32 container)
+{
+    return cellSaveDataFixedLoad2(version, setList, setBuf, funcFixed, funcStat,
+                                  funcFile, container, NULL);
+}
+
 s32 cellSaveDataAutoSave(u32 version, const char* dirName,
                           u32 errDialog,
                           CellSaveDataSetBuf* setBuf,

--- a/libs/system/cellSaveData.h
+++ b/libs/system/cellSaveData.h
@@ -252,6 +252,24 @@ typedef struct CellSaveDataSetBuf {
  * Functions
  * -----------------------------------------------------------------------*/
 
+/* pre-3.00 entry points; forwarders to the "2" forms with userdata = NULL. */
+s32 cellSaveDataListSave(u32 version, CellSaveDataSetList* setList,
+                         CellSaveDataSetBuf* setBuf, CellSaveDataListCallback funcList,
+                         CellSaveDataStatCallback funcStat,
+                         CellSaveDataFileCallback funcFile, u32 container);
+s32 cellSaveDataListLoad(u32 version, CellSaveDataSetList* setList,
+                         CellSaveDataSetBuf* setBuf, CellSaveDataListCallback funcList,
+                         CellSaveDataStatCallback funcStat,
+                         CellSaveDataFileCallback funcFile, u32 container);
+s32 cellSaveDataFixedSave(u32 version, CellSaveDataSetList* setList,
+                          CellSaveDataSetBuf* setBuf, CellSaveDataFixedCallback funcFixed,
+                          CellSaveDataStatCallback funcStat,
+                          CellSaveDataFileCallback funcFile, u32 container);
+s32 cellSaveDataFixedLoad(u32 version, CellSaveDataSetList* setList,
+                          CellSaveDataSetBuf* setBuf, CellSaveDataFixedCallback funcFixed,
+                          CellSaveDataStatCallback funcStat,
+                          CellSaveDataFileCallback funcFile, u32 container);
+
 s32 cellSaveDataListSave2(u32 version, CellSaveDataSetList* setList,
                            CellSaveDataSetBuf* setBuf,
                            CellSaveDataListCallback funcList,

--- a/libs/system/cellSysutil.c
+++ b/libs/system/cellSysutil.c
@@ -127,8 +127,20 @@ s32 cellSysutilUnregisterCallback(s32 slot)
     return CELL_OK;
 }
 
+/* Whether the title actually pumps sysutil. cellMsgDialog needs to know: it
+ * defers a dialog answer to this pump (which is where hardware delivers it) and
+ * must not defer into a pump that never runs. */
+static int s_pump_seen = 0;
+int cellSysutil_pump_seen(void) { return s_pump_seen; }
+
 s32 cellSysutilCheckCallback(void)
 {
+    { extern void cellMsgDialog_pump(void);
+      if (!s_pump_seen) {
+          s_pump_seen = 1;
+          printf("[cellSysutil] CheckCallback: the title pumps sysutil%c", 10);
+      }
+      cellMsgDialog_pump(); }
     /* Drain the event queue, dispatching each event into guest code via
      * the registered ps3_guest_caller hook. Standard PS3 sysutil callback
      * signature is:

--- a/libs/system/sysPrxForUser.c
+++ b/libs/system/sysPrxForUser.c
@@ -727,23 +727,93 @@ s32 sys_heap_destroy_heap(sys_heap_t heap)
     return CELL_ESRCH;
 }
 
-/* Guest-address bump allocator for the _sys_heap_* API. These return a GUEST
+/* Guest-address allocator for the _sys_heap_* API. These return a GUEST
  * effective address (the caller writes to it through the VM), so a host malloc
  * pointer is wrong -- the guest would treat it as a 32-bit EA and fault. Hand
- * out addresses from a dedicated guest window above the sys_memory window. */
+ * out addresses from a dedicated guest window above the sys_memory window.
+ *
+ * This was a pure bump allocator with a no-op free, which is fine for a title
+ * that allocates a few blocks at startup and fine for getting past an
+ * out-of-memory path -- and not fine for a title whose middleware allocates and
+ * frees working buffers continuously. Virtua Fighter 5's CRI ADXM threads do
+ * exactly that and walked the window until they were reading each other's
+ * blocks.
+ *
+ * ponytail: size-binned free lists, not a general heap. The traffic here is a
+ * small number of repeated sizes, so returning a freed block to a bin keyed by
+ * its rounded size reuses memory perfectly for that pattern and costs one
+ * array. No coalescing: a title that allocates thousands of DISTINCT sizes will
+ * still exhaust the window, and the fix then is a real first-fit heap, not a
+ * bigger window.
+ *
+ * Block layout, all relative to the address handed to the guest:
+ *   user-4   offset back to the raw block start
+ *   user-8   bin index
+ *   user-12  magic (so free() can tell our blocks from a foreign pointer)
+ * The free-list link lives at the raw block start, which is dead space while
+ * the block is free. */
 #define YZ_HEAP_BASE 0x50000000u
 #define YZ_HEAP_END  0x58000000u
+#define YZ_HEAP_MAGIC 0x595A4850u        /* 'YZHP' */
+#define YZ_BINS 32
 static u32 s_heap_bump = 0;
+static u32 s_heap_bin[YZ_BINS];          /* guest EA of each free list head */
+
+static u32 yz_bin_for(u32 need)
+{
+    u32 b = 4;                            /* 16 bytes minimum */
+    while (b < YZ_BINS - 1 && (1u << b) < need) b++;
+    return b;
+}
 
 static u32 yz_heap_alloc(u32 size, u32 align)
 {
-    if (s_heap_bump == 0) s_heap_bump = YZ_HEAP_BASE;
     if (align < 16) align = 16;
-    s_heap_bump = (s_heap_bump + align - 1) & ~(align - 1);
-    u32 ea = s_heap_bump;
-    s_heap_bump += (size + 15) & ~15u;
-    if (s_heap_bump > YZ_HEAP_END) return 0;
-    return ea;   /* guest EA; flat VM commits pages on first access */
+    u32 need = size + align + 16;         /* header + worst-case alignment pad */
+    u32 b = yz_bin_for(need);
+    u32 raw;
+
+    slot_lock();
+    if (s_heap_bin[b]) {
+        raw = s_heap_bin[b];
+        s_heap_bin[b] = vm_read32(raw);
+    } else {
+        if (s_heap_bump == 0) s_heap_bump = YZ_HEAP_BASE;
+        raw = s_heap_bump;
+        s_heap_bump += (1u << b);
+        if (s_heap_bump > YZ_HEAP_END) { slot_unlock(); return 0; }
+    }
+    slot_unlock();
+
+    u32 user = (raw + 16 + align - 1) & ~(align - 1);
+    { static int dbg = -1;
+      if (dbg < 0) dbg = getenv("SYS_HEAP_DBG") ? 1 : 0;
+      if (dbg) { static int n = 0; if (n++ < 400)
+          fprintf(stderr, "[heap] alloc size=%u align=%u -> 0x%08X (raw 0x%08X, bin %u)%c",
+                  size, align, user, raw, b, 10); } }
+    vm_write32(user - 4,  user - raw);
+    vm_write32(user - 8,  b);
+    vm_write32(user - 12, YZ_HEAP_MAGIC);
+    return user;                          /* guest EA; the flat VM is already backed */
+}
+
+static void yz_heap_free(u32 user)
+{
+    if (!user || user < YZ_HEAP_BASE || user >= YZ_HEAP_END) return;
+    if (vm_read32(user - 12) != YZ_HEAP_MAGIC) return;   /* not one of ours */
+    u32 b   = vm_read32(user - 8);
+    u32 off = vm_read32(user - 4);
+    if (b >= YZ_BINS || off > (1u << b)) return;         /* corrupt header */
+    u32 raw = user - off;
+    { static int dbg = -1;
+      if (dbg < 0) dbg = getenv("SYS_HEAP_DBG") ? 1 : 0;
+      if (dbg) { static int n = 0; if (n++ < 400)
+          fprintf(stderr, "[heap] free  0x%08X (bin %u)%c", user, b, 10); } }
+    vm_write32(user - 12, 0);                            /* poison: catch double free */
+    slot_lock();
+    vm_write32(raw, s_heap_bin[b]);
+    s_heap_bin[b] = raw;
+    slot_unlock();
 }
 
 void* sys_heap_malloc(sys_heap_t heap, u32 size)
@@ -754,7 +824,8 @@ void* sys_heap_malloc(sys_heap_t heap, u32 size)
 
 s32 sys_heap_free(sys_heap_t heap, void* ptr)
 {
-    (void)heap; (void)ptr;   /* bump allocator: no per-alloc free */
+    (void)heap;
+    yz_heap_free((u32)(uintptr_t)ptr);
     return CELL_OK;
 }
 
@@ -762,16 +833,6 @@ void* sys_heap_memalign(sys_heap_t heap, u32 align, u32 size)
 {
     (void)heap;
     return (void*)(uintptr_t)yz_heap_alloc(size, align);
-#if 0
-#ifdef _WIN32
-    return _aligned_malloc(size, align);
-#else
-    void* ptr = NULL;
-    if (posix_memalign(&ptr, align, size) != 0)
-        return NULL;
-    return ptr;
-#endif
-#endif
 }
 
 /* _sys_heap_create_heap (libdbgfont / dinkum ABI): RETURNS a non-zero heap id

--- a/libs/system/sysPrxForUser.c
+++ b/libs/system/sysPrxForUser.c
@@ -784,6 +784,41 @@ u32 sys_heap_create_heap_ret(u32 name, u32 type, u32 blocksize, u32 flags)
     return s_hid++;
 }
 
+/* The names titles actually import. Every one of these existed above under a
+ * name without the leading underscore, so gen_hle_nids.py hashed a NID nothing
+ * imports and the whole family fell through to the unresolved-NID default --
+ * create_heap handed back 0, every allocation off it returned 0, and the title
+ * took its out-of-memory path. Virtua Fighter 5's boot ends in exactly that:
+ * _sys_heap_create_heap unresolved, then _sys_heap_memalign unresolved, then
+ * cellMsgDialogOpen and a permanent wait.
+ *
+ * ponytail: forwarders, not a second implementation. The allocator stays the
+ * one bump allocator above. */
+u32 _sys_heap_create_heap(u32 name, u32 type, u32 blocksize, u32 flags)
+{
+    return sys_heap_create_heap_ret(name, type, blocksize, flags);
+}
+
+s32 _sys_heap_delete_heap(sys_heap_t heap)
+{
+    return sys_heap_destroy_heap(heap);
+}
+
+void* _sys_heap_malloc(sys_heap_t heap, u32 size)
+{
+    return sys_heap_malloc(heap, size);
+}
+
+void* _sys_heap_memalign(sys_heap_t heap, u32 align, u32 size)
+{
+    return sys_heap_memalign(heap, align, size);
+}
+
+s32 _sys_heap_free(sys_heap_t heap, void* ptr)
+{
+    return sys_heap_free(heap, ptr);
+}
+
 /* ---------------------------------------------------------------------------
  * PRX utilities
  * -----------------------------------------------------------------------*/

--- a/libs/system/sysPrxForUser.h
+++ b/libs/system/sysPrxForUser.h
@@ -147,6 +147,14 @@ void* sys_heap_malloc(sys_heap_t heap, u32 size);
 s32 sys_heap_free(sys_heap_t heap, void* ptr);
 void* sys_heap_memalign(sys_heap_t heap, u32 align, u32 size);
 
+/* The underscore-prefixed names titles import; forwarders to the above. */
+u32   sys_heap_create_heap_ret(u32 name, u32 type, u32 blocksize, u32 flags);
+u32   _sys_heap_create_heap(u32 name, u32 type, u32 blocksize, u32 flags);
+s32   _sys_heap_delete_heap(sys_heap_t heap);
+void* _sys_heap_malloc(sys_heap_t heap, u32 size);
+void* _sys_heap_memalign(sys_heap_t heap, u32 align, u32 size);
+s32   _sys_heap_free(sys_heap_t heap, void* ptr);
+
 /* ---------------------------------------------------------------------------
  * PRX utilities
  * -----------------------------------------------------------------------*/

--- a/libs/video/cellGcmSys.c
+++ b/libs/video/cellGcmSys.c
@@ -1795,6 +1795,8 @@ s32 cellGcmSetFlipCommand(u32 bufferId)
                   char tag[48];
                   snprintf(tag, sizeof tag, "flip#%llu", m);
                   ppu_dump_guest_stack(g_active_ctx, tag);
+                  { extern void ppu_dump_bctrl_ring(uint32_t, const char*);
+                    ppu_dump_bctrl_ring((uint32_t)g_active_ctx->thread_id, tag); }
               }
           }
       } }

--- a/libs/video/cellGcmSys.c
+++ b/libs/video/cellGcmSys.c
@@ -676,6 +676,10 @@ unsigned long long ps3_ms_now(void)
 }
 
 static u32 s_sema_offset = 0;   /* NV406E semaphore offset (label window) */
+/* Backlog past which the drain stops honouring one-flip-per-tick and
+ * catches up instead. Sized well above a frame's command list so a
+ * title that keeps up never sees this path. */
+#define GCM_FIFO_CATCHUP_BYTES 0x10000u
 static u32 s_fifo_getoff  = 0;
 static u32 s_fifo_calloff = 0;
 
@@ -1175,6 +1179,7 @@ static void gcm_rsx_process_fifo_unlocked(void)
      * writes its waits spin on) silently never executed. */
     u32 put = vm_read32(GCM_CONTROL_GUEST_ADDR + 0);
 
+    u32 start_off = s_fifo_getoff;
     if (getenv("GCM_DRAINDBG")) {
         static int n = 0;
         if (n++ % 60 == 0)
@@ -1183,7 +1188,33 @@ static void gcm_rsx_process_fifo_unlocked(void)
                    vm_read32(s_gcm_context_ea + 0x8));
     }
 
+
+    /* GCM_FIFO_SNAP=N: dump N snapshots of the raw words at both ends of the
+     * ring -- what `get` is about to decode, and what the title just wrote at
+     * `put`. When get and put drift apart, the two windows say immediately
+     * whether get is grinding through NOPs/garbage or the title is writing
+     * somewhere get can never reach. The [FIFOSTEP] trace only ever fired on a
+     * bad branch, which is exactly the case where the drift is silent. */
+    { static int snap = -1;
+      if (snap < 0) { const char* e = getenv("GCM_FIFO_SNAP"); snap = e ? atoi(e) : 0; }
+      if (snap > 0 && put) {
+          snap--;
+          fprintf(stderr, "[SNAP] get=%08X put=%08X\n", s_fifo_getoff, put);
+          for (int k = 0; k < 16; k++) {
+              u32 gio = s_fifo_getoff + (u32)(k * 4), pio = put + (u32)(k * 4);
+              u32 gea = gcm_io2ea(gio), pea = gcm_io2ea(pio);
+              fprintf(stderr, "[SNAP]  get+%-3d io=%08X w=%08X   put+%-3d io=%08X w=%08X\n",
+                      k * 4, gio, gea ? vm_read32(gea) : 0xDEADDEADu,
+                      k * 4, pio, pea ? vm_read32(pea) : 0xDEADDEADu);
+          }
+          fflush(stderr);
+      } }
+
     int budget = 0x100000;                    /* words per tick cap */
+    /* GCM_DRAINDBG also reports WHY each pass stopped. A drain that ends far
+     * short of `put` every tick is the signature of a FIFO that can never
+     * catch up, and the reason is the whole diagnosis. */
+    const char* why = "caught-up";
     while (s_fifo_getoff != put && budget-- > 0) {
         u32 ea = gcm_io2ea(s_fifo_getoff);
         if (!ea) {
@@ -1204,6 +1235,7 @@ static void gcm_rsx_process_fifo_unlocked(void)
                             s_fifo_getoff, put);
             }
             s_fifo_getoff = put;
+            why = "no-io-mapping";
             break;
         }
         u32 w = vm_read32(ea);
@@ -1222,7 +1254,19 @@ static void gcm_rsx_process_fifo_unlocked(void)
             extern s32 cellGcmSetFlipCommand(u32 bufferId);
             s_fifo_getoff += 4;
             cellGcmSetFlipCommand(w & 0xFFu);
-            break;
+            /* ...unless the FIFO is badly backlogged. One flip per drain is
+             * right while `get` is keeping up with `put`; when it is megabytes
+             * behind it is a deadlock, because the title's ring can only be
+             * reclaimed as `get` advances. VF5 submits ~5x faster than one
+             * flip per drain consumes, so its 4 MB ring fills, its own
+             * buffer-full callback can never free space, and AMGL prints
+             * "Command Buffer Overflow" forever. Past the threshold keep
+             * draining -- the intermediate presents are frames we are too far
+             * behind to show anyway. No-op for a title that is keeping up. */
+            if (put < s_fifo_getoff ||
+                put - s_fifo_getoff < GCM_FIFO_CATCHUP_BYTES)
+                { why = "flip"; break; }
+            continue;
         }
 
         if (type == 1) {                       /* JUMP: 0x20000000 | offset */
@@ -1230,7 +1274,7 @@ static void gcm_rsx_process_fifo_unlocked(void)
               if (_rd) fprintf(stderr, "[JMP] %08X -> %08X (put=%08X)\n",
                                s_fifo_getoff, w & 0x1FFFFFFCu, put); }
             { u32 tgt = w & 0x1FFFFFFCu;
-              if (!gcm_io2ea(tgt)) { gcm_fifo_bad_branch("JUMP", tgt, w); gcm_fifo_dump_around(s_fifo_getoff); gcm_fifo_resync(&s_fifo_getoff, put); break; }
+              if (!gcm_io2ea(tgt)) { gcm_fifo_bad_branch("JUMP", tgt, w); gcm_fifo_dump_around(s_fifo_getoff); gcm_fifo_resync(&s_fifo_getoff, put); why = "bad-jump"; break; }
               /* A JUMP to its own address is the "park the RSX here" idiom:
                * the title leaves it at the write head so the GPU stops if it
                * catches up, and overwrites it when the next segment is
@@ -1245,14 +1289,14 @@ static void gcm_rsx_process_fifo_unlocked(void)
                    * block. Waiting for a patch that will not come freezes the
                    * FIFO for the rest of the run, so follow the write head. */
                   if (put != s_fifo_getoff) { gcm_fifo_resync(&s_fifo_getoff, put); }
-                  break;
+                  why = "park"; break;
               }
               s_fifo_getoff = tgt; }
             continue;
         }
         if ((w & 3) == 2) {                    /* CALL: offset | 2 */
             { u32 tgt = w & 0x1FFFFFFCu;
-              if (!gcm_io2ea(tgt)) { gcm_fifo_bad_branch("CALL", tgt, w); gcm_fifo_resync(&s_fifo_getoff, put); break; }
+              if (!gcm_io2ea(tgt)) { gcm_fifo_bad_branch("CALL", tgt, w); gcm_fifo_resync(&s_fifo_getoff, put); why = "bad-call"; break; }
               s_fifo_calloff = s_fifo_getoff + 4;
               s_fifo_getoff  = tgt; }
             continue;
@@ -1319,7 +1363,7 @@ static void gcm_rsx_process_fifo_unlocked(void)
             if (blk) { sem_blocked = 1; break; }
         }
                 }
-                if (sem_blocked) break;
+                if (sem_blocked) { why = "sema"; break; }
                 s_fifo_getoff += 4 + count * 4;
                 continue;
             }
@@ -1412,6 +1456,38 @@ static void gcm_rsx_process_fifo_unlocked(void)
      * passes while `put` is somewhere else, there is work the walker will
      * never reach: resynchronise to the write head. Same trade as the
      * unmapped-get path -- commands are lost, the FIFO lives. */
+    /* The stuck-detector above only fires when `get` stops MOVING. A walker
+     * going in circles moves plenty -- it just never arrives. Twisted Metal
+     * and flOw both write one ring and their JUMPs lead to `put`; VF5 does
+     * not. AMGL leaves libgcm's default ring at IO 0 parked on its own JUMP
+     * loop and drives the RSX from a second buffer it mapped at IO 0xA00000,
+     * so the walker circulates the default ring forever, `get` never reaches
+     * `put`, the title's ring is never reclaimed, and AMGL prints "Command
+     * Buffer Overflow" until it runs off the end of its own mapping.
+     *
+     * A drain that burns its ENTIRE word budget without arriving is that
+     * signature: no legitimate frame leaves a million words pending, and a
+     * genuine burst clears within a tick or two. Circling does not, so
+     * require several passes in a row before following the write head.
+     *
+     * ponytail: consecutive-budget-burn is a heuristic, not a proof. The real
+     * fix is knowing which buffer the RSX is bound to -- that needs the
+     * SetQueueHandler / context-switch path modelled, not a walker rule. */
+    { static int burned = 0, passes = -1;
+      if (passes < 0) { const char* e = getenv("GCM_FIFO_CIRCLE_PASSES");
+                        passes = e ? atoi(e) : 4; }
+      if (passes && budget <= 0 && s_fifo_getoff != put) {
+          if (++burned >= passes) {
+              static int n = 0;
+              if (n++ < 8)
+                  fprintf(stderr, "[cellGcmSys] FIFO walker circling (get=0x%08X, "
+                          "put=0x%08X, full budget burned x%d) -- following the "
+                          "write head\n", s_fifo_getoff, put, burned);
+              gcm_fifo_resync(&s_fifo_getoff, put);
+              burned = 0;
+          }
+      } else burned = 0; }
+
     { static u32 last = 0xFFFFFFFFu; static int stuck = 0;
       if (s_fifo_getoff == last && s_fifo_getoff != put) {
           if (++stuck >= 8) { gcm_fifo_resync(&s_fifo_getoff, put); stuck = 0; }
@@ -1421,6 +1497,12 @@ static void gcm_rsx_process_fifo_unlocked(void)
      * per tick (gcm_ref_push/gcm_ref_publish_one above) so every SET_REFERENCE
      * value stays observable to equality-waiters. The wrap recycle path polls
      * the drained EA. */
+    if (getenv("GCM_DRAINDBG")) {
+        static int n2 = 0;
+        if (n2++ % 60 == 0)
+            fprintf(stderr, "[DRAINEND] %s: %08X -> %08X (%u bytes), put=%08X\n",
+                    why, start_off, s_fifo_getoff, s_fifo_getoff - start_off, put);
+    }
     g_gcm_fifo_drained_ea = gcm_io2ea(s_fifo_getoff);
     vm_write32(GCM_CONTROL_GUEST_ADDR + 4, s_fifo_getoff);              /* get */
     AcquireSRWLockExclusive(&s_ref_pub_lock);                           /* ref */
@@ -1533,6 +1615,17 @@ int cellGcmOffsetIsDisplay(u32 offset)
 }
 
 /* NID: 0xEAA52F23 */
+/* How many display buffers the title has actually registered. cellResc needs
+ * it to know how far to rotate its flip target; nothing else about the set is
+ * anyone else's business, so this stays a count rather than exposing the array. */
+u32 cellGcm_display_buffer_count(void)
+{
+    u32 n = 0;
+    for (u32 i = 0; i < CELL_GCM_MAX_DISPLAY_BUFFER_NUM; i++)
+        if (s_display_buffer_set[i]) n++;
+    return n;
+}
+
 s32 cellGcmSetFlipCommand(u32 bufferId)
 {
     { static int _n=0; if (getenv("FLIP_DBG") && _n++ < 20)

--- a/libs/video/cellGcmSys.c
+++ b/libs/video/cellGcmSys.c
@@ -2611,6 +2611,24 @@ void cellGcmSetDefaultCommandBuffer(void)
     s_control.put = 0;
     s_control.get = 0;
     s_control.ref = 0;
+
+    /* On hardware this re-points gCellGcmCurrentContext at the default context
+     * cellGcmInit built. Zeroing a host-side struct is not that: a title that
+     * calls it to go back to the big default buffer stays on whatever smaller
+     * segment it had switched to.
+     *
+     * GCM_DEFAULT_CTX_REPOINT=1 does the real thing -- write our context's EA
+     * into the guest variable cellGcmInit's ctx_out pointed at, and rewind that
+     * context. Off by default because a title managing its own segment chain
+     * may hold pointers into the old one; this exists to be measured, not
+     * assumed. */
+    if (getenv("GCM_DEFAULT_CTX_REPOINT") && s_gcm_ctx_out_ea && s_gcm_context_ea) {
+        vm_write32(s_gcm_context_ea + 0x8, vm_read32(s_gcm_context_ea + 0x0));
+        vm_write32(s_gcm_ctx_out_ea, s_gcm_context_ea);
+        printf("[cellGcmSys] SetDefaultCommandBuffer: repointed "
+               "gCellGcmCurrentContext@0x%08X -> 0x%08X\n",
+               s_gcm_ctx_out_ea, s_gcm_context_ea);
+    }
 }
 
 /* Debug dump — no-op in recomp */

--- a/libs/video/cellGcmSys.c
+++ b/libs/video/cellGcmSys.c
@@ -1295,6 +1295,17 @@ static void gcm_rsx_process_fifo_unlocked(void)
              * frame split across 4 presents, layout flashing/zooming). */
             extern s32 cellGcmSetFlipCommand(u32 bufferId);
             s_fifo_getoff += 4;
+            /* Count the flip WORDS the title actually writes into the FIFO,
+             * separately from the presents that result. When a title stops
+             * appearing on screen the first question is which side stopped:
+             * this counter still climbing while presents do not is a runtime
+             * problem, both stopping together is the guest's. */
+            { static unsigned long long flips = 0; static int dbg = -1;
+              if (dbg < 0) dbg = getenv("GCM_FLIPCOUNT") ? 1 : 0;
+              ++flips;
+              if (dbg && (flips <= 8ull || (flips % 200ull) == 0))
+                  fprintf(stderr, "[flipword] %llu FIFO flip words decoded%c",
+                          flips, 10); }
             cellGcmSetFlipCommand(w & 0xFFu);
             /* ...unless the FIFO is badly backlogged. One flip per drain is
              * right while `get` is keeping up with `put`; when it is megabytes
@@ -1749,6 +1760,24 @@ u32 cellGcm_display_buffer_count(void)
 
 s32 cellGcmSetFlipCommand(u32 bufferId)
 {
+    /* GCM_FLIPCOUNT=1: every flip, with a timestamp. FLIP_DBG caps at 20 lines,
+     * which answers "did it ever flip?" and not "is it still flipping, and how
+     * fast?" -- the question that matters when a title stops appearing on
+     * screen. Virtua Fighter 5 does not use the in-FIFO 0xFEADxxxx flip word at
+     * all (that counter stays at zero for the whole run); it flips through
+     * cellGcmSetFlip, so this is where its frame rate actually is. */
+    { static int dbg = -1;
+      if (dbg < 0) dbg = getenv("GCM_FLIPCOUNT") ? 1 : 0;
+      if (dbg) {
+          extern unsigned long long ps3_ms_now(void);
+          static unsigned long long n = 0, t0 = 0;
+          unsigned long long now = ps3_ms_now();
+          if (!t0) t0 = now;
+          ++n;
+          if (n <= 400ull || (n % 100ull) == 0)
+              fprintf(stderr, "[flip] %llu at %llu ms%c", n, now - t0, 10);
+      } }
+
     { static int _n=0; if (getenv("FLIP_DBG") && _n++ < 20)
         fprintf(stderr, "[FLIP] SetFlipCommand(buf=%u) set=%d\n",
                 bufferId, bufferId < CELL_GCM_MAX_DISPLAY_BUFFER_NUM ? s_display_buffer_set[bufferId] : -1); }

--- a/libs/video/cellGcmSys.c
+++ b/libs/video/cellGcmSys.c
@@ -521,6 +521,9 @@ void cellGcmSetWaitFlip(void)
 /* NID: 0x51C9D62B */
 void cellGcmResetFlipStatus(void)
 {
+    { static int n = 0;
+      if (getenv("FLIP_DBG") && n++ < 12)
+          fprintf(stderr, "[FLIP] ResetFlipStatus%c", 10); }
     s_flip_status = CELL_GCM_FLIP_STATUS_WAITING;
 }
 
@@ -534,6 +537,10 @@ u32 cellGcmGetFlipStatus(void)
      * beat) completes pending flips. The old self-completing version made
      * every wait-for-flip loop exit on its first poll, so titles ran
      * completely unpaced (wave: 95 fps with a fixed-dt simulation). */
+    { static int n = 0;
+      if (getenv("FLIP_DBG") && n++ < 24)
+          fprintf(stderr, "[FLIP] GetFlipStatus -> %u (0=DONE 1=WAITING)%c",
+                  s_flip_status, 10); }
     return s_flip_status;
 }
 
@@ -1504,7 +1511,16 @@ static void gcm_rsx_process_fifo_unlocked(void)
                     why, start_off, s_fifo_getoff, s_fifo_getoff - start_off, put);
     }
     g_gcm_fifo_drained_ea = gcm_io2ea(s_fifo_getoff);
-    vm_write32(GCM_CONTROL_GUEST_ADDR + 4, s_fifo_getoff);              /* get */
+    /* GCM_GET_EQ_PUT=1: publish `get` as having reached `put` rather than where
+     * the walker actually is. A probe, not a fix -- it removes the back-pressure
+     * a title uses to avoid overwriting commands the GPU has not read. It exists
+     * to answer one question for a title that reports its ring full while the
+     * walker says it is drained: is the title reading `get`, or something else?
+     * If the overflow survives this, `get` is not what it consults. */
+    { static int eq = -1;
+      if (eq < 0) { const char* e = getenv("GCM_GET_EQ_PUT"); eq = e ? atoi(e) : 0; }
+      vm_write32(GCM_CONTROL_GUEST_ADDR + 4, eq ? put : s_fifo_getoff); }
+
     AcquireSRWLockExclusive(&s_ref_pub_lock);                           /* ref */
     gcm_ref_publish_one();
     ReleaseSRWLockExclusive(&s_ref_pub_lock);

--- a/libs/video/cellGcmSys.c
+++ b/libs/video/cellGcmSys.c
@@ -1774,8 +1774,29 @@ s32 cellGcmSetFlipCommand(u32 bufferId)
           unsigned long long now = ps3_ms_now();
           if (!t0) t0 = now;
           ++n;
-          if (n <= 400ull || (n % 100ull) == 0)
+          if (n <= 400ull || (n % 10ull) == 0)
               fprintf(stderr, "[flip] %llu at %llu ms%c", n, now - t0, 10);
+      } }
+
+    /* GCM_FLIP_BT=<n>: dump the flipping thread's guest stack for the flips
+     * around n. When a title renders correctly for a while and then stops
+     * submitting -- no error, no unresolved import, no overflow -- the only
+     * thing separating the last good frame from the first missing one is what
+     * the render path was doing on each. This is the window onto that. */
+    { static long long at = -2;
+      if (at == -2) { const char* e = getenv("GCM_FLIP_BT"); at = e ? atoll(e) : -1; }
+      if (at >= 0) {
+          static unsigned long long m = 0;
+          ++m;
+          if ((long long)m >= at - 5 && (long long)m <= at + 5) {
+              extern PPU_THREAD_LOCAL ppu_context* g_active_ctx;
+              extern void ppu_dump_guest_stack(ppu_context*, const char*);
+              if (g_active_ctx) {
+                  char tag[48];
+                  snprintf(tag, sizeof tag, "flip#%llu", m);
+                  ppu_dump_guest_stack(g_active_ctx, tag);
+              }
+          }
       } }
 
     { static int _n=0; if (getenv("FLIP_DBG") && _n++ < 20)

--- a/libs/video/cellGcmSys.c
+++ b/libs/video/cellGcmSys.c
@@ -1585,6 +1585,17 @@ static void gcm_rsx_process_fifo_unlocked(void)
             (s_fifo_getoff == put ||
              (s_fifo_getoff > io_begin_chk &&
               s_fifo_getoff - io_begin_chk >= GCM_RECYCLE_MARGIN));
+        /* Already overrun. gcmReserve writes past `end` when its callback
+         * declines to recycle (AMGL's only prints), and once the guest is out
+         * there the walker follows into memory that is not the ring: `get`
+         * stops advancing, head_consumed can never become true again, and the
+         * title is wedged for good -- which is exactly where Virtua Fighter 5
+         * stops, at the same flip every run however long it is left.
+         *
+         * There is nothing left to protect at that point. Recycling loses
+         * whatever was written past the end; not recycling loses the rest of
+         * the run. */
+        if (begin && end > begin && cur >= end) head_consumed = 1;
         if (begin && end > begin && cur >= begin && cur + GCM_RECYCLE_SLACK >= end
                 && head_consumed) {
             u32 io_begin = gcm_ea2io(begin);

--- a/libs/video/cellGcmSys.c
+++ b/libs/video/cellGcmSys.c
@@ -246,6 +246,12 @@ static u32 s_labels[CELL_GCM_MAX_LABEL_COUNT];
  * just-written commands are lost). Updated in cellGcm_rsx_process_fifo. */
 volatile u32 g_gcm_fifo_drained_ea = 0;
 
+/* The guest variable cellGcmInit's ctx_out pointed at -- the title's own
+ * gCellGcmCurrentContext. A title that switches to a command buffer of its own
+ * does it by repointing this, and until something reads it back the runtime has
+ * no way to notice. GCM_CTXDBG=1 reports it. */
+static u32 s_gcm_ctx_out_ea = 0;
+
 /* ---------------------------------------------------------------------------
  * Internal helpers
  * -----------------------------------------------------------------------*/
@@ -449,6 +455,7 @@ u32 cellGcmSetupContext(u32 ctx_out_addr, u32 cmdSize, u32 ioSize, u32 ioAddress
         }
         if (ctx_out_addr)
             gwrite32(ctx_out_addr, cdata);          /* *context = &ctxdata */
+        s_gcm_ctx_out_ea = ctx_out_addr;   /* the title's gCellGcmCurrentContext */
         s_gcm_context_ea = cdata;                   /* RSX drains commands from here */
     }
     return cdata;
@@ -687,6 +694,11 @@ static u32 s_sema_offset = 0;   /* NV406E semaphore offset (label window) */
  * catches up instead. Sized well above a frame's command list so a
  * title that keeps up never sees this path. */
 #define GCM_FIFO_CATCHUP_BYTES 0x10000u
+/* How close `current` must get to `end` before the runtime will recycle a ring
+ * on the title's behalf. One gcmReserve is 8 bytes; a page of slack keeps a
+ * title that is merely near the end from being touched. */
+#define GCM_RECYCLE_SLACK 0x1000u
+static u32 gcm_ea2io(u32 ea);   /* defined with the wrap callback below */
 static u32 s_fifo_getoff  = 0;
 static u32 s_fifo_calloff = 0;
 
@@ -1186,6 +1198,25 @@ static void gcm_rsx_process_fifo_unlocked(void)
      * writes its waits spin on) silently never executed. */
     u32 put = vm_read32(GCM_CONTROL_GUEST_ADDR + 0);
 
+    /* GCM_CTXDBG=1: which context the title is actually driving. Ours is written
+     * once at init; if the title repoints gCellGcmCurrentContext at a buffer of
+     * its own, every field below moves with it and the FIFO the runtime walks
+     * stops being the one the title fills. Reported on change, not per tick. */
+    if (getenv("GCM_CTXDBG") && s_gcm_ctx_out_ea) {
+        static u32 last_ptr = 0xFFFFFFFFu, last_cur = 0xFFFFFFFFu;
+        u32 ptr = vm_read32(s_gcm_ctx_out_ea);
+        u32 cur = ptr ? vm_read32(ptr + 0x8) : 0;
+        if (ptr != last_ptr || cur != last_cur) {
+            last_ptr = ptr; last_cur = cur;
+            fprintf(stderr, "[CTX] gCellGcmCurrentContext@0x%08X -> 0x%08X  "
+                    "begin=%08X end=%08X current=%08X callback=%08X  (ours=0x%08X)\n",
+                    s_gcm_ctx_out_ea, ptr,
+                    ptr ? vm_read32(ptr + 0x0) : 0, ptr ? vm_read32(ptr + 0x4) : 0,
+                    cur, ptr ? vm_read32(ptr + 0xC) : 0, s_gcm_context_ea);
+            fflush(stderr);
+        }
+    }
+
     u32 start_off = s_fifo_getoff;
     if (getenv("GCM_DRAINDBG")) {
         static int n = 0;
@@ -1510,6 +1541,48 @@ static void gcm_rsx_process_fifo_unlocked(void)
             fprintf(stderr, "[DRAINEND] %s: %08X -> %08X (%u bytes), put=%08X\n",
                     why, start_off, s_fifo_getoff, s_fifo_getoff - start_off, put);
     }
+    /* Recycle the TITLE'S OWN command buffer when its callback will not.
+     *
+     * gCellGcmCurrentContext points at the title's context, not the one
+     * cellGcmInit handed back: Virtua Fighter 5's is a 512 KB ring at EA
+     * 0x4AE00000, and the buffer-full callback AMGL installs (0x006A8030) only
+     * prints "[AMGL]:[ERROR] Command Buffer Overflow!" and returns 0 -- which
+     * libgcm's gcmReserve reads as "retry", so the title writes straight past
+     * `end` into unmapped memory and never renders again.
+     *
+     * Hardware never reaches that state because the ring is recycled once the
+     * RSX has consumed it. Do the same here, on the title's context, and only
+     * when it is provably safe: the walker has drained everything the title
+     * submitted (get == put) and `current` is within one reserve of `end`.
+     * A title whose own callback recycles never reaches that state, so this is
+     * inert for every port that works today.
+     *
+     * ponytail: append the JUMP at `current` the way the SDK's own callback
+     * does, rather than tracking a second copy of the ring's geometry. */
+    if (s_gcm_ctx_out_ea) {
+        u32 ctx = vm_read32(s_gcm_ctx_out_ea);
+        u32 begin = ctx ? vm_read32(ctx + 0x0) : 0;
+        u32 end   = ctx ? vm_read32(ctx + 0x4) : 0;
+        u32 cur   = ctx ? vm_read32(ctx + 0x8) : 0;
+        if (begin && end > begin && cur >= begin && cur + GCM_RECYCLE_SLACK >= end
+                && s_fifo_getoff == put) {
+            u32 io_begin = gcm_ea2io(begin);
+            if (io_begin != 0xFFFFFFFFu) {
+                u32 jmp_at = (cur + 4 <= end) ? cur : end - 4;
+                vm_write32(jmp_at, 0x20000000u | io_begin);   /* JUMP -> begin */
+                vm_write32(ctx + 0x8, begin);                 /* current = begin */
+                vm_write32(GCM_CONTROL_GUEST_ADDR + 0, io_begin);  /* put */
+                s_fifo_getoff = io_begin;                          /* get */
+                put = io_begin;
+                static int n = 0;
+                if (n++ < 8)
+                    fprintf(stderr, "[cellGcmSys] recycled the title's own ring "
+                            "(ctx=0x%08X begin=0x%08X end=0x%08X) -- its callback "
+                            "does not%c", ctx, begin, end, 10);
+            }
+        }
+    }
+
     g_gcm_fifo_drained_ea = gcm_io2ea(s_fifo_getoff);
     /* GCM_GET_EQ_PUT=1: publish `get` as having reached `put` rather than where
      * the walker actually is. A probe, not a fix -- it removes the back-pressure

--- a/libs/video/cellGcmSys.c
+++ b/libs/video/cellGcmSys.c
@@ -698,6 +698,10 @@ static u32 s_sema_offset = 0;   /* NV406E semaphore offset (label window) */
  * on the title's behalf. One gcmReserve is 8 bytes; a page of slack keeps a
  * title that is merely near the end from being touched. */
 #define GCM_RECYCLE_SLACK 0x1000u
+/* How far past the ring's start the walker must have read before the runtime
+ * will recycle on the title's behalf. The guest resumes writing at `begin`, so
+ * this is the amount of already-consumed head room it gets. */
+#define GCM_RECYCLE_MARGIN 0x20000u
 static u32 gcm_ea2io(u32 ea);   /* defined with the wrap callback below */
 static u32 s_fifo_getoff  = 0;
 static u32 s_fifo_calloff = 0;
@@ -1564,8 +1568,25 @@ static void gcm_rsx_process_fifo_unlocked(void)
         u32 begin = ctx ? vm_read32(ctx + 0x0) : 0;
         u32 end   = ctx ? vm_read32(ctx + 0x4) : 0;
         u32 cur   = ctx ? vm_read32(ctx + 0x8) : 0;
+        /* `get == put` -- a fully drained FIFO -- was too strict. It holds
+         * while a title is only clearing, and stops holding the moment its SPU
+         * work starts producing real command volume: the walker then always has
+         * a backlog, the recycle never fires, and the ring overflows again.
+         * That is exactly where Virtua Fighter 5 stalls once its "SPU Delegate"
+         * group starts feeding the renderer.
+         *
+         * Hardware does not need a drained FIFO either -- only that the bytes
+         * about to be overwritten have already been read. So require the walker
+         * to be a margin PAST `begin` instead: the head of the ring is consumed,
+         * which is the region the guest is about to write. */
+        u32 io_begin_chk = begin ? gcm_ea2io(begin) : 0xFFFFFFFFu;
+        int head_consumed =
+            (io_begin_chk != 0xFFFFFFFFu) &&
+            (s_fifo_getoff == put ||
+             (s_fifo_getoff > io_begin_chk &&
+              s_fifo_getoff - io_begin_chk >= GCM_RECYCLE_MARGIN));
         if (begin && end > begin && cur >= begin && cur + GCM_RECYCLE_SLACK >= end
-                && s_fifo_getoff == put) {
+                && head_consumed) {
             u32 io_begin = gcm_ea2io(begin);
             if (io_begin != 0xFFFFFFFFu) {
                 u32 jmp_at = (cur + 4 <= end) ? cur : end - 4;

--- a/libs/video/cellResc.c
+++ b/libs/video/cellResc.c
@@ -8,6 +8,7 @@
 
 #include "cellResc.h"
 #include "../../runtime/ppu/ppu_memory.h"   /* GUEST_PTR, vm_write*: translate + byte-swap */
+#include "ps3emu/guest_call.h"   /* ps3_invoke_guest: handlers are guest OPDs */
 #include <stdio.h>
 #include <string.h>
 
@@ -20,8 +21,13 @@ static CellRescInitConfig s_config;
 static u32 s_display_mode = CELL_RESC_1280x720;
 static CellRescSrc s_src[8]; /* up to 8 color buffers */
 static CellRescDsts s_dsts[4]; /* one per display mode */
-static void (*s_flip_handler)(u32) = NULL;
-static void (*s_vblank_handler)(u32) = NULL;
+/* Guest OPD addresses, not host function pointers: what a title passes is a
+ * guest function descriptor, and calling it as a host pointer is a crash
+ * waiting for the first title that sets one. Invoked through ps3_invoke_guest,
+ * the same way cellGcmSetFlipHandler's is. */
+static u32 s_flip_handler_opd = 0;
+static u32 s_vblank_handler_opd = 0;
+static u32 s_flip_target = 0;   /* display buffer the next convert-and-flip presents */
 static s32 s_flip_status = 0;
 static u64 s_last_flip_time = 0;
 static float s_aspect_h = 1.0f;
@@ -45,8 +51,9 @@ s32 cellRescInit(const CellRescInitConfig* initConfig)
     s_config = *GUEST_PTR(initConfig, const CellRescInitConfig*);
     memset(s_src, 0, sizeof(s_src));
     memset(s_dsts, 0, sizeof(s_dsts));
-    s_flip_handler = NULL;
-    s_vblank_handler = NULL;
+    s_flip_handler_opd = 0;
+    s_vblank_handler_opd = 0;
+    s_flip_target = 0;
     s_flip_status = 0;
     s_last_flip_time = 0;
     s_aspect_h = 1.0f;
@@ -160,32 +167,55 @@ s32 cellRescSetDsts(u32 displayMode, const CellRescDsts* dsts)
 
 s32 cellRescSetConvertAndFlip(s32 index)
 {
-    (void)index;
-
     if (!s_initialized)
         return (s32)CELL_RESC_ERROR_NOT_INITIALIZED;
 
-    /* In recomp, the host GPU handles display -- we just track the flip */
-    s_flip_status = 0; /* flip complete */
-    s_last_flip_time++; /* monotonic counter, actual time comes from host */
+    /* This is a real flip, not bookkeeping. A title that presents through RESC
+     * -- Virtua Fighter 5 does -- renders into an off-screen surface and asks
+     * RESC to scale it into a display buffer and show it. Tracking a counter
+     * here and returning CELL_OK meant no flip ever reached cellGcm, so the
+     * title's frame loop never closed: nothing retired, and it kept appending
+     * to a command buffer it could never reclaim.
+     *
+     * ponytail: the convert half is deliberately not emitted -- the backend
+     * already presents at the output resolution, so RESC's scale is a no-op for
+     * us. What must happen is the flip. Rotate through the display buffers the
+     * title registered, the way RESC's own double/triple buffering does. Emit a
+     * real conversion draw if a title ever needs RESC's PAL/interlace modes
+     * rather than a plain scale. */
+    extern s32 cellGcmSetFlipCommand(u32 bufferId);
+    extern u32 cellGcm_display_buffer_count(void);
+    u32 nbuf = cellGcm_display_buffer_count();
+    if (nbuf) {
+        cellGcmSetFlipCommand(s_flip_target % nbuf);
+        s_flip_target = (u32)((s_flip_target + 1) % nbuf);
+    }
 
-    if (s_flip_handler)
-        s_flip_handler(1);
+    s_flip_status = 0;      /* flip complete */
+    s_last_flip_time++;
+
+    { static int n = 0;
+      if (n++ < 4)
+          printf("[cellResc] SetConvertAndFlip(src=%d) -> flip, %u display buffer(s)\n",
+                 index, nbuf); }
+
+    if (s_flip_handler_opd)
+        ps3_invoke_guest(s_flip_handler_opd, 1, 0, 0, 0, 0, 0, 0, 0);
 
     return CELL_OK;
 }
 
 s32 cellRescSetFlipHandler(void (*handler)(u32))
 {
-    printf("[cellResc] SetFlipHandler(%p)\n", (void*)(uintptr_t)handler);
-    s_flip_handler = handler;
+    s_flip_handler_opd = (u32)(uintptr_t)handler;
+    printf("[cellResc] SetFlipHandler(opd=0x%08X)\n", s_flip_handler_opd);
     return CELL_OK;
 }
 
 s32 cellRescSetVBlankHandler(void (*handler)(u32))
 {
-    printf("[cellResc] SetVBlankHandler(%p)\n", (void*)(uintptr_t)handler);
-    s_vblank_handler = handler;
+    s_vblank_handler_opd = (u32)(uintptr_t)handler;
+    printf("[cellResc] SetVBlankHandler(opd=0x%08X)\n", s_vblank_handler_opd);
     return CELL_OK;
 }
 
@@ -219,10 +249,10 @@ s32 cellRescGetFlipStatus(void)
     if (s_flip_status == 1) {
         s_flip_status = 0;
         s_last_flip_time++;
-        if (s_flip_handler)
-            s_flip_handler(1);
-        if (s_vblank_handler)
-            s_vblank_handler(1);
+        if (s_flip_handler_opd)
+            ps3_invoke_guest(s_flip_handler_opd, 1, 0, 0, 0, 0, 0, 0, 0);
+        if (s_vblank_handler_opd)
+            ps3_invoke_guest(s_vblank_handler_opd, 1, 0, 0, 0, 0, 0, 0, 0);
     }
     return s_flip_status;
 }

--- a/libs/video/rsx_live_draw.c
+++ b/libs/video/rsx_live_draw.c
@@ -8066,7 +8066,12 @@ void rsx_live_draw_present(u32 buffer_id)
                   fps_f0, g_ld_frames, (now - fps_t0) / 1000.0);
           fps_t0 = now; fps_f0 = g_ld_frames;
       } }
-    if (LD_DIAG_ENABLED("YZ_RSX_DUMP") && g_ld_frames <= 8) {
+    /* YZ_RSX_DUMP_EVERY=N: also dump every Nth frame, not just the first 8 --
+     * a title whose content starts after the boot clears is invisible otherwise. */
+    static int ld_dump_every = -1;
+    if (ld_dump_every < 0) { const char* e = getenv("YZ_RSX_DUMP_EVERY"); ld_dump_every = e ? atoi(e) : 0; }
+    if (LD_DIAG_ENABLED("YZ_RSX_DUMP") &&
+        (g_ld_frames <= 8 || (ld_dump_every > 0 && (g_ld_frames % (u32)ld_dump_every) == 0))) {
         /* Dump the presented color surface (RENDER_TARGET state -> safe). */
         const u32 cur = current_surface();
         if (cur != LD_INVALID_SURFACE) {

--- a/libs/video/rsx_live_draw.c
+++ b/libs/video/rsx_live_draw.c
@@ -3642,25 +3642,61 @@ static int ld_current_vertex_layout(rsx_vertex_layout_plan* layout)
     return vp_instrs != 0;
 }
 
+/* LD_PSO_DBG=1: name the first bail-out of each kind in get_pso(). Every exit
+ * there returns NULL silently and the caller only counts drop{pso=N}, so a
+ * title whose draws ALL die in this function has no way to say which gate
+ * rejected them. One line per distinct reason, so a stuck title prints a
+ * handful of lines rather than one per draw. */
+static void ld_pso_bail(int* said, const char* reason)
+{
+    static int dbg = -1;
+    if (dbg < 0) dbg = getenv("LD_PSO_DBG") ? 1 : 0;
+    if (!dbg || *said) return;
+    *said = 1;
+    fprintf(stderr, "[pso-bail] %s\n", reason);
+    fflush(stderr);
+}
+#define LD_PSO_BAIL(reason) \
+    do { static int _said_ = 0; ld_pso_bail(&_said_, (reason)); } while (0)
+
 static ID3D12PipelineState* get_pso(
     const rsx_vertex_layout_plan* masked_layout, int packed_payload)
 {
     memset(&g_ld_current_pso, 0, sizeof(g_ld_current_pso));
     const u32 start = rsx_dsp_vp_start(&g.rsx);
-    if (start >= RSX_DSP_VP_INSTR) return NULL;
+    if (start >= RSX_DSP_VP_INSTR) { LD_PSO_BAIL("no vertex program uploaded (vp start out of range)"); return NULL; }
     const u8* vp_uc = (const u8*)(g.rsx.vp + start * 4);
     const u32 vp_instrs = rsx_vp_program_size_instrs(vp_uc, (RSX_DSP_VP_INSTR - start) * 16);
-    if (!vp_instrs) return NULL;
+    if (!vp_instrs) { LD_PSO_BAIL("vertex program has zero instructions"); return NULL; }
 
     u32 fp_loc = 0;
     const u32 fp_off = rsx_dsp_fragment_program(&g.rsx, &fp_loc);
     const u8* fp_uc = guest_ptr(fp_loc, fp_off, 16);
-    if (!fp_uc) return NULL;
+    if (!fp_uc) { LD_PSO_BAIL("fragment program address does not resolve to guest memory"); return NULL; }
     const u32 fp_size = rsx_fp_program_size(fp_uc, 0x10000);
-    if (!fp_size) return NULL;
+    if (!fp_size) {
+        /* No END-bit instruction in 64 KB: the bytes at (location, offset) are
+         * not a fragment program. Almost always the LOCATION is wrong, not the
+         * offset -- the same class of bug caner hit in Yakuza with textures --
+         * so report the register the guest actually wrote and the head of what
+         * we read, which is what says local-vs-main. */
+        static int said = 0;
+        if (!said && getenv("LD_PSO_DBG")) {
+            said = 1;
+            fprintf(stderr,
+                    "[pso-bail] fragment program size reads as zero: "
+                    "reg=0x%08X -> loc=%u off=0x%08X, first words "
+                    "%08X %08X %08X %08X\n",
+                    rsx_dsp_reg(&g.rsx, 0x08E4 /* M_FP_ACTIVE_PROGRAM */), fp_loc, fp_off,
+                    rsx_fp_read_word(fp_uc + 0), rsx_fp_read_word(fp_uc + 4),
+                    rsx_fp_read_word(fp_uc + 8), rsx_fp_read_word(fp_uc + 12));
+            fflush(stderr);
+        }
+        return NULL;
+    }
     /* re-resolve with the true size to validate the whole program is mapped */
     fp_uc = guest_ptr(fp_loc, fp_off, fp_size);
-    if (!fp_uc) return NULL;
+    if (!fp_uc) { LD_PSO_BAIL("fragment program is not fully mapped in guest memory"); return NULL; }
 
     /* Fragment output register mode (fp16 h0 vs fp32 r0) is driven by the
      * SHADER_CONTROL word bit 0x40 (same fix as the replay harness — the
@@ -3708,8 +3744,10 @@ static ID3D12PipelineState* get_pso(
     render_state_t rs;
     decode_render_state(&rs);
     if (rsx_fp_collect_constants(
-            fp_uc, fp_size, &g.fp_constants) < 0)
+            fp_uc, fp_size, &g.fp_constants) < 0) {
+        LD_PSO_BAIL("fragment program constant collection failed");
         return NULL;
+    }
     g.fp_alpha_ref = rsx_fp_alpha_ref(
         rs.alpha_ref_raw, rs.alpha_ref_format);
 
@@ -3719,8 +3757,10 @@ static ID3D12PipelineState* get_pso(
         key = rsx_fp_structural_hash(fp_uc, fp_size, key);
     else
         key = fnv1a(fp_uc, fp_size, key);
-    if (!key)
+    if (!key) {
+        LD_PSO_BAIL("shader hash collapsed to zero");
         return NULL;
+    }
     const u32 fp_ctrl_key = fp_ctrl & 0x40u;
     key = fnv1a(&fp_ctrl_key, sizeof(fp_ctrl_key), key);
     key = fnv1a(&cube_mask, sizeof(cube_mask), key);
@@ -3788,6 +3828,7 @@ static ID3D12PipelineState* get_pso(
 #if defined(YZ_PERF_PROFILE)
         g_ld_profile.total.pso_full++;
 #endif
+        LD_PSO_BAIL("PSO cache full (MAX_PSOS)");
         return NULL;
     }
 

--- a/libs/video/rsx_live_draw.c
+++ b/libs/video/rsx_live_draw.c
@@ -1773,6 +1773,12 @@ static void decode_texel(u32 base_fmt, const u8* p, u32 remap, u8 d[4])
 {
     u8 s[4];
     switch (base_fmt) {
+    /* B8 is one channel. Broadcasting it to alpha as well is arguably more
+     * faithful (the YUV movie combine shader samples each plane's .w), but
+     * DO NOT do it until the USM decode actually fills those planes: while
+     * they are empty it only makes the garbage VISIBLE, putting green noise
+     * behind the title screen and every other movie-backed UI. Tried
+     * 2026-09-01, reverted the same session. See ydkj-live-draw-rebuild. */
     case TEX_FMT_B8: s[0] = 255; s[1] = s[2] = s[3] = p[0]; break;
     case TEX_FMT_A4R4G4B4: {
         const u16 v = (u16)((p[0] << 8) | p[1]);
@@ -2175,6 +2181,25 @@ static ID3D12Resource* decode_guest_texture(const rsx_dsp_texture* t, u32 remap)
         if (!rgba[n]) { oom = 1; break; }
         const u32 lw = log2_u32(mw), lh = log2_u32(mh);
         const u8* level_src = src + off;
+        /* LD_PLANE_DUMP=1: write the first few big single-channel (B8) planes
+         * straight out as PGM, exactly as the guest laid them down. Settles
+         * "is the video decode producing an image?" without guessing from the
+         * composited frame. ponytail: one-shot debug, costs nothing when off. */
+        { static int pd = -1; static int pdn = 0;
+          if (pd < 0) { const char* e = getenv("LD_PLANE_DUMP"); pd = e ? atoi(e) : 0; }
+          if (pd && (int)g_ld_frames >= pd && m == 0 && base_fmt == TEX_FMT_B8 && mw >= 320 && pdn < 6) {
+              char fn[128];
+              snprintf(fn, sizeof fn, "scratch/plane_%02d_%ux%u_p%u.pgm", pdn, mw, mh, pitch);
+              FILE* pf = fopen(fn, "wb");
+              if (pf) {
+                  fprintf(pf, "P5\n%u %u\n255\n", mw, mh);
+                  for (u32 yy = 0; yy < mh; yy++)
+                      fwrite(level_src + (size_t)yy * pitch, 1, mw, pf);
+                  fclose(pf);
+                  fprintf(stderr, "[plane-dump] %s linear=%d\n", fn, linear);
+              }
+              pdn++;
+          } }
         for (u32 y = 0; y < mh; y++)
             for (u32 x = 0; x < mw; x++) {
                 const u8* pixel = linear
@@ -2292,6 +2317,28 @@ static u32 texture_srv_slot(const rsx_dsp_texture* t)
             entry->last_hash_frame != g_ld_frames) {
             int readable = 0;
             const u64 hash = texture_content_hash(t, &readable);
+            /* LD_TEX_RACE=1: hash the SAME source twice, back to back. The two
+             * reads are microseconds apart, so they can only disagree if a
+             * guest thread is writing this texture right now -- i.e. we are
+             * decoding a half-written image. Pure observation; it changes
+             * nothing. Counts per source so one torn texture is attributable. */
+            { static int race = -1;
+              if (race < 0) race = getenv("LD_TEX_RACE") ? 1 : 0;
+              if (race && readable) {
+                  int r2 = 0;
+                  const u64 again = texture_content_hash(t, &r2);
+                  static unsigned long long checks = 0, torn = 0;
+                  checks++;
+                  if (r2 && again != hash) torn++;
+                  if ((checks % 256) == 0)
+                      fprintf(stderr,
+                              "[tex-race] src=%u:0x%08X %ux%u  torn %llu/%llu reads"
+                              " (%.1f%%)\n",
+                              t->location, t->offset, t->width, t->height,
+                              (unsigned long long)torn,
+                              (unsigned long long)checks,
+                              100.0 * (double)torn / (double)checks);
+              } }
             entry->last_hash_frame = g_ld_frames;
             if (readable && hash != entry->content_hash) {
                 ID3D12Resource* replacement =
@@ -3690,6 +3737,25 @@ static ID3D12PipelineState* get_pso(
                     rsx_dsp_reg(&g.rsx, 0x08E4 /* M_FP_ACTIVE_PROGRAM */), fp_loc, fp_off,
                     rsx_fp_read_word(fp_uc + 0), rsx_fp_read_word(fp_uc + 4),
                     rsx_fp_read_word(fp_uc + 8), rsx_fp_read_word(fp_uc + 12));
+            /* All-zero here has two very different causes: the offset resolved
+             * into the wrong memory, or nothing ever wrote the buffer. Scan
+             * forward for the first non-zero byte -- a hit a few hundred bytes
+             * on means the region IS populated and the offset is wrong; no hit
+             * across 64 KB means the producer never ran. */
+            {
+                const u8* q = guest_ptr(fp_loc, fp_off, 0x10000);
+                u32 i = 0;
+                if (q) { while (i < 0x10000u && !q[i]) i++; }
+                if (!q)
+                    fprintf(stderr, "[pso-bail]   (64 KB window not mapped)\n");
+                else if (i == 0x10000u)
+                    fprintf(stderr, "[pso-bail]   64 KB from here is entirely "
+                                    "zero -- nothing ever wrote this buffer\n");
+                else
+                    fprintf(stderr, "[pso-bail]   first non-zero byte at "
+                                    "+0x%X -- the region is populated, the "
+                                    "offset is wrong\n", i);
+            }
             fflush(stderr);
         }
         return NULL;
@@ -7595,6 +7661,34 @@ static void ld_vertex_diag_emit(const char* reason, int dump_surface)
 void rsx_live_draw_present(u32 buffer_id)
 {
     if (!g.ready) return;
+
+    /* LD_FRAME_DUMP=<dir> [+ LD_FRAME_DUMP_EVERY=<n>, default 300]: write the
+     * PRESENTED surface to a .ppm every n flips. The engine could already dump
+     * a surface, but only at shutdown or behind the parity harness -- neither
+     * reachable when a title is simply left running, which is exactly when you
+     * want to see what is on screen. PrintWindow and CopyFromScreen both come
+     * back white for a D3D12 swapchain, so a readback here is the only way to
+     * answer "what is it actually drawing?". */
+    { static int every = -1; static const char* dir; static unsigned n;
+      if (every < 0) { dir = getenv("LD_FRAME_DUMP");
+                       const char* e = getenv("LD_FRAME_DUMP_EVERY");
+                       every = (dir && dir[0]) ? (e ? atoi(e) : 300) : 0;
+                       if (every <= 0 && dir && dir[0]) every = 300; }
+      if (every > 0 && buffer_id < 8 && g.display_buffers[buffer_id].valid &&
+          (n++ % (unsigned)every) == 0) {
+          for (u32 i = 0; i < g.n_surfaces; i++) {
+              if (g.surfaces[i].location != g.display_buffers[buffer_id].location ||
+                  g.surfaces[i].offset   != g.display_buffers[buffer_id].offset) continue;
+              char path[MAX_PATH * 2];
+              snprintf(path, sizeof(path), "%s\\frame_%06u.ppm", dir, n - 1u);
+              const u64 nb = ld_dump_surface_ppm(path, &g.surfaces[i]);
+              fprintf(stderr, "[frame-dump] %s %ux%u nonblack=%llu\n", path,
+                      g.surfaces[i].w, g.surfaces[i].h,
+                      (unsigned long long)(nb == UINT64_MAX ? 0 : nb));
+              fflush(stderr);
+              break;
+          }
+      } }
     /* A flip names a registered display buffer. The current color target may
      * be an offscreen shadow/postprocess surface at that instant; copying it
      * caused a010 to present black despite executing the scene's draws. */
@@ -7625,6 +7719,24 @@ void rsx_live_draw_present(u32 buffer_id)
     g_ld_last_present_target = target;
     const u32 current = current_surface();
     surface_t* presented_surface = &g.surfaces[target];
+    /* LD_PRESENT_DBG=1: is this surface actually finished? A surface whose last
+     * clear is NEWER than its last draw has been wiped and not redrawn -- that
+     * presents as a black frame. Counting them separates "we present the wrong
+     * buffer" from "we present the right buffer too early". */
+    { static int dbg = -1;
+      if (dbg < 0) dbg = getenv("LD_PRESENT_DBG") ? 1 : 0;
+      if (dbg) {
+          static unsigned long long n = 0, blank = 0;
+          n++;
+          if (presented_surface->last_draw_generation <
+              presented_surface->last_clear_generation) blank++;
+          if ((n % 256) == 0)
+              fprintf(stderr,
+                      "[present] %llu/%llu presents showed a surface cleared "
+                      "after its last draw (%.1f%%)\n",
+                      (unsigned long long)blank, (unsigned long long)n,
+                      100.0 * (double)blank / (double)n);
+      } }
 #if !defined(YZ_PERF_CLEAN)
     presented_surface->last_present_copy_generation =
         ++g_ld_present_copy_generation;

--- a/runtime/ppu/ppu_fs.cpp
+++ b/runtime/ppu/ppu_fs.cpp
@@ -37,6 +37,7 @@ extern "C" void ydkj_host_bt(const char* tag);
 #endif
 
 extern "C" uint8_t* vm_base;
+extern "C" void ppu_guest_caller(char* out, size_t n);
 extern "C" uint32_t ppu_vm_size;
 extern "C" void     ps3_hle_register_ctx(uint32_t nid, const char* name, void (*fn)(ppu_context*));
 extern "C" void     vm_write32(uint64_t a, uint32_t v);
@@ -215,7 +216,14 @@ static void cellFsOpen(ppu_context* ctx)
     if (fd < 0) { fclose(f); ctx->gpr[3] = (uint64_t)(int64_t)CELL_FS_EIO; return; }
     if (fd_ptr) vm_write32(fd_ptr, (uint32_t)fd);
     g_fd_usm[fd] = (strstr(gpath, ".usm") != nullptr) ? 1 : 0;
-    fprintf(stderr, "[fs] open '%s' -> fd %d\n", gpath, fd);
+    /* FS_CALLER=1: name the guest function that opened each file. A title whose
+     * streaming layer opens a file and never reads it (You Don't Know Jack's
+     * movies) is diagnosed from the opener: its sibling read path is the one
+     * that is not running. */
+    { char who[64] = "?";
+      if (getenv("FS_CALLER")) { ppu_guest_caller(who, sizeof who);
+          fprintf(stderr, "[fs] open '%s' -> fd %d  (opened by %s)\n", gpath, fd, who); }
+      else fprintf(stderr, "[fs] open '%s' -> fd %d\n", gpath, fd); }
     if (getenv("YDKJ_USMBT") && strstr(gpath, ".usm")) {
         /* Resolve to GUEST functions (raw host RVAs are useless here): this tells us
          * which criMv/criFs function opened the movie, so the reader-attach path
@@ -373,7 +381,23 @@ static void cellFsRead(ppu_context* ctx)
 #ifdef _WIN32
     if (getenv("YDKJ_FSDBG") && buf==0 && raw_nbytes>0x10000) { static int _b=0; if(_b++<2){ void* fr[30]; unsigned short nn=RtlCaptureStackBackTrace(0,30,fr,0); uintptr_t mb=(uintptr_t)GetModuleHandleA(0); fprintf(stderr,"[FSBT] null-buf read caller rvas:"); for(unsigned short i=0;i<nn&&i<16;i++) fprintf(stderr," %llX",(unsigned long long)((uintptr_t)fr[i]-mb)); fprintf(stderr,"\n"); } }
 #endif
-    { static uint64_t tot=0; static int _n=0; tot+=n; if(_n++<50) fprintf(stderr,"[fs] read fd=%d nbytes=%llu -> %zu (magic=%02X%02X%02X%02X, total=%llu)\n",fd,(unsigned long long)nbytes,n,vm_base[buf],vm_base[buf+1],vm_base[buf+2],vm_base[buf+3],(unsigned long long)tot); }
+    /* Per-fd totals, not just the first 50 lines. The flat cap made "this file is
+     * opened and never read" unfalsifiable: reads on a later-opened fd fall off
+     * the end of the log and look identical to reads that never happen.
+     * FS_READ_ALL=1 logs every read; otherwise a per-fd first-read line plus a
+     * periodic summary is enough to tell the two apart. */
+    { static uint64_t tot=0; static int _n=0;
+      static uint64_t per_fd[64]; static uint32_t cnt_fd[64];
+      tot+=n;
+      if (fd>=0 && fd<64) { per_fd[fd]+=n; cnt_fd[fd]++; }
+      int first_for_fd = (fd>=0 && fd<64 && cnt_fd[fd]==1);
+      if(_n++<50 || first_for_fd || getenv("FS_READ_ALL"))
+        fprintf(stderr,"[fs] read fd=%d nbytes=%llu -> %zu (magic=%02X%02X%02X%02X, total=%llu)%s\n",
+                fd,(unsigned long long)nbytes,n,vm_base[buf],vm_base[buf+1],vm_base[buf+2],vm_base[buf+3],
+                (unsigned long long)tot, first_for_fd?"  <= FIRST READ ON THIS FD":"");
+      if ((_n % 2000)==0) { fprintf(stderr,"[fs] read summary after %d reads:",_n);
+          for (int i=0;i<64;i++) if (cnt_fd[i]) fprintf(stderr," fd%d=%ux/%lluB",i,cnt_fd[i],(unsigned long long)per_fd[i]);
+          fprintf(stderr,"\n"); } }
     if (getenv("YDKJ_TOCTRACE") && nbytes >= 50000) {  /* data.toc read -> who parses it? */
         fprintf(stderr, "[TOC] data.toc read into buf=0x%08X n=%zu; lr=0x%08llX; guest-stack RAs:\n", buf, n, (unsigned long long)ctx->lr);
         uint32_t sp = (uint32_t)ctx->gpr[1];

--- a/runtime/ppu/ppu_fs.cpp
+++ b/runtime/ppu/ppu_fs.cpp
@@ -148,7 +148,8 @@ static void host_path(char* out, size_t cap, const char* guest)
 /* ---- fd / dir handle tables ---- */
 #define FS_MAX 256
 static FILE* g_files[FS_MAX];
-static uint8_t g_fd_usm[FS_MAX];   /* 1 if this fd is an open .usm movie (read tracker) */
+static uint8_t g_fd_usm[FS_MAX];
+static char    g_fd_path[FS_MAX][192];   /* guest path per fd (diagnostics) */   /* 1 if this fd is an open .usm movie (read tracker) */
 static DIR*  g_dirs[FS_MAX];
 static char  g_dir_path[FS_MAX][1024];   /* host path per open dir (for readdir stat) */
 
@@ -220,6 +221,7 @@ static void cellFsOpen(ppu_context* ctx)
      * streaming layer opens a file and never reads it (You Don't Know Jack's
      * movies) is diagnosed from the opener: its sibling read path is the one
      * that is not running. */
+    if (fd >= 0 && fd < FS_MAX) { strncpy(g_fd_path[fd], gpath, sizeof g_fd_path[fd]-1); g_fd_path[fd][sizeof g_fd_path[fd]-1]=0; }
     { char who[64] = "?";
       if (getenv("FS_CALLER")) { ppu_guest_caller(who, sizeof who);
           fprintf(stderr, "[fs] open '%s' -> fd %d  (opened by %s)\n", gpath, fd, who);
@@ -518,6 +520,18 @@ static void cellFsFstat(ppu_context* ctx)
     fseek(g_files[fd], 0, SEEK_END);
     long sz = ftell(g_files[fd]);
     fseek(g_files[fd], cur, SEEK_SET);
+    /* FS_FSTAT_CAP=<bytes>: DIAGNOSTIC. Report a smaller size than the file
+     * has. You Don't Know Jack reads a 100 KB archive whole but only probes
+     * (open/fstat/close) its 500 KB and 2.4 MB ones; if that branch is driven
+     * by the size it just asked for, capping it makes the title take the read
+     * path. Answers whether the split is size-based -- nothing more. */
+    { const char* cap = getenv("FS_FSTAT_CAP");
+      const char* only = getenv("FS_FSTAT_CAP_PATH");
+      if (cap && only && *only && !(g_fd_path[fd][0] && strstr(g_fd_path[fd], only))) cap = 0;
+      if (cap) { long c = strtol(cap, 0, 0);
+          if (c > 0 && sz > c) {
+              fprintf(stderr, "[fs] fstat fd=%d size %ld -> capped %ld (FS_FSTAT_CAP)\n", fd, sz, c);
+              sz = c; } } }
     if (sb) write_stat(sb, CELL_FS_S_IFREG | 0x1B6, (uint64_t)sz);
     if (getenv("YDKJ_FSDBG")) { static int _n=0; if(_n++<12) fprintf(stderr,"[FSDBG] cellFsFstat(fd=%d) -> size=0x%lX\n",fd,sz); }
     ctx->gpr[3] = CELL_OK;

--- a/runtime/ppu/ppu_fs.cpp
+++ b/runtime/ppu/ppu_fs.cpp
@@ -405,6 +405,8 @@ static void cellFsRead(ppu_context* ctx)
         fprintf(stderr,"[fs] read fd=%d nbytes=%llu -> %zu (magic=%02X%02X%02X%02X, total=%llu)%s\n",
                 fd,(unsigned long long)nbytes,n,vm_base[buf],vm_base[buf+1],vm_base[buf+2],vm_base[buf+3],
                 (unsigned long long)tot, first_for_fd?"  <= FIRST READ ON THIS FD":"");
+      if (getenv("FS_READ_PATH") && fd>=0 && fd<64 && g_fd_path[fd][0])
+          fprintf(stderr, "        from %s\n", g_fd_path[fd]);
       if ((_n % 2000)==0) { fprintf(stderr,"[fs] read summary after %d reads:",_n);
           for (int i=0;i<64;i++) if (cnt_fd[i]) fprintf(stderr," fd%d=%ux/%lluB",i,cnt_fd[i],(unsigned long long)per_fd[i]);
           fprintf(stderr,"\n"); } }

--- a/runtime/ppu/ppu_fs.cpp
+++ b/runtime/ppu/ppu_fs.cpp
@@ -222,7 +222,13 @@ static void cellFsOpen(ppu_context* ctx)
      * that is not running. */
     { char who[64] = "?";
       if (getenv("FS_CALLER")) { ppu_guest_caller(who, sizeof who);
-          fprintf(stderr, "[fs] open '%s' -> fd %d  (opened by %s)\n", gpath, fd, who); }
+          fprintf(stderr, "[fs] open '%s' -> fd %d  (opened by %s)\n", gpath, fd, who);
+          /* FS_STACK=<substr>: every open funnels through one guest wrapper, so
+           * one caller level says nothing about WHICH subsystem wanted the file.
+           * Dump the guest call chain for the opens that matter. */
+          { const char* want = getenv("FS_STACK");
+            if (want && *want && strstr(gpath, want)) ydkj_host_bt("fs-open");
+          } }
       else fprintf(stderr, "[fs] open '%s' -> fd %d\n", gpath, fd); }
     if (getenv("YDKJ_USMBT") && strstr(gpath, ".usm")) {
         /* Resolve to GUEST functions (raw host RVAs are useless here): this tells us
@@ -313,6 +319,8 @@ static void cellFsSdataOpen(ppu_context* ctx)
 static void cellFsClose(ppu_context* ctx)
 {
     int fd = (int)(uint32_t)ctx->gpr[3];
+    if (getenv("FS_CALLER")) { char w[64]="?"; ppu_guest_caller(w,sizeof w);
+        fprintf(stderr, "[fs] close fd=%d  (by %s)\n", fd, w); }
     if (fd >= 0 && fd < FS_MAX && g_files[fd]) {
         if (g_fd_usm[fd] && getenv("YDKJ_USMRD")) fprintf(stderr, "[USMRD] CLOSE usm fd=%d\n", fd);
         fclose(g_files[fd]); g_files[fd] = nullptr; g_fd_usm[fd] = 0;
@@ -451,6 +459,8 @@ static void cellFsLseek(ppu_context* ctx)
     uint32_t wh   = (uint32_t)ctx->gpr[5];
     uint32_t pos_ptr = (uint32_t)ctx->gpr[6];
     if (fd < 0 || fd >= FS_MAX || !g_files[fd]) { ctx->gpr[3] = (uint64_t)(int64_t)CELL_FS_EIO; return; }
+    if (getenv("FS_CALLER")) { char w[64]="?"; ppu_guest_caller(w,sizeof w);
+        fprintf(stderr, "[fs] lseek fd=%d off=%lld whence=%u  (by %s)\n", fd, (long long)off, wh, w); }
     int worigin = (wh == CELL_FS_SEEK_END) ? SEEK_END : (wh == CELL_FS_SEEK_CUR) ? SEEK_CUR : SEEK_SET;
     fseek(g_files[fd], (long)off, worigin);
     long p = ftell(g_files[fd]);
@@ -502,6 +512,8 @@ static void cellFsFstat(ppu_context* ctx)
     int fd      = (int)(uint32_t)ctx->gpr[3];
     uint32_t sb = (uint32_t)ctx->gpr[4];
     if (fd < 0 || fd >= FS_MAX || !g_files[fd]) { ctx->gpr[3] = (uint64_t)(int64_t)CELL_FS_EIO; return; }
+    if (getenv("FS_CALLER")) { char w[64]="?"; ppu_guest_caller(w,sizeof w);
+        fprintf(stderr, "[fs] fstat fd=%d  (by %s)\n", fd, w); }
     long cur = ftell(g_files[fd]);
     fseek(g_files[fd], 0, SEEK_END);
     long sz = ftell(g_files[fd]);

--- a/runtime/ppu/ppu_hle.cpp
+++ b/runtime/ppu/ppu_hle.cpp
@@ -180,6 +180,8 @@ extern "C" void ps3_hle_call(uint32_t nid, ppu_context* ctx)
               char tag[64];
               snprintf(tag, sizeof tag, "hle#%u tid=%u nid=0x%08X", n[t] - 1u, t, nid);
               ppu_dump_guest_stack(ctx, tag);
+              { extern void ppu_dump_bctrl_ring(uint32_t, const char*);
+                ppu_dump_bctrl_ring((uint32_t)ctx->thread_id, tag); }
           }
       } }
 

--- a/runtime/ppu/ppu_hle.cpp
+++ b/runtime/ppu/ppu_hle.cpp
@@ -374,6 +374,18 @@ extern "C" void ps3_hle_call(uint32_t nid, ppu_context* ctx)
             { static int64_t st=-2; if(st==-2){const char*e=getenv("YDKJ_SPURSTRACE"); st=e?1:0;}
               if (st) fprintf(stderr, "[SPURSTRACE] nid=0x%08X -> libsre code=0x%08X  r3=0x%08X r4=0x%08X r5=0x%08X r6=0x%08X lr=0x%08X\n",
                   nid, code, (uint32_t)ctx->gpr[3],(uint32_t)ctx->gpr[4],(uint32_t)ctx->gpr[5],(uint32_t)ctx->gpr[6],(uint32_t)ctx->lr);
+              /* CRI task-arg trace: _cellSpursTaskAttributeInitialize (0xB8474EFF) carries the
+               * CellSpursTaskArgument (16B). Dump all 8 arg regs + the r9/r10 targets so we can
+               * find which game value becomes the task's r3 (wrong vs the RPCS3 dump). */
+              if (st && nid==0xB8474EFFu) { extern uint8_t* vm_base;
+                  fprintf(stderr,"[TASKARG] 0xB8474EFF r3..r10= %08X %08X %08X %08X %08X %08X %08X %08X (lr=0x%08X)\n",
+                      (uint32_t)ctx->gpr[3],(uint32_t)ctx->gpr[4],(uint32_t)ctx->gpr[5],(uint32_t)ctx->gpr[6],
+                      (uint32_t)ctx->gpr[7],(uint32_t)ctx->gpr[8],(uint32_t)ctx->gpr[9],(uint32_t)ctx->gpr[10],(uint32_t)ctx->lr);
+                  for (int rr=9; rr<=10; rr++){ uint32_t p=(uint32_t)ctx->gpr[rr];
+                      if (p>=0x10000 && p<0x0F000000u){ fprintf(stderr,"[TASKARG]   r%d@0x%08X:",rr,p);
+                          for(int k=0;k<0x20;k+=4) fprintf(stderr," %08X",
+                              (vm_base[p+k]<<24)|(vm_base[p+k+1]<<16)|(vm_base[p+k+2]<<8)|vm_base[p+k+3]);
+                          fprintf(stderr,"\n"); } } }
               /* Dump the struct state at the failing task-attach calls: libsre 0x300158C4
                * (nid 0x87630976) STATs unless struct+0xC==0xFF & +0xE in{1,3}; 0x30015AA4
                * (0x22AAB31D) validates the same struct. Show what our recomp left there. */

--- a/runtime/ppu/ppu_hle.cpp
+++ b/runtime/ppu/ppu_hle.cpp
@@ -178,7 +178,12 @@ extern "C" void ps3_hle_call(uint32_t nid, ppu_context* ctx)
           if ((n[t]++ % (unsigned)every) == 0) {
               extern void ppu_dump_guest_stack(ppu_context*, const char*);
               char tag[64];
-              snprintf(tag, sizeof tag, "hle#%u tid=%u nid=0x%08X", n[t] - 1u, t, nid);
+              /* Print the REAL thread id, not the ring index: tid&7 collides
+               * (1, 9 and 17 all land on slot 1) and a stack from a CRI worker
+               * reads exactly like one from the main thread. That collision
+               * cost a round. */
+              snprintf(tag, sizeof tag, "hle#%u tid=%llu nid=0x%08X", n[t] - 1u,
+                       (unsigned long long)ctx->thread_id, nid);
               ppu_dump_guest_stack(ctx, tag);
               { extern void ppu_dump_bctrl_ring(uint32_t, const char*);
                 ppu_dump_bctrl_ring((uint32_t)ctx->thread_id, tag); }

--- a/runtime/ppu/ppu_hle.cpp
+++ b/runtime/ppu/ppu_hle.cpp
@@ -164,6 +164,25 @@ extern "C" void ppu_prof_stamp(void* ctx, unsigned lr);
 extern "C" uint32_t ppu_prof_resolve_host(void* ra);
 extern "C" void ps3_hle_call(uint32_t nid, ppu_context* ctx)
 {
+    /* HLE_BT_EVERY=<n>: dump the calling thread's guest stack every nth HLE
+     * call it makes. WAITBT_EVERY only samples threads that are blocking on an
+     * event queue, which misses a thread that stops looping while it is BUSY --
+     * and "the title ran for a while and then quietly stopped advancing" is
+     * exactly that shape. Every guest frame goes through HLE calls, so the last
+     * dump in the log names the frame the loop was in when it stopped. */
+    { static int every = -1;
+      if (every < 0) { const char* e = getenv("HLE_BT_EVERY"); every = e ? atoi(e) : 0; }
+      if (every > 0 && ctx) {
+          static unsigned n[8] = {0};
+          unsigned t = (unsigned)ctx->thread_id & 7;
+          if ((n[t]++ % (unsigned)every) == 0) {
+              extern void ppu_dump_guest_stack(ppu_context*, const char*);
+              char tag[64];
+              snprintf(tag, sizeof tag, "hle#%u tid=%u nid=0x%08X", n[t] - 1u, t, nid);
+              ppu_dump_guest_stack(ctx, tag);
+          }
+      } }
+
     /* Preserve the caller TOC (r2) across the HLE call. ELFv1 makes r2 caller-saved
      * across a cross-module call: the glink stub does `std r2,40(r1)` before jumping and
      * the caller does `ld r2,40(r1)` after. Our HLE import stubs (`ps3_hle_call(nid);

--- a/runtime/ppu/ppu_loader.cpp
+++ b/runtime/ppu/ppu_loader.cpp
@@ -1339,9 +1339,41 @@ extern "C" void lbp_breadcrumb_dump(const char* tag)
     for(int i=0;i<64;i++) if(g_bc_cnt[i]) p+=snprintf(ln+p,sizeof(ln)-p," t%d=%08X(%u)",i,g_bc_last[i],g_bc_cnt[i]);
     fprintf(stderr,"%s\n",ln); fflush(stderr);
 }
+/* Per-thread ring of recent indirect-call targets (BCTRL_RING=1). */
+#define BCTRL_RING_N 512
+static uint32_t g_bctrl_ring[16][BCTRL_RING_N];
+static uint32_t g_bctrl_pos[16];
+
+extern "C" void ppu_dump_bctrl_ring(uint32_t thread_id, const char* tag)
+{
+    unsigned t = (unsigned)thread_id & 15;
+    uint32_t n = g_bctrl_pos[t] < BCTRL_RING_N ? g_bctrl_pos[t] : BCTRL_RING_N;
+    if (!n) return;
+    fprintf(stderr, "[BCTRL:%s] tid=%u last %u indirect targets:", tag, t, n);
+    for (uint32_t i = 0; i < n; i++) {
+        uint32_t idx = (g_bctrl_pos[t] - n + i) & (BCTRL_RING_N - 1);
+        fprintf(stderr, " %08X", g_bctrl_ring[t][idx]);
+    }
+    fputc(10, stderr);
+    fflush(stderr);
+}
+
 extern "C" void ps3_indirect_call(ppu_context* ctx)
 {
     g_active_ctx = ctx;
+    /* BCTRL_RING=1: keep the last N indirect-call targets per thread, and let
+     * anything that can name a moment dump them. A render path built out of
+     * function pointers and vtables -- a scene graph -- cannot be mapped from
+     * the disassembly, because nothing calls it with a `bl`. Diffing this ring
+     * between the last frame a title drew and the first it did not is the only
+     * way to see which way the dispatch went. */
+    { static int on = -1;
+      if (on < 0) on = getenv("BCTRL_RING") ? 1 : 0;
+      if (on) {
+          unsigned t = (unsigned)ctx->thread_id & 15;
+          g_bctrl_ring[t][g_bctrl_pos[t] & (BCTRL_RING_N - 1)] = (uint32_t)ctx->ctr;
+          g_bctrl_pos[t]++;
+      } }
     { static int bc=-2; if(bc==-2) bc=getenv("LBP_BREADCRUMB")?1:0;
       if(bc){ unsigned t=(unsigned)ctx->thread_id & 63; g_bc_last[t]=(uint32_t)ctx->ctr; g_bc_cnt[t]++; } }
 #ifdef _WIN32

--- a/runtime/ppu/ppu_loader.cpp
+++ b/runtime/ppu/ppu_loader.cpp
@@ -405,6 +405,16 @@ extern "C" void ppu_guest_callstack(const char* tag);
 static uint32_t s_guard_pre = 0;
 static LONG WINAPI ppu_guard_veh(EXCEPTION_POINTERS* ep)
 {
+    /* Re-entrancy guard. The handler logs with fprintf, and if the guarded page
+     * is one the C runtime or this process touches while logging -- guarding the
+     * GCM control register at 0x20002000 is enough -- the log write faults into
+     * this handler again, forever. It surfaces as a [STACKOVERFLOW] whose
+     * backtrace is a repeating ppu_guard_veh / fprintf cycle, i.e. a diagnostic
+     * reporting itself as the title's bug. Drop the nested fault instead. */
+    static PPU_THREAD_LOCAL int in_veh = 0;
+    if (in_veh) return EXCEPTION_CONTINUE_SEARCH;
+    struct Re { int* f; Re(int* p) : f(p) { *f = 1; } ~Re() { *f = 0; } } _re(&in_veh);
+
     DWORD code = ep->ExceptionRecord->ExceptionCode;
     if (code == EXCEPTION_ACCESS_VIOLATION && s_guard_page &&
         ep->ExceptionRecord->NumberParameters >= 2) {

--- a/runtime/ppu/ppu_loader.cpp
+++ b/runtime/ppu/ppu_loader.cpp
@@ -2278,6 +2278,36 @@ extern "C" uint32_t ppu_load_elf(const char* path)
      * otherwise unanswerable without implementing a whole subsystem -- "if this
      * flag did become what the title is waiting for, would it go anywhere?" --
      * and the answer decides whether the subsystem is worth building. */
+    /* PPU_POKE8=<hex ea>:<hex byte>[,...] -- the byte-wide form. A flag a title
+     * gates behaviour on is often one byte inside a struct, and a 32-bit poke
+     * would trample its neighbours. */
+    { const char* pk8 = getenv("PPU_POKE8");
+      if (pk8 && *pk8 && vm_base) {
+          static uint32_t ea8[8]; static uint8_t v8[8]; static int n8;
+          const char* c = pk8;
+          while (*c && n8 < 8) {
+              ea8[n8] = (uint32_t)strtoul(c, (char**)&c, 16);
+              if (*c == ':') c++;
+              v8[n8]  = (uint8_t)strtoul(c, (char**)&c, 16);
+              fprintf(stderr, "[poke8] holding 0x%08X = 0x%02X%c", ea8[n8], v8[n8], 10);
+              n8++;
+              while (*c == ',' || *c == ' ') c++;
+          }
+          /* PPU_POKE_AFTER_MS delays the start. Asserting a value from boot
+           * changes what the title does on the way to the moment you care
+           * about -- forcing VF5's render gate on from t=0 left it opening 15
+           * files instead of 134. Wait until the title is where you want it. */
+          struct P8 { static unsigned long __stdcall go(void*) {
+              { const char* d = getenv("PPU_POKE_AFTER_MS");
+                if (d && *d) Sleep((unsigned long)strtoul(d, 0, 0)); }
+              for (;;) {
+                  for (int i = 0; i < n8; i++)
+                      if (!ppu_vm_size || ea8[i] < ppu_vm_size) vm_base[ea8[i]] = v8[i];
+                  Sleep(2);
+              } } };
+          if (n8) CloseHandle(CreateThread(0, 0, P8::go, 0, 0, 0));
+      } }
+
     { const char* pk = getenv("PPU_POKE");
       if (pk && *pk && vm_base) {
           static uint32_t ea[8], val[8]; static int n;

--- a/runtime/ppu/ppu_loader.cpp
+++ b/runtime/ppu/ppu_loader.cpp
@@ -2272,6 +2272,33 @@ extern "C" uint32_t ppu_load_elf(const char* path)
      * further would the title get?" -- before spending a session on WHY it is
      * being clobbered. Default length 4096, one page, which is the granularity
      * the guard reports in. */
+    /* PPU_POKE=<hex ea>:<hex value>[,<ea>:<value>...] -- hold those guest words
+     * at those values. A PROBE, NOT A FIX, and a blunter one than PPU_KEEP_EA:
+     * it asserts a value the guest never wrote. It answers one question that is
+     * otherwise unanswerable without implementing a whole subsystem -- "if this
+     * flag did become what the title is waiting for, would it go anywhere?" --
+     * and the answer decides whether the subsystem is worth building. */
+    { const char* pk = getenv("PPU_POKE");
+      if (pk && *pk && vm_base) {
+          static uint32_t ea[8], val[8]; static int n;
+          const char* c = pk;
+          while (*c && n < 8) {
+              ea[n]  = (uint32_t)strtoul(c, (char**)&c, 16);
+              if (*c == ':') c++;
+              val[n] = (uint32_t)strtoul(c, (char**)&c, 16);
+              fprintf(stderr, "[poke] holding 0x%08X = 0x%X%c", ea[n], val[n], 10);
+              n++;
+              while (*c == ',' || *c == ' ') c++;
+          }
+          struct P { static unsigned long __stdcall go(void*) {
+              for (;;) {
+                  for (int i = 0; i < n; i++)
+                      if (!ppu_vm_size || ea[i] + 4 <= ppu_vm_size) vm_write32(ea[i], val[i]);
+                  Sleep(2);
+              } } };
+          if (n) CloseHandle(CreateThread(0, 0, P::go, 0, 0, 0));
+      } }
+
     { const char* ke = getenv("PPU_KEEP_EA");
       if (ke && *ke && vm_base) {
           uint32_t kea = (uint32_t)strtoul(ke, 0, 16);

--- a/runtime/ppu/ppu_loader.cpp
+++ b/runtime/ppu/ppu_loader.cpp
@@ -1656,6 +1656,19 @@ extern "C" void ps3_indirect_call(ppu_context* ctx)
     if (cur == last) {
         if (++streak == stuckmax) {
             fprintf(stderr, "[ppu] FATAL: stuck calling 0x%08X (%u times) -- aborting run\n", cur, streak);
+            /* The target alone rarely says why. Dump the descriptor the guest
+             * dereferenced (r9/r11/r12 are where the ELFv1 idiom keeps it) and
+             * the words at the target, so a garbage OPD is distinguishable from
+             * a real one pointing at an unlifted address. */
+            for (int _r = 9; _r <= 12; _r++) {
+                uint32_t a_ = (uint32_t)ctx->gpr[_r];
+                if (!a_ || (ppu_vm_size && a_ + 16 > ppu_vm_size)) continue;
+                fprintf(stderr, "[ppu]   r%d=0x%08X -> %08X %08X %08X %08X\n", _r, a_,
+                        vm_read32(a_), vm_read32(a_+4), vm_read32(a_+8), vm_read32(a_+12));
+            }
+            if (!ppu_vm_size || cur + 16 <= ppu_vm_size)
+                fprintf(stderr, "[ppu]   [target]=0x%08X -> %08X %08X %08X %08X\n", cur,
+                        vm_read32(cur), vm_read32(cur+4), vm_read32(cur+8), vm_read32(cur+12));
             fprintf(stderr, "[ppu]   tid=%llu lr=0x%08X r2=0x%08X r3=0x%08X r31=0x%08X\n",
                     (unsigned long long)ctx->thread_id, (uint32_t)ctx->lr, (uint32_t)ctx->gpr[2],
                     (uint32_t)ctx->gpr[3], (uint32_t)ctx->gpr[31]);

--- a/runtime/ppu/ppu_loader.cpp
+++ b/runtime/ppu/ppu_loader.cpp
@@ -1349,13 +1349,24 @@ extern "C" void ppu_dump_bctrl_ring(uint32_t thread_id, const char* tag)
     unsigned t = (unsigned)thread_id & 15;
     uint32_t n = g_bctrl_pos[t] < BCTRL_RING_N ? g_bctrl_pos[t] : BCTRL_RING_N;
     if (!n) return;
-    fprintf(stderr, "[BCTRL:%s] tid=%u last %u indirect targets:", tag, t, n);
+    /* Its own file when BCTRL_RING names one. A 512-entry line on stderr
+     * interleaves with everything else the runtime and the guest are printing
+     * from other threads, and a spliced ring is worse than no ring -- the first
+     * use of this tool produced a diff that had a [surfsz] log line embedded in
+     * the middle of it. */
+    static FILE* out = NULL; static int tried = 0;
+    if (!tried) { tried = 1;
+        const char* e = getenv("BCTRL_RING");
+        if (e && *e && e[1]) out = fopen(e, "w");   /* "1" means stderr */
+    }
+    FILE* f = out ? out : stderr;
+    fprintf(f, "[BCTRL:%s] tid=%u last %u indirect targets:", tag, t, n);
     for (uint32_t i = 0; i < n; i++) {
         uint32_t idx = (g_bctrl_pos[t] - n + i) & (BCTRL_RING_N - 1);
-        fprintf(stderr, " %08X", g_bctrl_ring[t][idx]);
+        fprintf(f, " %08X", g_bctrl_ring[t][idx]);
     }
-    fputc(10, stderr);
-    fflush(stderr);
+    fputc(10, f);
+    fflush(f);
 }
 
 extern "C" void ps3_indirect_call(ppu_context* ctx)

--- a/runtime/ppu/ppu_loader.cpp
+++ b/runtime/ppu/ppu_loader.cpp
@@ -2176,6 +2176,41 @@ extern "C" uint32_t ppu_load_elf(const char* path)
      * load time covers that window; the later arm is a no-op once armed. */
     { const char* ge = getenv("PPU_GUARD_EA");
       if (ge && *ge) ppu_guard_page((uint32_t)strtoul(ge, 0, 16)); }
+
+    /* PPU_KEEP_EA=<hex>[:<len>] -- snapshot that guest range at load time and
+     * restore it continuously. A PROBE, NOT A FIX: it fights the guest for
+     * ownership of memory, and if the guest legitimately writes there it will
+     * corrupt it. It exists to answer one question that is otherwise very
+     * expensive to answer -- "if this region were not being clobbered, how much
+     * further would the title get?" -- before spending a session on WHY it is
+     * being clobbered. Default length 4096, one page, which is the granularity
+     * the guard reports in. */
+    { const char* ke = getenv("PPU_KEEP_EA");
+      if (ke && *ke && vm_base) {
+          uint32_t kea = (uint32_t)strtoul(ke, 0, 16);
+          const char* c = strchr(ke, ':');
+          uint32_t klen = c ? (uint32_t)strtoul(c + 1, 0, 0) : 4096u;
+          if (klen && (!ppu_vm_size || (uint64_t)kea + klen <= ppu_vm_size)) {
+              static uint8_t* keep; static uint32_t keep_ea, keep_len;
+              keep = (uint8_t*)malloc(klen);
+              if (keep) {
+                  memcpy(keep, vm_base + kea, klen);
+                  keep_ea = kea; keep_len = klen;
+                  fprintf(stderr, "[keep] snapshotting 0x%08X..0x%08X and restoring it%c",
+                          kea, kea + klen, 10);
+                  struct R { static unsigned long __stdcall go(void*) {
+                      for (;;) {
+                          if (memcmp(vm_base + keep_ea, keep, keep_len)) {
+                              memcpy(vm_base + keep_ea, keep, keep_len);
+                              static int n = 0;
+                              if (n++ < 8) fprintf(stderr, "[keep] restored 0x%08X%c", keep_ea, 10);
+                          }
+                          Sleep(2);
+                      } } };
+                  CloseHandle(CreateThread(0, 0, R::go, 0, 0, 0));
+              }
+          }
+      } }
     return entry;
 }
 

--- a/runtime/ppu/ppu_loader.cpp
+++ b/runtime/ppu/ppu_loader.cpp
@@ -1978,6 +1978,40 @@ extern "C" void lv2_syscall(ppu_context* ctx)
             if (n < 20) { fprintf(stderr, "[tty] suspicious len=%u (buf=0x%08X) clamped\n", len, buf); n++; }
             wlen = 0x4000u;
         }
+        /* Collapse a repeating line. A title that logs an error from inside a
+         * retry loop prints it thousands of times a second, and every one of
+         * those is an unbuffered fwrite+fflush on the guest thread -- our
+         * logging then costs far more than whatever the title is retrying.
+         * Virtua Fighter 5 emits "[AMGL]:[ERROR] Command Buffer Overflow!"
+         * 88,000 times in a run and its render loop drops to nothing, most of
+         * that spent in our own fflush. Print the first few, then one line per
+         * 1000 with a count, and say so when the run of repeats ends.
+         *
+         * TTY_NO_DEDUPE=1 restores the raw firehose. */
+        { static char last[128]; static unsigned long long run_len = 0;
+          static int dedupe = -1;
+          if (dedupe < 0) dedupe = getenv("TTY_NO_DEDUPE") ? 0 : 1;
+          if (dedupe && vm_base && wlen > 0 && wlen < sizeof(last)) {
+              char cur[128]; uint32_t cn = wlen;
+              for (uint32_t i = 0; i < cn; i++) cur[i] = (char)vm_read8(buf + i);
+              cur[cn] = 0;
+              if (run_len && strcmp(cur, last) == 0) {
+                  run_len++;
+                  if (run_len > 4 && (run_len % 1000ull) != 0) {
+                      if (pwl) vm_write32(pwl, wlen);
+                      ctx->gpr[3] = 0;
+                      return;
+                  }
+                  fprintf(stderr, "[tty] (x%llu) ", (unsigned long long)run_len);
+              } else {
+                  if (run_len > 4)
+                      fprintf(stderr, "[tty] previous line repeated %llu times%c",
+                              (unsigned long long)run_len, 10);
+                  memcpy(last, cur, cn + 1);
+                  run_len = 1;
+              }
+          } }
+
         FILE* out = stdout;   /* keep all TTY on stdout, clean of [ppu] logs */
         /* TTY_BT=<substring>: dump the call chain whenever the title prints a
          * line containing it. Three hooks in this function and one in

--- a/runtime/ppu/ppu_loader.cpp
+++ b/runtime/ppu/ppu_loader.cpp
@@ -1956,6 +1956,33 @@ extern "C" void lv2_syscall(ppu_context* ctx)
             wlen = 0x4000u;
         }
         FILE* out = stdout;   /* keep all TTY on stdout, clean of [ppu] logs */
+        /* TTY_BT=<substring>: dump the call chain whenever the title prints a
+         * line containing it. Three hooks in this function and one in
+         * lv2_register.c already do exactly this for one hardcoded string
+         * each, which only ever helped the title they were written for. A
+         * title's own error message is the cheapest breakpoint there is -- it
+         * fires exactly when the thing went wrong, on the thread it went wrong
+         * on -- so it should be a knob, not an edit.
+         *
+         * The host chain is the useful half: link with /MAP and every RVA maps
+         * straight back to a func_XXXXXXXX, i.e. a guest address. */
+        if (vm_base && wlen < 4096) {
+            static const char* pat = (const char*)1;
+            if (pat == (const char*)1) pat = getenv("TTY_BT");
+            if (pat && *pat) {
+                char bt[512]; uint32_t bn = wlen < 511 ? wlen : 511;
+                for (uint32_t i = 0; i < bn; i++) bt[i] = (char)vm_read8(buf + i);
+                bt[bn] = 0;
+                if (strstr(bt, pat)) {
+                    static int tn = 0;
+                    if (tn++ < 3) {
+                        fprintf(stderr, "%c[TTY_BT] \"%.90s\"%c", 10, bt, 10);
+                        ppu_log_host_chain("tty-bt");
+                    }
+                }
+            }
+        }
+
         /* POOL CORRUPTION TRACE: dump the host->guest call chain the first few
          * times the game's debug allocator reports a bad block / wrong pool /
          * zeroed sentinel, to locate who passed/corrupted the block. */

--- a/runtime/ppu/ppu_sysprx.cpp
+++ b/runtime/ppu/ppu_sysprx.cpp
@@ -605,6 +605,28 @@ static void hle_net_sendto(ppu_context* ctx) { ctx->gpr[3] = (uint32_t)ctx->gpr[
 extern "C" uint32_t g_spu_image_src_ea = 0, g_spu_image_ls_start = 0,
                     g_spu_image_span = 0;
 
+/* img_ea -> the EA of the SPU ELF it was parsed from. Small and fixed: a title
+ * has a handful of images, and a repeat import of the same descriptor replaces
+ * its entry. */
+#define SPU_IMG_SRC_MAX 32
+static struct { uint32_t img, src; } s_spu_img_src[SPU_IMG_SRC_MAX];
+
+extern "C" void ps3_spu_image_record(uint32_t img_ea, uint32_t src_ea)
+{
+    if (!img_ea || !src_ea) return;
+    for (int i = 0; i < SPU_IMG_SRC_MAX; i++)
+        if (s_spu_img_src[i].img == img_ea || s_spu_img_src[i].img == 0) {
+            s_spu_img_src[i].img = img_ea; s_spu_img_src[i].src = src_ea; return;
+        }
+}
+
+extern "C" uint32_t ps3_spu_image_source_ea(uint32_t img_ea)
+{
+    for (int i = 0; i < SPU_IMG_SRC_MAX; i++)
+        if (s_spu_img_src[i].img == img_ea) return s_spu_img_src[i].src;
+    return 0;
+}
+
 static void hle_sys_spu_image_import(ppu_context* ctx)
 {
     uint32_t img_ea = (uint32_t)ctx->gpr[3];
@@ -654,6 +676,11 @@ static void hle_sys_spu_image_import(ppu_context* ctx)
         g_spu_image_ls_start = vm_read32(segs_ea + 0x04);
         g_spu_image_span     = vm_read32(last + 0x04) - g_spu_image_ls_start;
     }
+    /* Remember which ELF this descriptor was parsed from. sys_spu_thread_group_
+     * start only gets the DESCRIPTOR, but the workload registry is keyed by a
+     * fingerprint of the ELF's own bytes -- without this the raw SPU path has no
+     * way to ask whether the image it is about to run was lifted. */
+    ps3_spu_image_record(img_ea, src_ea);
     vm_write32(img_ea + 0x00, 0);                              /* type = USER */
     vm_write32(img_ea + 0x04, entry);
     vm_write32(img_ea + 0x08, nsegs ? segs_ea : 0);

--- a/runtime/ppu/ppu_sysprx.cpp
+++ b/runtime/ppu/ppu_sysprx.cpp
@@ -598,6 +598,13 @@ static void hle_net_sendto(ppu_context* ctx) { ctx->gpr[3] = (uint32_t)ctx->gpr[
  * Self-verifying: no-op unless r4 points to an ELF (so a wrong NID guess is safe).
  * sys_spu_image { u32 type; u32 entry; sys_spu_segment* segs; int nsegs; }
  * sys_spu_segment{ int type; u32 ls_start; int size; u64 src_pa }  (0x18, src@0x10) */
+/* Last SPU image parsed below: where its loadable bytes live, which local
+ * store address they start at, and how far they span. Read by the SPU DMA
+ * path (SPU_DSP_IMAGE_EA in spu_dma.h) to recover a section load whose
+ * source address the title lost between import and use. */
+extern "C" uint32_t g_spu_image_src_ea = 0, g_spu_image_ls_start = 0,
+                    g_spu_image_span = 0;
+
 static void hle_sys_spu_image_import(ppu_context* ctx)
 {
     uint32_t img_ea = (uint32_t)ctx->gpr[3];
@@ -637,14 +644,118 @@ static void hle_sys_spu_image_import(ppu_context* ctx)
     }
     s_seg_bump += (uint32_t)nsegs * 0x18;
     if (s_seg_bump >= 0x0E000000u) s_seg_bump = 0x0D000000u;
+    /* Remember where this image's loadable bytes live, for the SPU-side
+     * recovery in spu_dma.h (SPU_DSP_IMAGE_EA). The segments are contiguous in
+     * the source image, so segment 0's address plus the span from its ls_start
+     * to the end of the last segment describes the whole thing. */
+    if (nsegs > 0) {
+        uint32_t last = segs_ea + (uint32_t)(nsegs - 1) * 0x18;
+        g_spu_image_src_ea   = vm_read32(segs_ea + 0x14);
+        g_spu_image_ls_start = vm_read32(segs_ea + 0x04);
+        g_spu_image_span     = vm_read32(last + 0x04) - g_spu_image_ls_start;
+    }
     vm_write32(img_ea + 0x00, 0);                              /* type = USER */
     vm_write32(img_ea + 0x04, entry);
     vm_write32(img_ea + 0x08, nsegs ? segs_ea : 0);
     vm_write32(img_ea + 0x0C, (uint32_t)nsegs);
     fprintf(stderr, "[HLE] _sys_spu_image_import -> entry=0x%05X nsegs=%d machine=%u (SPU=23)\n",
             entry, nsegs, machine);
+    /* SPU_IMAGE_DIAG=1: r6 is a caller-supplied guest buffer that differs on
+     * every call, which this handler ignores -- it points the segments at the
+     * source image instead. Show the segments written and what the caller's
+     * buffer holds, to establish whether the caller expects it to be filled. */
+    if (getenv("SPU_IMAGE_DIAG")) {
+        for (int i = 0; i < nsegs; i++) {
+            uint32_t s = segs_ea + (uint32_t)i * 0x18;
+            fprintf(stderr, "        seg[%d] type=%u ls=0x%05X size=%u src=0x%08X%08X\n",
+                    i, vm_read32(s + 0x00), vm_read32(s + 0x04), vm_read32(s + 0x08),
+                    vm_read32(s + 0x10), vm_read32(s + 0x14));
+        }
+        uint32_t r6 = (uint32_t)ctx->gpr[6];
+        if (r6 && r6 < 0xD0000000u) {
+            /* Scan a window around the caller's buffer for the DSP descriptor
+             * the SPU later reads: its first word is 0x0052E1E8 and it carries
+             * the image's {entry, size, ls_start, size} at +0x150. Finding it
+             * at a fixed offset says r6 IS that descriptor. */
+            for (int32_t o = -0x400; o <= 0x400; o += 4) {
+                uint32_t a = (uint32_t)((int32_t)r6 + o);
+                if (vm_read32(a) == 0x0052E1E8u)
+                    fprintf(stderr, "        descriptor marker 0x0052E1E8 at r6%+d (0x%08X)\n", o, a);
+                if (vm_read32(a) == 0x00000248u && vm_read32(a + 4) == 0x00002CB0u)
+                    fprintf(stderr, "        image quad {248,2CB0,80,2CB0} at r6%+d (0x%08X) "
+                            "=> descriptor+0x150, descriptor=0x%08X, its +0x140=%08X %08X %08X %08X\n",
+                            o, a, a - 0x150,
+                            vm_read32(a - 0x10), vm_read32(a - 0xC),
+                            vm_read32(a - 8), vm_read32(a - 4));
+            }
+        }
+    }
     fflush(stderr);
     ctx->gpr[3] = 0;
+}
+
+/* ---- sys_spinlock_* (sysPrxForUser) -------------------------------------
+ *
+ * A sys_spinlock_t is one 32-bit word in guest memory and nothing else -- the
+ * real firmware spins on it with lwarx/stwcx. The guest only ever touches that
+ * word through these four calls, so a host test-and-set on the same address is
+ * exactly equivalent and stays correct across the title's own threads.
+ *
+ * Stored big-endian, so a guest that peeks at the word still reads 1.
+ *
+ * ABI: initialize / lock / unlock return void; trylock returns CELL_OK or
+ * EBUSY. Found via Virtua Fighter 5, which locks with trylock in a retry loop
+ * and was the first title to import the family -- the three NIDs were unnamed
+ * in the database until compute_nid() was brute-forced over the sysPrxForUser
+ * export list.
+ */
+#define SPINLOCK_BE1  0x01000000u          /* be32(1) */
+
+static inline volatile long* spin_word(uint32_t ea)
+{
+    return (volatile long*)(vm_base + ea);
+}
+
+/* Test-and-set, not compare-and-swap: writing "locked" over an already-locked
+ * word is idempotent, so a plain atomic exchange is enough -- and _Interlocked-
+ * Exchange is the one RMW the POSIX shim in win32_compat.h already provides. */
+static inline int spin_try(uint32_t ea)
+{
+    return _InterlockedExchange(spin_word(ea), (long)SPINLOCK_BE1) == 0;
+}
+
+static void sys_spinlock_initialize(ppu_context* ctx)
+{
+    uint32_t ea = (uint32_t)ctx->gpr[3];
+    if (ea) _InterlockedExchange(spin_word(ea), 0);
+}
+
+static void sys_spinlock_lock(ppu_context* ctx)
+{
+    uint32_t ea = (uint32_t)ctx->gpr[3];
+    if (!ea) return;
+    /* ponytail: spin briefly, then hand the core back. On real hardware the
+     * holder runs to completion in a few instructions; here it is a host thread
+     * the OS can deschedule mid-section, so busy-waiting a whole quantum is the
+     * wrong trade. Swap in a futex if a title ever shows real contention here. */
+    for (unsigned n = 0; !spin_try(ea); n++) {
+        if (n < 64) YieldProcessor();
+        else        Sleep(0);
+    }
+}
+
+static void sys_spinlock_trylock(ppu_context* ctx)
+{
+    uint32_t ea = (uint32_t)ctx->gpr[3];
+    ctx->gpr[3] = (ea && spin_try(ea))
+                ? 0                                            /* CELL_OK */
+                : (uint64_t)(int64_t)(int32_t)0x8001000Au;     /* EBUSY   */
+}
+
+static void sys_spinlock_unlock(ppu_context* ctx)
+{
+    uint32_t ea = (uint32_t)ctx->gpr[3];
+    if (ea) _InterlockedExchange(spin_word(ea), 0);
 }
 
 extern "C" void ppu_sysprx_register(void)
@@ -685,6 +796,12 @@ extern "C" void ppu_sysprx_register(void)
     ps3_hle_register_ctx(ps3_compute_nid("sys_lwmutex_lock"),    "sys_lwmutex_lock",    sys_lwmutex_lock);
     ps3_hle_register_ctx(ps3_compute_nid("sys_lwmutex_unlock"),  "sys_lwmutex_unlock",  sys_lwmutex_unlock);
     ps3_hle_register_ctx(ps3_compute_nid("sys_lwmutex_trylock"), "sys_lwmutex_trylock", sys_lwmutex_trylock);
+
+    /* Spinlocks. One guest word each, no kernel object; see the block above. */
+    ps3_hle_register_ctx(ps3_compute_nid("sys_spinlock_initialize"), "sys_spinlock_initialize", sys_spinlock_initialize);
+    ps3_hle_register_ctx(ps3_compute_nid("sys_spinlock_lock"),       "sys_spinlock_lock",       sys_spinlock_lock);
+    ps3_hle_register_ctx(ps3_compute_nid("sys_spinlock_trylock"),    "sys_spinlock_trylock",    sys_spinlock_trylock);
+    ps3_hle_register_ctx(ps3_compute_nid("sys_spinlock_unlock"),     "sys_spinlock_unlock",     sys_spinlock_unlock);
 
     ps3_hle_register_ctx(ps3_compute_nid("sys_lwcond_create"),     "sys_lwcond_create",     sys_lwcond_create);
     ps3_hle_register_ctx(ps3_compute_nid("sys_lwcond_destroy"),    "sys_lwcond_destroy",    sys_lwcond_destroy);

--- a/runtime/ppu/tests/boot_main.cpp
+++ b/runtime/ppu/tests/boot_main.cpp
@@ -189,6 +189,59 @@ extern "C" void cellGcm_rsx_process_fifo(void);   /* cellGcmSys.c: drain get->pu
 extern "C" unsigned cellGcm_flip_request_count(void);
 extern "C" int sys_event_queue_inject(unsigned int, unsigned long long, unsigned long long, unsigned long long, unsigned long long);
 
+/* Live NV4097->D3D12 engine (libs/video/rsx_live_draw.c, from caner /
+ * canersaka's Yakuza: Dead Souls port). Opt-in with RSX_LIVE_DRAW=1: the null
+ * backend opens the window, the engine binds its swap chain to that HWND and
+ * owns presentation, so rsx_d3d12_backend is left out entirely rather than run
+ * alongside it. Unset, every path below is exactly what it was. */
+extern "C" int   rsx_live_draw_enabled(void);
+extern "C" int   rsx_live_draw_init(void* hwnd, uint32_t w, uint32_t h,
+                                    const uint8_t* (*guest_ptr)(void*, uint32_t,
+                                                                uint32_t, uint32_t),
+                                    void* user);
+extern "C" void  rsx_live_draw_present(uint32_t buffer_id);
+extern "C" uint32_t rsx_live_draw_get_frames(void);
+extern "C" uint32_t rsx_live_draw_get_last_draws(void);
+extern "C" int   rsx_null_backend_init(uint32_t w, uint32_t h, const char* title);
+extern "C" int   rsx_null_backend_pump_messages(void);
+extern "C" void* rsx_null_backend_get_hwnd(void);
+extern "C" void  rsx_null_backend_suppress_present(int on);
+extern "C" uint32_t cellGcmResolveLocated(int local, uint32_t offset);
+extern "C" uint32_t cellGcmResolveIO(uint32_t offset);
+
+static int s_rsx_live = 0;   /* live engine selected AND up */
+
+/* Resolve (location, offset) to host memory for the engine. location 0 is RSX
+ * local VRAM, 1 is main/IO memory; the engine promises its callers the whole
+ * min_bytes span is readable, so validate the interval, not just its start.
+ * The location comes straight from the RSX DMA context selector and is
+ * authoritative -- cellGcmResolveOffset()'s heuristic prefers VRAM for any page
+ * the guest ever derived from a local EA, which maps a title's MAIN-memory
+ * textures into local memory where they read as garbage (caner hit exactly
+ * that in the Yakuza port; the geometry came out flat white). */
+static const uint8_t* rsx_live_guest_ptr(void* user, uint32_t location,
+                                         uint32_t offset, uint32_t min_bytes)
+{
+    (void)user;
+    if (!vm_base) return nullptr;
+    uint32_t ea;
+    if (location == 0) {
+        ea = cellGcmResolveLocated(1, offset);          /* RSX local VRAM */
+    } else {
+        ea = cellGcmResolveIO(offset);                  /* main, via the IO table */
+        if (!ea) ea = cellGcmResolveLocated(0, offset); /* unmapped: old behaviour */
+    }
+    if (!ea || ea == 0xFFFFFFFFu ||
+        (uint64_t)ea + min_bytes > 0x100000000ull) return nullptr;
+    return (const uint8_t*)vm_base + ea;
+}
+
+/* Present / pump through whichever backend is live. */
+static void rsx_present_frame(void)
+{ if (s_rsx_live) rsx_live_draw_present(0); else rsx_d3d12_backend_present(); }
+static int rsx_pump_messages(void)
+{ return s_rsx_live ? rsx_null_backend_pump_messages() : rsx_d3d12_backend_pump_messages(); }
+
 /* ---- Guest-PC sampling profiler (PS3_GUEST_PROF=1) -----------------------
  * Samples every guest thread's ctx.cia every ~5ms and dumps the top sites
  * every 5s. cia is refreshed at every syscall, and guest spin loops issue a
@@ -243,7 +296,27 @@ static DWORD WINAPI vblank_ticker(LPVOID)
 {
     const char* _title = getenv("PS3_TITLE");
     if (!_title || !*_title) _title = "You Don't Know Jack (ps3recomp)";
-    int rsx_ok = (rsx_d3d12_backend_init(1280, 720, _title) == 0);
+    /* The live engine's RT-as-backbuffer rescue only treats a surface as the
+     * backbuffer when its clip EQUALS the backend size, so a title that renders
+     * into something other than 1280x720 must say so: RSX_W / RSX_H. */
+    uint32_t rsx_w = 1280, rsx_h = 720;
+    if (const char* e = getenv("RSX_W")) rsx_w = (uint32_t)strtoul(e, 0, 0);
+    if (const char* e = getenv("RSX_H")) rsx_h = (uint32_t)strtoul(e, 0, 0);
+    int rsx_ok;
+    if (rsx_live_draw_enabled()) {
+        rsx_ok = (rsx_null_backend_init(rsx_w, rsx_h, _title) == 0);
+        if (rsx_ok && rsx_live_draw_init(rsx_null_backend_get_hwnd(), rsx_w, rsx_h,
+                                         rsx_live_guest_ptr, nullptr) == 0) {
+            s_rsx_live = 1;
+            rsx_null_backend_suppress_present(1);
+            fprintf(stderr, "[rsx] live-draw engine up (D3D12); GDI present suppressed\n");
+        } else {
+            fprintf(stderr, "[rsx] live-draw init FAILED -- falling back to the D3D12 backend\n");
+            rsx_ok = (rsx_d3d12_backend_init(rsx_w, rsx_h, _title) == 0);
+        }
+    } else {
+        rsx_ok = (rsx_d3d12_backend_init(rsx_w, rsx_h, _title) == 0);
+    }
     fprintf(stderr, "[rsx] backend init %s\n", rsx_ok ? "OK -- window open" : "FAILED");
     unsigned last_flip = 0;
     /* The game's frame pacing (vblank/flip handlers -> display frame counter) must
@@ -266,7 +339,7 @@ static DWORD WINAPI vblank_ticker(LPVOID)
              * writes and showed empty or mixed batches. */
             {
                 if (rsx_ok && cellGcm_take_flip_pending()) {
-                    rsx_d3d12_backend_present();
+                    rsx_present_frame();
                     last_flip = cellGcm_flip_request_count();
                 }
             }
@@ -285,7 +358,7 @@ static DWORD WINAPI vblank_ticker(LPVOID)
          * The real RSX writes those fences in microseconds. */
         if (rsx_ok) {
             if (cellGcm_take_flip_pending()) {
-                rsx_d3d12_backend_present();
+                rsx_present_frame();
                 last_flip = cellGcm_flip_request_count();
             }
             cellGcm_rsx_process_fifo();
@@ -299,11 +372,11 @@ static DWORD WINAPI vblank_ticker(LPVOID)
             if(++s_q3 % 8 == 0){ int r=sys_event_queue_inject(qid, 0x1234, 0, 0, 0);
               static int _n=0; if(_n++<12) fprintf(stderr,"[INJQ3] injected q%u event rc=%d\n",qid,r); } }
         if (rsx_ok) {
-            if (rsx_d3d12_backend_pump_messages() != 0) { rsx_ok = 0; }
+            if (rsx_pump_messages() != 0) { rsx_ok = 0; }
             if (getenv("YDKJ_PACETRACE")) {
                 static ULONGLONG s_win=0; static int s_pf=0, s_pres=0; static ULONGLONG s_presms=0;
                 s_pf += fired; s_pres++;
-                ULONGLONG t0=GetTickCount64(); rsx_d3d12_backend_present(); ULONGLONG t1=GetTickCount64();
+                ULONGLONG t0=GetTickCount64(); rsx_present_frame(); ULONGLONG t1=GetTickCount64();
                 s_presms += (t1-t0);
                 if (s_win==0) s_win=now;
                 if (now - s_win >= 1000) {
@@ -320,7 +393,7 @@ static DWORD WINAPI vblank_ticker(LPVOID)
                  * during boot. */
                 unsigned fc = cellGcm_flip_request_count();
                 if (fc != last_flip || fc == 0) {
-                    rsx_d3d12_backend_present();
+                    rsx_present_frame();
                     last_flip = fc;
                 }
             }

--- a/runtime/spu/spu_channels.c
+++ b/runtime/spu/spu_channels.c
@@ -1430,6 +1430,26 @@ void spu_indirect_branch(spu_context* ctx)
               } }
             fflush(stderr);
         }
+        /* SPU_INTERP_UNLIFTED=1: if real code is present at the target, run it
+         * through the interpreter instead of ending the job. No lift can exist
+         * for a module the title loads at runtime -- You Don't Know Jack's FMOD
+         * mixer relocates a DSP plugin into local store and calls it -- and the
+         * interpreter rejoins the compiled path as soon as it reaches a lifted
+         * address, which is what the plugin's return does. Opt-in so titles
+         * that reach here on a genuinely bad pc keep the loud stop. */
+        { uint32_t p = ctx->pc & SPU_LS_MASK;
+          uint32_t w0 = ((uint32_t)ctx->ls[p] << 24) | ((uint32_t)ctx->ls[p+1] << 16) |
+                        ((uint32_t)ctx->ls[p+2] << 8) | ctx->ls[p+3];
+          static int s_iu = -1;
+          if (s_iu < 0) { const char* e = getenv("SPU_INTERP_UNLIFTED"); s_iu = e ? 1 : 0; }
+          if (s_iu && w0) {
+              static int _n = 0;
+              if (_n++ < 8)
+                  fprintf(stderr, "[spu] img=%d interpreting unlifted LS 0x%05X "
+                          "(runtime-loaded code)\n", ctx->image_id, p);
+              spu_interp_run(ctx, p);
+              return;
+          } }
         spu_halt(ctx);
         return;
     }

--- a/runtime/spu/spu_channels.c
+++ b/runtime/spu/spu_channels.c
@@ -1415,6 +1415,19 @@ void spu_indirect_branch(spu_context* ctx)
             fprintf(stderr, "[spu] img=%d branched into unlifted LS 0x%05X "
                     "(lr=0x%05X) -- ending the job\n",
                     ctx->image_id, ctx->pc, ctx->gpr[0]._u32[0] & SPU_LS_MASK);
+            /* Is there real code at the target, or is the pc garbage? Eight
+             * words at the target and at the return address separate "the lift
+             * missed a function" from "this branch should never have happened". */
+            { uint32_t a[2]; a[0] = ctx->pc & SPU_LS_MASK;
+              a[1] = ctx->gpr[0]._u32[0] & SPU_LS_MASK;
+              for (int k = 0; k < 2; k++) {
+                  fprintf(stderr, "      LS[0x%05X]:", a[k]);
+                  for (uint32_t o = 0; o < 32 && a[k] + o + 3 < SPU_LS_SIZE; o += 4)
+                      fprintf(stderr, " %02X%02X%02X%02X",
+                              ctx->ls[a[k]+o], ctx->ls[a[k]+o+1],
+                              ctx->ls[a[k]+o+2], ctx->ls[a[k]+o+3]);
+                  fprintf(stderr, "\n");
+              } }
             fflush(stderr);
         }
         spu_halt(ctx);

--- a/runtime/spu/spu_dma.h
+++ b/runtime/spu/spu_dma.h
@@ -455,6 +455,31 @@ static inline int mfc_do_transfer(spu_context* spu, uint32_t lsa, uint64_t ea,
      *
      * This is opt-in: it repairs a pointer the guest should have supplied, so
      * it must not mask the real defect by default. */
+    /* SPU_DUMP_GET=<hexEA>: dump the source bytes the first time an SPU fetches
+     * from that address. Fixed BSS structures have the same address in a
+     * reference run, so this is what a dump from real hardware diffs against. */
+    if (mfc_is_get(cmd) && size && vm_base) {
+        static uint32_t s_dg = 0xFFFFFFFFu;
+        if (s_dg == 0xFFFFFFFFu) { const char* e = getenv("SPU_DUMP_GET");
+                                   s_dg = e ? (uint32_t)strtoul(e, 0, 0) : 0; }
+        if (s_dg && (uint32_t)ea == s_dg) {
+            static int done = 0;
+            if (!done) { done = 1;
+                uint32_t n = size > 128 ? 128 : size;
+                fprintf(stderr, "[get-dump] img%d GET 0x%08X size=%u pc=0x%05X\n",
+                        spu->image_id, (uint32_t)ea, size, (uint32_t)spu->pc & SPU_LS_MASK);
+                for (uint32_t o = 0; o < n; o += 16) {
+                    fprintf(stderr, "  +0x%03X:", o);
+                    for (uint32_t i = 0; i < 16; i += 4) {
+                        const uint8_t* q = vm_base + (uint32_t)ea + o + i;
+                        fprintf(stderr, " %02X%02X%02X%02X", q[0], q[1], q[2], q[3]);
+                    }
+                    fprintf(stderr, "\n");
+                }
+                fflush(stderr);
+            }
+        }
+    }
     /* The DSP descriptor arrives as a 368-byte GET shortly before the section
      * load; remember where it came from so the substitution below can name it.
      * That guest address is what a write-watch needs to find its producer. */

--- a/runtime/spu/spu_dma.h
+++ b/runtime/spu/spu_dma.h
@@ -442,6 +442,34 @@ static inline int mfc_do_transfer(spu_context* spu, uint32_t lsa, uint64_t ea,
     { extern int g_cri_video_dma;
       if (spu->image_id == 22 && mfc_is_get(cmd) && size > 0x100)
           g_cri_video_dma = 1; }
+    /* SPU_DSP_IMAGE_EA -- recover an SPU image load whose source address the
+     * title lost. You Don't Know Jack's FMOD mixer relocates a DSP plugin into
+     * local store and calls it, but the descriptor it builds carries a NULL
+     * source address, so the transfer reads guest memory at 0, the mixer calls
+     * into zeros, its job ends, and the event flag the menu waits on is never
+     * set. The plugin itself is present and known: _sys_spu_image_import parsed
+     * it moments earlier, and its segments are contiguous in the source image
+     * (segment 0 at 0x4D3900 + (0x2C00 - 0x80) lands exactly on segment 1's
+     * 0x4D6480), so a transfer of the image's span belongs at segment 0's
+     * address. Match on the size the import recorded and substitute it.
+     *
+     * This is opt-in: it repairs a pointer the guest should have supplied, so
+     * it must not mask the real defect by default. */
+    if (mfc_is_get(cmd) && !(uint32_t)ea && size) {
+        static int s_di = -1;
+        if (s_di < 0) s_di = getenv("SPU_DSP_IMAGE_EA") ? 1 : 0;
+        extern uint32_t g_spu_image_src_ea, g_spu_image_ls_start, g_spu_image_span;
+        if (s_di && g_spu_image_src_ea) {
+            static int _n = 0;
+            if (_n++ < 8)
+                fprintf(stderr, "[dsp-image] img%d GET ea=0 size=%u dest=0x%05X -> 0x%08X "
+                        "(last imported SPU image: ls_start=0x%X span=%u)\n",
+                        spu->image_id, size, lsa, g_spu_image_src_ea,
+                        g_spu_image_ls_start, g_spu_image_span);
+            ea = g_spu_image_src_ea;
+            ea_ptr = vm_base + (uint32_t)ea;   /* the copy reads ea_ptr, not ea */
+        }
+    }
     /* DIAGNOSTIC (LBP_SKIP_NULL_DMA): a GET from a null/near-null EA reads guest
      * memory at ~0 (the ELF header / low mem) = garbage. The FMOD SPU mixer's DSP
      * buffer pointers are 0 in our run; if the real task would SKIP a null DSP

--- a/runtime/spu/spu_dma.h
+++ b/runtime/spu/spu_dma.h
@@ -455,6 +455,11 @@ static inline int mfc_do_transfer(spu_context* spu, uint32_t lsa, uint64_t ea,
      *
      * This is opt-in: it repairs a pointer the guest should have supplied, so
      * it must not mask the real defect by default. */
+    /* The DSP descriptor arrives as a 368-byte GET shortly before the section
+     * load; remember where it came from so the substitution below can name it.
+     * That guest address is what a write-watch needs to find its producer. */
+    static uint32_t s_desc_ea = 0;
+    if (mfc_is_get(cmd) && size == 368) s_desc_ea = (uint32_t)ea;
     if (mfc_is_get(cmd) && !(uint32_t)ea && size) {
         static int s_di = -1;
         if (s_di < 0) s_di = getenv("SPU_DSP_IMAGE_EA") ? 1 : 0;
@@ -463,9 +468,9 @@ static inline int mfc_do_transfer(spu_context* spu, uint32_t lsa, uint64_t ea,
             static int _n = 0;
             if (_n++ < 8)
                 fprintf(stderr, "[dsp-image] img%d GET ea=0 size=%u dest=0x%05X -> 0x%08X "
-                        "(last imported SPU image: ls_start=0x%X span=%u)\n",
+                        "(last imported SPU image: ls_start=0x%X span=%u) descriptor@0x%08X\n",
                         spu->image_id, size, lsa, g_spu_image_src_ea,
-                        g_spu_image_ls_start, g_spu_image_span);
+                        g_spu_image_ls_start, g_spu_image_span, s_desc_ea);
             ea = g_spu_image_src_ea;
             ea_ptr = vm_base + (uint32_t)ea;   /* the copy reads ea_ptr, not ea */
         }

--- a/runtime/spu/spu_helpers.h
+++ b/runtime/spu/spu_helpers.h
@@ -360,7 +360,28 @@ static inline u128 spu_frest(u128 a){ u128 r; for(int i=0;i<4;i++) r._f32[i]= 1.
  * at the *lower* storage address). Same caveat as the mpy family. */
 static inline u128 spu_xsbh(u128 a) { u128 r; for(int i=0;i<8;i++) r._s16[i] = (int8_t)a._u8[2*i]; return r; }
 static inline u128 spu_xshw(u128 a) { u128 r; for(int i=0;i<4;i++) r._s32[i] = (int16_t)a._s16[2*i]; return r; }
-static inline u128 spu_xswd(u128 a) { u128 r; for(int i=0;i<2;i++) r._s64[i] = (int32_t)a._s32[2*i]; return r; }
+/* xswd: rt.doubleword[d] = sign_extend_64(ra.word[2d+1]) -- the ODD word of
+ * each doubleword, because that is the low half in big-endian order.
+ *
+ * This read the EVEN words (2d) and wrote the result through _s64, which is a
+ * host little-endian lane: writing it puts the value in _u32[2d] (SPU word 2d,
+ * the HIGH half) and the sign fill in _u32[2d+1]. Both halves were therefore
+ * wrong, and the common case -- a small positive value -- came out as ZERO.
+ *
+ * You Don't Know Jack's FMOD mixer hit exactly that: a compiler-generated
+ * 64-bit multiply helper received `1 * 0` instead of `1 * 16`, so the mixer's
+ * block count was zero and it stopped on its own assert. Unlike its siblings
+ * xsbh/xshw, whose source and destination swaps cancel, nothing cancels here.
+ * Write the two words explicitly. */
+static inline u128 spu_xswd(u128 a) {
+    u128 r;
+    for (int d = 0; d < 2; d++) {
+        int32_t v = (int32_t)a._u32[2*d + 1];
+        r._u32[2*d]     = (uint32_t)(v >> 31);   /* sign fill (high word) */
+        r._u32[2*d + 1] = (uint32_t)v;           /* value      (low word) */
+    }
+    return r;
+}
 
 /* ---- Phase 3: OR across ---- */
 static inline u128 spu_orx(u128 a) {

--- a/runtime/spu/spu_interp.c
+++ b/runtime/spu/spu_interp.c
@@ -343,6 +343,13 @@ uint32_t spu_interp_run(spu_context* ctx, uint32_t start_lsa) {
      * interp halts -- shows the path to a branch-to-0 (the cri task/policy wall). */
     static int _tr=-1; if(_tr<0){const char*e=getenv("YDKJ_SPU_TRACE");_tr=e?atoi(e):0;}
     static uint64_t _cap=0; { static int _ci=0; if(!_ci){_ci=1; const char*e=getenv("YDKJ_SPU_STEPCAP"); _cap=e?strtoull(e,0,0):0;} }
+    /* YDKJ_CRI_GATE1TRACE=N: cri decode task busy-spins in the validator func_00026E80
+     * (LS 0x26E80..0x26F14), a straight-line leaf that returns r3 = 0 / 0x8041090F /
+     * 0x80410909. Hand-decoding its selb/fsm/gb/ceqh lanes proved unreliable, so log the
+     * ACTUAL runtime result + inputs the first N times it returns. Fires on range-exit
+     * (pc left the fn), when r3 and the leaf's non-restored intermediates are still live. */
+    static int _g1=-1; if(_g1<0){const char*e=getenv("YDKJ_CRI_GATE1TRACE");_g1=e?atoi(e):0;}
+    static int _g1in=0;
     uint32_t ring[64]; int rc=0, rn=0;
     for (;;) {
         /* Taskset PM task-syscall entry (LS 0xA70): the pure interpreter has no PM
@@ -372,6 +379,20 @@ uint32_t spu_interp_run(spu_context* ctx, uint32_t start_lsa) {
          * another image's functions that happen to share an LS address. */
         if (ctx->image_id >= 0 && spu_lifted_lookup(ctx, ctx->pc)) { g_spu_interp_steps = steps; g_spu_interp_last_pc = ctx->pc; return ctx->pc; }  /* rejoin fast path */
         g_spu_interp_last_pc = ctx->pc;
+        if (_g1>0) {
+            int inr = (ctx->pc >= 0x26E80u && ctx->pc < 0x26F14u);
+            if (inr) { _g1in = 1; }
+            else if (_g1in) {
+                _g1in = 0;
+                #define GLB(o) (((uint32_t)ctx->ls[(o)]<<24)|((uint32_t)ctx->ls[(o)+1]<<16)|((uint32_t)ctx->ls[(o)+2]<<8)|ctx->ls[(o)+3])
+                fprintf(stderr,"[gate1] func_00026E80 ret r3=%08X | LS2FB0=%08X LS2FB4=%08X LS2FB8=%08X | LS1E0=%08X LS1E4=%08X LS1E8=%08X | r1=%05X r29=%08X r32=%08X r16=%08X r22=%08X r8=%08X r6=%08X\n",
+                    ctx->gpr[3]._u32[0], GLB(0x2FB0),GLB(0x2FB4),GLB(0x2FB8), GLB(0x1E0),GLB(0x1E4),GLB(0x1E8),
+                    ctx->gpr[1]._u32[0], ctx->gpr[29]._u32[0], ctx->gpr[32]._u32[0],
+                    ctx->gpr[16]._u32[0], ctx->gpr[22]._u32[0], ctx->gpr[8]._u32[0], ctx->gpr[6]._u32[0]);
+                #undef GLB
+                fflush(stderr); _g1--;
+            }
+        }
         if (_tr>0) { ring[rc&63]=ctx->pc; rc++; if(rn<64)rn++; }
         steps++;
         /* YDKJ_SPU_STEPCAP=N: a task that never halts (infinite work/wait loop) never

--- a/runtime/spu/spu_lifted_job.h
+++ b/runtime/spu/spu_lifted_job.h
@@ -136,10 +136,29 @@ static inline int32_t spu_run_lifted_job_abi(spu_lifted_entry_fn entry,
     int taskset_ctx = (_LB(0x27C4) == 0xA70u);
     if (spurs_task_abi) {
         if (r3_override) {
-            ctx.gpr[3]._u32[0] = r3_override[0];   /* 0x40-marker handle      */
-            ctx.gpr[3]._u32[1] = args_ea;          /* eaContext (DMA'd first) */
-            ctx.gpr[3]._u32[2] = r3_override[2];   /* queue/lock EA           */
+            /* Pass the game's own CellSpursTaskArgument through UNCHANGED.
+             *
+             * Word 1 used to be overwritten with args_ea, the eaContext this
+             * runtime's HLE task-attribute handler had recorded. That is the
+             * word the task DMAs its 64-byte context from (func_00003ED8 puts
+             * it in MFC_EAL), and the substituted address is a PPU STACK
+             * temporary: by the third task the frame has already been recycled,
+             * so the task DMAs stack junk and decodes garbage.
+             *
+             * The game's own word 1 is the task's persistent control block --
+             * 0x006B4500 / 0x006B4780 / 0x006B4A00 for the three cri decode
+             * tasks. Those are load-bearing: the PPU waits on control+0x100
+             * (0x006B4600 / 0x006B4880 / 0x006B4B00), which is exactly the flag
+             * the task is supposed to set when a work cycle completes. Pointing
+             * the task at a different context is why it never sets it.
+             *
+             * A substituted eaContext remains the fallback below, for a task
+             * whose real argument this runtime never captured. */
+            ctx.gpr[3]._u32[0] = r3_override[0];   /* 0x40-marker handle       */
+            ctx.gpr[3]._u32[1] = r3_override[1];   /* task control block EA    */
+            ctx.gpr[3]._u32[2] = r3_override[2];   /* queue/lock EA            */
             ctx.gpr[3]._u32[3] = r3_override[3];
+            if (!ctx.gpr[3]._u32[1]) ctx.gpr[3]._u32[1] = args_ea;
         } else if (image_id == 22) {
             /* cri_mpv leaf (func_00003E68) gate is `rotmai(r3.word0, 112) == 64`
              * = an ARITHMETIC RIGHT-SHIFT BY 16 then ceqi 64, i.e. it wants

--- a/runtime/spu/spu_workload.c
+++ b/runtime/spu/spu_workload.c
@@ -672,6 +672,16 @@ static void spu_async_run(spu_async_job* j)
                 ydkj_wake_all_event_flags();
                 fprintf(stderr, "[cri] YDKJ_CRI_WAKE: woke all event-flag waiters on cri completion\n");
             }
+            /* SPU_LS_DUMP=<prefix>: write this job's whole local store when it
+             * ends. A reference dump from real hardware is a full local store,
+             * so the only way to ask "what ELSE is different" -- rather than
+             * checking one guessed word at a time -- is to diff all 256 KB. */
+            { const char* pfx = getenv("SPU_LS_DUMP");
+              if (pfx) { char path[512];
+                  snprintf(path, sizeof path, "%s_img%d.bin", pfx, j->image_id);
+                  FILE* f = fopen(path, "wb");
+                  if (f) { fwrite(ls, 1, SPU_LS_SIZE, f); fclose(f);
+                      fprintf(stderr, "[spu_workload] wrote local store -> %s\n", path); } } }
             fprintf(stderr, "[spu_workload] async image=%d RETURNED rc=%d "
                     "(job ran to completion, did not loop)\n", j->image_id, rc);
             spu_serial_release();

--- a/runtime/spu/spu_workload.c
+++ b/runtime/spu/spu_workload.c
@@ -445,10 +445,40 @@ static void spu_async_run(spu_async_job* j)
                      * from the actual BE CellSpursTaskset (spurs ptr, args, TaskInfo)
                      * so the cri leaf reads valid data instead of my planted guesses. */
                     uint64_t elf = spurs_pm_build_context(ls, g_ydkj_real_taskset_ea, g_ydkj_real_taskid, 0, 0);
+                    /* --- Golden-reference context fields for the CRI task, recovered from a
+                     * WORKING RPCS3 SPU-LS snapshot via caner's rpcs3-guest-memory-dumper fork
+                     * (github.com/canersaka/rpcs3-guest-memory-dumper): YDKJ BLUS30569, SPU0
+                     * "CellSpursKernel0" mid-cri-decode. These are what the cri task's context
+                     * validator (func_00026E80/F18/FC4) reads; our values differed and tripped
+                     * its 0x80410911 error path. CRI-SCOPED (image 22 only) -- overriding these
+                     * in the shared build_context breaks the audio SPURS task. */
+                    LSBE32(0x2840, 0x53505552u); LSBE32(0x2844, 0x53544153u); /* moduleId "SPURSTASK MODULE" */
+                    LSBE32(0x2848, 0x4B204D4Fu); LSBE32(0x284C, 0x44554C45u);
+                    /* TI_LS_PATTERN = full-coverage (all-ones). The prior "golden fix"
+                     * set this to 0 from the decode-time RPCS3 LS dump, but that region
+                     * is post-validation (also zero) so it wasn't authoritative. Runtime
+                     * probe YDKJ_CRI_GATE1TRACE proved 0 makes the validator func_00026E80
+                     * return 0x8041090F (busy-spin poll); all-ones makes it return 0 -- the
+                     * task then passes and reaches the taskset-state getllar (func_00027028).
+                     * Verified by direct r3 read (YDKJ_G1_LSPAT=0xFFFFFFFF -> r3=0). */
+                    LSBE32(0x27A0, 0xFFFFFFFFu); LSBE32(0x27A4, 0xFFFFFFFFu);
+                    LSBE32(0x27A8, 0xFFFFFFFFu); LSBE32(0x27AC, 0xFFFFFFFFu);
+                    LSBE32(0x27D0, 0x1F);                       /* dmaTagId = 0x1F (build_context wrote 0) */
                     /* still plant the cri-specific task descriptor @0x2FB0 that build_context
                      * doesn't cover (cri func_00026DE0 reads it). */
                     LSBE32(0x2FB0, 0xFFFFFFFFu); LSBE32(0x2FB4, 0x400);
                     LSBE32(0x2FB8, 0x2700);      LSBE32(0x2FBC, 0x3000);
+                    /* GATE1 SWEEP (YDKJ_G1_*): the validator func_00026E80 reads the
+                     * TI_CONTEXT(0x2798)/TI_LS_PATTERN(0x27A0) region; YDKJ_CRI_GATE1TRACE
+                     * proved r16=rotqby(LS[0x2798],8)=0 forces its 0x8041090F return. The
+                     * decode-time RPCS3 dump has this region zero (post-validation), so it
+                     * can't be diffed -- sweep candidate values here and read the probe's
+                     * r3. Overrides the plants above so one build tests many values. */
+                    { const char* _e;
+                      if ((_e=getenv("YDKJ_G1_LSPAT"))) { uint32_t v=(uint32_t)strtoul(_e,0,0);
+                          LSBE32(0x27A0,v); LSBE32(0x27A4,v); LSBE32(0x27A8,v); LSBE32(0x27AC,v); }
+                      if ((_e=getenv("YDKJ_G1_CTX")))   { uint32_t v=(uint32_t)strtoul(_e,0,0);
+                          LSBE32(0x2798,v); LSBE32(0x279C,v); } }
                     fprintf(stderr, "[cri] REAL SpursTasksetContext built from taskset 0x%08X task %u (elf=0x%llX)\n",
                             g_ydkj_real_taskset_ea, g_ydkj_real_taskid, (unsigned long long)elf);
                 } else {

--- a/runtime/syscalls/lv2_register.c
+++ b/runtime/syscalls/lv2_register.c
@@ -275,6 +275,7 @@ typedef struct {
     uint32_t args_ea;
     uint32_t args_size;
     uint32_t img_ea;         /* sys_spu_image descriptor EA (for LS segment load) */
+    uint64_t spu_cfg;        /* sys_spu_thread_{set,get}_spu_cfg */
     /* Async fallback execution. host_thread is set when group_start spawned
      * a host thread for this SPU thread's PPU fallback; finish_event is
      * signalled when the handler returns; running indicates the thread is
@@ -1566,6 +1567,41 @@ static int64_t sys_spu_image_open_handler(ppu_context* ctx)
 }
 
 /* Catch-all stub for SPU syscalls we don't model individually yet. */
+/* sys_spu_thread_{set,get}_spu_cfg -- the SPU's signal-notification config
+ * word. Both were stubs, which means set() dropped the value and get() handed
+ * back whatever the stub returns; a title that writes a config and reads it
+ * back to confirm sees a mismatch. Virtua Fighter 5 calls both, once each,
+ * exactly as its "SPU Delegate" group starts.
+ *
+ * There is nothing to configure on our side -- the lifted SPU code does not
+ * consult it -- so this is storage, per thread, which is all the ABI promises
+ * the caller. */
+extern void vm_write64(uint64_t a, uint64_t v);
+
+static int64_t sys_spu_thread_set_spu_cfg(ppu_context* ctx)
+{
+    uint32_t tid = (uint32_t)ctx->gpr[3];
+    uint64_t val = ctx->gpr[4];
+    for (int i = 0; i < MAX_SPU_THREADS; i++)
+        if (s_spu_threads[i].in_use && s_spu_threads[i].tid == tid) {
+            s_spu_threads[i].spu_cfg = val;
+            return CELL_OK;
+        }
+    return (int64_t)(int32_t)CELL_ESRCH;
+}
+
+static int64_t sys_spu_thread_get_spu_cfg(ppu_context* ctx)
+{
+    uint32_t tid    = (uint32_t)ctx->gpr[3];
+    uint32_t out_ea = (uint32_t)ctx->gpr[4];
+    for (int i = 0; i < MAX_SPU_THREADS; i++)
+        if (s_spu_threads[i].in_use && s_spu_threads[i].tid == tid) {
+            if (out_ea) vm_write64(out_ea, s_spu_threads[i].spu_cfg);
+            return CELL_OK;
+        }
+    return (int64_t)(int32_t)CELL_ESRCH;
+}
+
 static int64_t sys_spu_thread_stub(ppu_context* ctx)
 {
     (void)ctx;
@@ -1641,6 +1677,8 @@ void lv2_register_all_syscalls(lv2_syscall_table* tbl)
     lv2_syscall_register(tbl, SYS_SPU_THREAD_WRITE_LS,        sys_spu_thread_write_ls_handler);
     lv2_syscall_register(tbl, SYS_SPU_THREAD_READ_LS,         sys_spu_thread_read_ls_handler);
     lv2_syscall_register(tbl, SYS_SPU_THREAD_WRITE_SNR,       sys_spu_thread_stub);
+    lv2_syscall_register(tbl, SYS_SPU_THREAD_SET_SPU_CFG,     sys_spu_thread_set_spu_cfg);
+    lv2_syscall_register(tbl, SYS_SPU_THREAD_GET_SPU_CFG,     sys_spu_thread_get_spu_cfg);
     lv2_syscall_register(tbl, SYS_SPU_THREAD_BIND_QUEUE,      sys_spu_thread_stub);
     lv2_syscall_register(tbl, SYS_SPU_THREAD_UNBIND_QUEUE,    sys_spu_thread_stub);
     lv2_syscall_register(tbl, SYS_SPU_THREAD_GROUP_CONNECT_EVENT_ALL_THREADS, sys_spu_thread_group_connect_event_handler);

--- a/runtime/syscalls/lv2_register.c
+++ b/runtime/syscalls/lv2_register.c
@@ -25,10 +25,12 @@
 #include "sys_fs.h"
 #include "ps3emu/spu_fallback.h"
 #include "../spu/spu_lifted_job.h"   /* spu_run_interp_job — run un-lifted SPU images */
+#include "../spu/spu_workload.h"   /* the content-fingerprint registry */
 #include "sys_event.h"
 
 #include <stdio.h>
-#include <string.h>
+#include <string.h>
+
 #include "../platform/win32_compat.h"   /* QueryPerformanceCounter shim for the SPU_SPEED timing */
 
 /* ---------------------------------------------------------------------------
@@ -56,6 +58,40 @@ static int64_t sys_tty_write(ppu_context* ctx)
         /* Write guest string data to host stderr */
         fwrite(vm_base + buf_ea, 1, len, stderr);
         fflush(stderr);
+        /* TTY_BT=<substring>: dump the guest LR back-chain whenever the title
+         * prints a line containing it. The two hooks below do exactly this for
+         * one hardcoded string each, which only ever helped the title they were
+         * written for. A title's own error message is the cheapest breakpoint
+         * there is -- it fires exactly when the thing went wrong, in the thread
+         * it went wrong on -- so make it a knob rather than an edit.
+         *
+         * Virtua Fighter 5: TTY_BT="Command Buffer Overflow" names the AMGL
+         * function whose free-space check is failing. */
+        { static const char* pat = (const char*)1;
+          if (pat == (const char*)1) pat = getenv("TTY_BT");
+          if (pat && *pat && len < 4096) {
+              char tmp[512]; uint32_t n = len < 511 ? len : 511;
+              memcpy(tmp, vm_base + buf_ea, n); tmp[n] = 0;
+              if (strstr(tmp, pat)) {
+                  static int _n = 0;
+                  if (_n++ < 4) {
+                      uint32_t sp = (uint32_t)ctx->gpr[1];
+                      fprintf(stderr, "[TTY_BT] \"%.70s\" tid=%llu cia=0x%08X lr=0x%08X chain:",
+                              tmp, (unsigned long long)ctx->thread_id,
+                              (uint32_t)ctx->cia, (uint32_t)ctx->lr);
+                      for (int i = 0; i < 24 && sp && sp < 0x10000000u; i++) {
+                          uint32_t nsp; memcpy(&nsp, vm_base + sp, 4);
+                          nsp = ((nsp>>24)&0xFF)|((nsp>>8)&0xFF00)|((nsp<<8)&0xFF0000)|((nsp<<24)&0xFF000000);
+                          if (nsp <= sp || nsp >= 0x10000000u) break;
+                          uint32_t lr; memcpy(&lr, vm_base + nsp + 0x10, 4);
+                          lr = ((lr>>24)&0xFF)|((lr>>8)&0xFF00)|((lr<<8)&0xFF0000)|((lr<<24)&0xFF000000);
+                          fprintf(stderr, " %08X", lr); sp = nsp;
+                      }
+                      fprintf(stderr, "\n"); fflush(stderr);
+                  }
+              }
+          } }
+
         /* CRI error back-chain (YDKJ_CRIBT=1): dump the guest LR chain when a CRI
          * null-pointer / criFs error is printed, to locate the failing call. */
         if (getenv("YDKJ_CRIBT") && len < 4096) {
@@ -784,6 +820,33 @@ static int64_t sys_spu_thread_group_start_handler(ppu_context* ctx)
         if (!t->in_use) continue;
         void* user = NULL;
         spu_ppu_fallback_fn fb = spu_lookup_ppu_fallback(t->entry_point, &user);
+        /* No fallback by entry point -- ask the WORKLOAD registry, which is
+         * keyed by the image's content fingerprint and is what
+         * build_spu_workloads.py populates. The two registries have always both
+         * existed; only the SPURS path consulted this one, so a title driving
+         * plain SPU thread groups never ran a line of its lifted SPU code. */
+        if (!fb && t->img_ea && vm_base) {
+            extern uint32_t ps3_spu_image_source_ea(uint32_t img_ea);
+            extern int32_t spu_registry_fallback(uint32_t, uint32_t, uint32_t, void*);
+            uint32_t src = ps3_spu_image_source_ea(t->img_ea);
+            size_t isz = src ? spu_elf_image_size(vm_base + src, 1u << 20) : 0;
+            if (isz) {
+                uint64_t fp = spu_workload_fingerprint(vm_base + src, isz);
+                int iid = 0;
+                if (spu_workload_find_img(fp, &iid)) {
+                    fb = spu_registry_fallback;
+                    user = (void*)(uintptr_t)fp;
+                    fprintf(stderr, "[SPU] thread tid=0x%X image @0x%08X (%u bytes) "
+                            "matched lifted workload fp=0x%016llX image_id=%d\n",
+                            t->tid, src, (unsigned)isz,
+                            (unsigned long long)fp, iid);
+                } else {
+                    fprintf(stderr, "[SPU] thread tid=0x%X image @0x%08X (%u bytes) "
+                            "fp=0x%016llX is NOT in the workload registry\n",
+                            t->tid, src, (unsigned)isz, (unsigned long long)fp);
+                }
+            }
+        }
         if (!fb && getenv("RD_SPU_INTERP") && t->img_ea) {
             /* No lifted fallback: interpret the image instead of instant-
              * completing. Additive + env-gated so it can't destabilize titles

--- a/runtime/syscalls/spu_lifted_fallback.c
+++ b/runtime/syscalls/spu_lifted_fallback.c
@@ -12,6 +12,7 @@
  * the flOw SPU integration needs (feed lifted jobs as task bodies).
  */
 #include "../spu/spu_lifted_job.h"
+#include "../spu/spu_workload.h"
 #include <stdint.h>
 
 /* defined in lv2_register.c — the SPU thread's 256 KB local store */
@@ -24,3 +25,25 @@ int32_t spu_lifted_fallback(uint32_t tid, uint32_t args_ea,
     return spu_run_lifted_job((spu_lifted_entry_fn)user,
                               spu_thread_get_local_store(tid), args_ea);
 }
+
+/* As above, but the lifted entry is found at run time by CONTENT FINGERPRINT
+ * rather than by image entry point. Two registries existed and the raw
+ * sys_spu_thread_group path only ever consulted the entry-point one, so a title
+ * that starts a plain SPU thread group -- Virtua Fighter 5's "CriSr thread
+ * group", and it imports no cellSpurs at all -- reported "no fallback" with its
+ * image lifted and registered the whole time.
+ *
+ * `user` carries the fingerprint. spurs_task_abi is 0: a raw SPU thread is
+ * entered with its argument EA in r3, not the SPURS task descriptor. */
+int32_t spu_registry_fallback(uint32_t tid, uint32_t args_ea,
+                              uint32_t args_size, void* user)
+{
+    (void)args_size;
+    int image_id = 0;
+    spu_lifted_entry_fn fn =
+        spu_workload_find_img((uint64_t)(uintptr_t)user, &image_id);
+    if (!fn) return -1;
+    return spu_run_lifted_job_abi(fn, spu_thread_get_local_store(tid), args_ea,
+                                  image_id, 0, NULL);
+}
+

--- a/runtime/syscalls/sys_event.c
+++ b/runtime/syscalls/sys_event.c
@@ -309,6 +309,25 @@ int64_t sys_event_queue_receive(ppu_context* ctx)
         }
     }
 
+    /* WAITBT_EVERY=<n>: the same dump, but every nth wait per (tid,queue)
+     * instead of once. The one-shot above names where a thread FIRST parks,
+     * which is a boot-time answer; when a title runs for a while and then stops
+     * doing something, the question is where it is parked at the END, and the
+     * last dump in the log answers that. */
+    { static int every = -1;
+      if (every < 0) { const char* e = getenv("WAITBT_EVERY"); every = e ? atoi(e) : 0; }
+      if (every > 0) {
+          static unsigned n[8][8] = {{0}};
+          unsigned t = (unsigned)ctx->thread_id & 7, qk = queue_id & 7;
+          if ((n[t][qk]++ % (unsigned)every) == 0) {
+              extern void ppu_dump_guest_stack(ppu_context*, const char*);
+              char tag[64];
+              snprintf(tag, sizeof tag, "wait#%u tid=%u q=%u",
+                       n[t][qk] - 1u, t, queue_id);
+              ppu_dump_guest_stack(ctx, tag);
+          }
+      } }
+
     if (queue_id == 0 || queue_id > SYS_EVENT_QUEUE_MAX)
         return (int64_t)(int32_t)CELL_ESRCH;
 

--- a/runtime/syscalls/sys_event.c
+++ b/runtime/syscalls/sys_event.c
@@ -753,6 +753,7 @@ int64_t sys_event_port_connect_local(ppu_context* ctx)
         return (int64_t)(int32_t)CELL_ESRCH;
     if (queue_id == 0 || queue_id > SYS_EVENT_QUEUE_MAX)
         return (int64_t)(int32_t)CELL_ESRCH;
+    fprintf(stderr, "[evt] port_connect(port=%u -> queue=%u)\n", port_id, queue_id);
 
     evt_table_lock();
 

--- a/tools/find_spu_functions.py
+++ b/tools/find_spu_functions.py
@@ -117,7 +117,13 @@ def read_symbols(buf, shs):
             continue
         strtab = shs[sh["link"]] if 0 <= sh["link"] < len(shs) else None
         strbuf = buf[strtab["off"]:strtab["off"] + strtab["size"]] if strtab else b""
-        for i in range(sh["size"] // sh["entsize"]):
+        if sh["entsize"] <= 0:
+            continue
+        # An image carved out of a bigger binary (extract_spu_images.py sizes it
+        # by the PT_LOAD / section-table extent) can carry a symtab header whose
+        # data runs past the carved bytes. Truncate to what we actually have.
+        avail = max(0, len(buf) - sh["off"]) // sh["entsize"]
+        for i in range(min(sh["size"] // sh["entsize"], avail)):
             off = sh["off"] + i * sh["entsize"]
             st_name, st_value, st_size, st_info, st_other, st_shndx = \
                 struct.unpack_from(">IIIBBH", buf, off)

--- a/tools/nid_database.py
+++ b/tools/nid_database.py
@@ -340,6 +340,13 @@ _BUILTIN_FUNCTIONS: list[tuple[str, str]] = [
     ("sysPrxForUser", "sys_lwcond_create"),
     ("sysPrxForUser", "sys_lwcond_destroy"),
     ("sysPrxForUser", "sys_lwcond_wait"),
+    # Recovered by brute-forcing compute_nid() over the sysPrxForUser export
+    # list against Virtua Fighter 5's imports (0x8C2BB498 / 0x722A0254 /
+    # 0x5267CB35 were unresolved in every title until then).
+    ("sysPrxForUser", "sys_spinlock_initialize"),
+    ("sysPrxForUser", "sys_spinlock_lock"),
+    ("sysPrxForUser", "sys_spinlock_trylock"),
+    ("sysPrxForUser", "sys_spinlock_unlock"),
     ("sysPrxForUser", "sys_lwcond_signal"),
     ("sysPrxForUser", "sys_lwcond_signal_all"),
     ("sysPrxForUser", "sys_mutex_create"),


### PR DESCRIPTION
Everything here came out of bringing up a new port (Virtua Fighter 5, BLUS30020) on the shared harness. Each fix is title-agnostic; VF5 was just the title small enough — 107 imports across 10 modules, no PSN, no cellSpurs — that every gap was load-bearing.

Based on `feat/rsx-live-draw`. The branch also carries commits from parallel sessions on the same local branch (`fs:`, `input:`, `spu:` prefixes) — they are not from this work and are included only because the branch was shared.

## Correctness

**`find_spu_functions`: `read_symbols` unpacked past the end of the buffer.** An image carved out of a bigger binary (`extract_spu_images.py` sizes it by the PT_LOAD / section-table extent) can carry a symtab header whose data runs past the carved bytes. Crashed the lift of one of VF5's four SPU images.

**Raw SPU thread groups never consulted the workload registry.** Two registries have always existed: `build_spu_workloads.py` registers lifted images by FNV-1a-64 content fingerprint, which the cellSpurs path looks up; `sys_spu_thread_group_start` only ever called `spu_lookup_ppu_fallback(entry_point)`. A title driving plain SPU thread groups reported "no fallback" with its images lifted and registered the whole time. `_sys_spu_image_import` now records which ELF each descriptor was parsed from, so the raw path can fingerprint it.

**`cellMsgDialog` answered before `Open` returned.** The callback fired synchronously from inside the open call; hardware delivers it from the title's own `cellSysutilCheckCallback`. A title that arms its wait state *after* the call loses the answer:

```
state = WAITING;
cellMsgDialogOpen(..., cb, &state);   // our cb set state = DONE, here
state = WAITING;                      // ...overwritten
```

VF5 does exactly that. Deferred, files opened in the same 55 s went from 20 to 123.

**Six pre-3.00 entry points were unregistered** — only their `2` forms existed, so a title on the older API got the unresolved-NID default: `cellMsgDialogOpen`, `cellGameDataCheckCreate`, `cellSaveDataListSave` / `ListLoad` / `FixedSave` / `FixedLoad`. All were unnamed in the database; NIDs recovered by brute-forcing `compute_nid` over each API's export list, and added to `nid_database.py`.

**All four `cellSaveData` List/Fixed paths called the guest callback as a host function pointer** — `funcList(&cbResult, &listGet, &listSet)`. An immediate access violation the first time a title reaches one, with `rip` == the guest OPD. Nothing had ever reached one.

**`cellResc` never flipped.** `SetConvertAndFlip` incremented a counter and returned `CELL_OK`; both handler setters stored a guest OPD in a host function pointer. A title presenting through RESC had no way to retire a frame.

**`cellGcmSetDefaultCommandBuffer` did not re-point `gCellGcmCurrentContext`.** A title calling it to return to the default buffer stayed on whatever smaller segment it had switched to and overflowed it. VF5 calls it 634 times; with `GCM_DEFAULT_CTX_REPOINT=1` its overflow count goes 88,000 → 0. Opt-in, because it rewrites a guest variable behind the title's back.

**`sys_spinlock_initialize` / `_lock` / `_trylock` / `_unlock`**, the whole `_sys_heap_*` family (every function existed under a name without the leading underscore, so the generator hashed NIDs nothing imports), `cellAudioGetPortBlockTag`, `cellAudioOutGetState`, and lv2 187/188 (`sys_spu_thread_{set,get}_spu_cfg`).

**`_sys_heap_*` got a real allocator** — size-binned free lists instead of a bump pointer with a no-op free.

**The page guard reported itself as the title's bug.** `ppu_guard_veh` logs with `fprintf`; guarding a page the process touches while logging recurses into the handler forever, surfacing as a `[STACKOVERFLOW]` whose backtrace is a `ppu_guard_veh` / `fprintf` cycle.

**The HLE sampler printed `tid&7`.** Threads 1, 9 and 17 collide, so a stack from a CRI worker read exactly like one from the main thread. That produced three wrong readings in a row before it was found.

**A repeating TTY line is now collapsed.** A title logging an error from a retry loop prints it thousands of times a second, each an unbuffered `fwrite`+`fflush` on the guest thread. VF5 emitted one message 88,000 times; collapsing it took 30% off the boot.

## Diagnostics (all off by default)

| | |
|---|---|
| `TTY_BT=<substring>` | dump the call chain when the guest prints a matching line — a title's own error message is the cheapest breakpoint there is. Replaces three hardcoded one-string hooks. |
| `GCM_CTXDBG=1` | report `gCellGcmCurrentContext` and its begin/end/current/callback |
| `GCM_FIFO_SNAP=N` | the raw words at *both* ends of the ring |
| `GCM_FLIPCOUNT=1` | every flip with a timestamp (`FLIP_DBG` caps at 20) |
| `GCM_FLIP_BT=<n>` | the flipping thread's guest stack for flips n±5 |
| `GCM_GET_EQ_PUT=1` | publish `get` as fully drained — answers "is the title reading `get`?" |
| `LD_FRAME_DUMP=<dir>` | read back the presented surface while the title runs; `PrintWindow` returns white for a D3D12 swapchain |
| `BCTRL_RING=<file>` | last 512 indirect-call targets per thread — the only way to map a render path built from vtables |
| `HLE_BT_EVERY=<n>` / `WAITBT_EVERY=<n>` | guest-stack samplers that follow a thread while it is busy, not only while it blocks |
| `PPU_KEEP_EA` / `PPU_POKE` / `PPU_POKE8` / `PPU_POKE_AFTER_MS` | hold a guest range or word at a value, optionally after a delay — probes, labelled as such |
| `MSGDIALOG_ANSWER=no` | answer yes/no prompts NO instead of YES |
| `[DRAINEND] <reason>` | under `GCM_DRAINDBG`, why each FIFO pass stopped, with every break site tagged |

## Also

Two FIFO walker rules, both no-ops for a title that keeps up: stop honouring one-flip-per-drain past a 64 KB backlog, and recycle a title's own ring when its buffer-full callback will not (AMGL's only prints and returns 0, which libgcm reads as "retry", so the title writes past `end`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QSmibUDiiKuZ6YrTbxvTiY