### PR TITLE
spu: fix xswd — it read the wrong words and stored the halves backwards

### DIFF
--- a/runtime/spu/spu_helpers.h
+++ b/runtime/spu/spu_helpers.h
@@ -360,7 +360,27 @@ static inline u128 spu_frest(u128 a){ u128 r; for(int i=0;i<4;i++) r._f32[i]= 1.
  * at the *lower* storage address). Same caveat as the mpy family. */
 static inline u128 spu_xsbh(u128 a) { u128 r; for(int i=0;i<8;i++) r._s16[i] = (int8_t)a._u8[2*i]; return r; }
 static inline u128 spu_xshw(u128 a) { u128 r; for(int i=0;i<4;i++) r._s32[i] = (int16_t)a._s16[2*i]; return r; }
-static inline u128 spu_xswd(u128 a) { u128 r; for(int i=0;i<2;i++) r._s64[i] = (int32_t)a._s32[2*i]; return r; }
+/* xswd: sign-extend each SPU word 1 and 3 into a doubleword.
+ *
+ * SPU word 0 is _u32[0], so the SOURCE words are the ODD indices, and the
+ * result must be written as two u32 halves -- writing through _s64 puts the
+ * halves the wrong way round, because _s64 is host-little-endian while the
+ * quadword lanes are big-endian. The old form did both wrongly at once
+ * (reading the EVEN words and storing via _s64), which cancelled only for
+ * values whose two halves happen to be equal -- so small positive values came
+ * out as ZERO and everything derived from them silently collapsed.
+ *
+ * xsbh/xshw look like this too but are correct: their source and destination
+ * swaps cancel. Nothing cancels here, because words are not reversed. */
+static inline u128 spu_xswd(u128 a) {
+    u128 r;
+    for (int d = 0; d < 2; d++) {
+        int32_t v = (int32_t)a._u32[2*d + 1];
+        r._u32[2*d]     = (uint32_t)(v >> 31);   /* sign fill (high word) */
+        r._u32[2*d + 1] = (uint32_t)v;           /* value      (low word) */
+    }
+    return r;
+}
 
 /* ---- Phase 3: OR across ---- */
 static inline u128 spu_orx(u128 a) {

--- a/runtime/spu/tests/spu_xswd_test.c
+++ b/runtime/spu/tests/spu_xswd_test.c
@@ -1,0 +1,31 @@
+/* Standalone check of spu_xswd: sign-extend SPU words 1 and 3 to doublewords.
+ * SPU word N lives at _u32[N]; a doubleword result is (high,low) = (_u32[2d], _u32[2d+1]). */
+#include <stdio.h>
+#include <stdint.h>
+#include "../spu_helpers.h"
+
+static int fails = 0;
+static void check(const char* name, uint32_t w1, uint32_t w3,
+                  uint32_t eh0, uint32_t el0, uint32_t eh1, uint32_t el1)
+{
+    u128 a; for (int i = 0; i < 4; i++) a._u32[i] = 0xDEADBEEF;
+    a._u32[1] = w1; a._u32[3] = w3;
+    u128 r = spu_xswd(a);
+    int ok = r._u32[0]==eh0 && r._u32[1]==el0 && r._u32[2]==eh1 && r._u32[3]==el1;
+    printf("  %-28s %08X %08X %08X %08X   %s\n", name,
+           r._u32[0], r._u32[1], r._u32[2], r._u32[3], ok ? "ok" : "FAIL");
+    if (!ok) { printf("      expected %08X %08X %08X %08X\n", eh0, el0, eh1, el1); fails++; }
+}
+
+int main(void)
+{
+    printf("spu_xswd:\n");
+    /* the case that was silently returning zero */
+    check("small positive (1, 2)",      1u, 2u,          0u, 1u,          0u, 2u);
+    check("larger positive",            0x00001234u, 0x0000ABCDu, 0u, 0x00001234u, 0u, 0x0000ABCDu);
+    check("negative sign-extends",      0xFFFFFFFFu, 0x80000000u, 0xFFFFFFFFu, 0xFFFFFFFFu, 0xFFFFFFFFu, 0x80000000u);
+    check("zero",                       0u, 0u,          0u, 0u,          0u, 0u);
+    check("max positive int32",         0x7FFFFFFFu, 0x00000001u, 0u, 0x7FFFFFFFu, 0u, 1u);
+    printf(fails ? "FAILED %d\n" : "all passed\n", fails);
+    return fails != 0;
+}


### PR DESCRIPTION
`xswd` sign-extends SPU words 1 and 3 into doublewords. SPU word N lives at `_u32[N]`, so the **source words are the odd indices**, and the result must be written as two `u32` halves — storing through `_s64` puts them the wrong way round, because `_s64` is host-little-endian while the quadword lanes are big-endian.

The old form did both wrongly at once:

```c
r._s64[i] = (int32_t)a._s32[2*i];
```

reading the **even** words and storing via `_s64`. The two errors cancel only for values whose halves happen to be equal — so **small positive values came out as zero** and everything derived from them silently collapsed. Nothing crashes; the SPU just computes the wrong thing.

`xsbh` and `xshw` look like this too and are correct: their source and destination swaps genuinely cancel. Nothing cancels for `xswd`, because words are not reversed.

## Impact

Found on You Don't Know Jack, where this single intrinsic was the whole reason the title deadlocked on a black screen. Fixing it cleared a guest assert and both blocking waits, took draw groups from **24k → 485k**, textures **1 → 9**, and turned the boot into a live navigable menu. It affects **any** SPU code that uses `xswd`.

## Test

`runtime/spu/tests/spu_xswd_test.c` — standalone, five cases, no SDK compiler needed:

```
clang-cl -D_CRT_SECURE_NO_WARNINGS runtime/spu/tests/spu_xswd_test.c
```

Verified it **fails against the old implementation** (all five cases return the `0xDEADBEEF` filler, because the words being read are the wrong ones) and passes against this one.

## Context

Folded back from `ydkj-live-draw`, where it had been sitting unmerged. Master still had the broken version — which is why YDKJ builds against master but cannot reach its menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g73rkhLETZBjZ7rG8Sw2h