### PR TITLE
spu: GETLLAR must snapshot the reservation from local store, not re-read memory

### DIFF
--- a/runtime/spu/spu_channels.c
+++ b/runtime/spu/spu_channels.c
@@ -406,7 +406,17 @@ static int spu_mfc_atomic(spu_context* ctx, uint32_t cmd)
         yz_lockstep_tick(ctx);
         resv_lock();
         memcpy(ls, mem, MFC_ATOMIC_LINE);              /* line -> local store */
-        memcpy(ctx->resv_line, mem, MFC_ATOMIC_LINE);  /* snapshot for compare */
+        /* Snapshot from `ls`, NOT a second read of `mem`. Hardware GETLLAR is a
+         * single atomic 128-byte read, so the reserved data and the reservation
+         * come from the same instant. Reading guest memory twice lets a PPU store
+         * land between them, leaving the SPU a STALE line and a FRESH snapshot --
+         * and then both halves of the wait fail: the SPU compares its stale copy,
+         * sees produced == consumed and sleeps on MFC_LLR_LOST_EVENT, while the
+         * reservation poll compares memory against a snapshot that already holds
+         * the new value, finds no difference, and never raises the event. Nobody
+         * wakes anybody. Snapshotting from `ls` makes a later store leave BOTH
+         * stale, which is exactly what makes the lost-reservation event fire. */
+        memcpy(ctx->resv_line, ls, MFC_ATOMIC_LINE);   /* snapshot for compare */
         ctx->resv_ea = ea; ctx->resv_valid = 1; ctx->atomic_stat = 0;
         resv_unlock();
         return 1;


### PR DESCRIPTION
```diff
-   memcpy(ctx->resv_line, mem, MFC_ATOMIC_LINE);
+   memcpy(ctx->resv_line, ls,  MFC_ATOMIC_LINE);
```

GETLLAR read guest memory **twice** — once into the SPU's local store, once into the reservation snapshot. A PPU store landing between the two reads gives the SPU a **stale line** and a **fresh snapshot**, and then both halves of the wait fail:

- the SPU compares its stale copy, finds `produced == consumed`, decides there is nothing to do, and sleeps on `MFC_LLR_LOST_EVENT`
- the reservation poll compares memory against the snapshot — which *already holds the new value* — finds no difference, and never raises the event

Nobody wakes anybody. The SPU is stalled permanently.

Hardware cannot reach that state: GETLLAR is a single atomic 128-byte read, so the reserved data and the reservation come from the same instant. Snapshotting from `ls` restores the property — a store that lands after the read now leaves **both** stale, which is exactly what makes the lost-reservation event fire.

## Evidence

Found on the PS1-emulator port, where it froze roughly **one run in three** at no consistent point (13.6M, 61.8M, 893M, 1.5G, 2.36G instructions). At a caught freeze the SPU's local-store copy read `0x9E` while the reservation snapshot read `0x9F` — one item apart, the signature of a single lost update rather than a lost wake.

Before: a stalled run gives 18 heartbeats with 2–3 distinct instruction totals — a plateau.
After: 23 heartbeats, 23 distinct totals, ~14 MIPS sustained.

## Why not a cherry-pick

The origin commit (`5aa6e0f`) also carries `SPU_LLARWATCH`/`SPU_WATCHLSA` diagnostics and unrelated branch context across four files, and does not apply to master. This is the one-line fix on its own, re-applied to master; the runtime library builds clean.

This affects **any** title with a PPU/SPU producer-consumer queue over atomics, not just the port that found it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g73rkhLETZBjZ7rG8Sw2h