### PR TITLE
cellSail: report async call completion to the title's event handler

### DIFF
--- a/libs/codec/cellSail.c
+++ b/libs/codec/cellSail.c
@@ -7,6 +7,7 @@
  * initial recompilation testing.
  */
 
+#include "ps3emu/guest_call.h"
 #include "cellSail.h"
 #include "../../runtime/ppu/ppu_memory.h"   /* vm_read32 / vm_write32 */
 #include <stdio.h>
@@ -113,6 +114,24 @@ s32 cellSailPlayerDestroy(CellSailPlayerHandle handle)
     return CELL_OK;
 }
 
+/* CellSailEvent is {be32 major; be32 minor} -- one 64-bit register, major in
+ * the high half. Async player calls report completion as major=2
+ * (CALL_COMPLETED) with minor = the CellSailPlayerCall id that finished; a
+ * title that drives SAIL asynchronously blocks until its handler sees that.
+ * We run every call synchronously, so notify right after each one. */
+#define SAIL_EV_CALL_COMPLETED 2
+enum { SAIL_CALL_BOOT = 1, SAIL_CALL_OPEN_STREAM = 2, SAIL_CALL_CLOSE_STREAM = 3,
+       SAIL_CALL_START = 10, SAIL_CALL_STOP = 11 };
+
+static void sail_notify(int slot, u32 major, u32 minor, u64 arg0)
+{
+    if (slot < 0 || !g_ps3_guest_caller) return;
+    const u32 cb = s_sail_players[slot].callback_ea;
+    if (!cb) return;
+    g_ps3_guest_caller(cb, s_sail_players[slot].arg_ea,
+                       ((u64)major << 32) | minor, arg0, 0, 0, 0, 0, 0);
+}
+
 s32 cellSailPlayerBoot(CellSailPlayerHandle handle, u64 userParam)
 {
     (void)userParam;
@@ -121,6 +140,7 @@ s32 cellSailPlayerBoot(CellSailPlayerHandle handle, u64 userParam)
     if (_sp < 0)
         return (s32)CELL_SAIL_ERROR_INVALID_ARGUMENT;
     s_sail_players[_sp].state = CELL_SAIL_PLAYER_STATE_RUNNING;
+    sail_notify(_sp, SAIL_EV_CALL_COMPLETED, SAIL_CALL_BOOT, 0);
     return CELL_OK;
 }
 
@@ -132,6 +152,7 @@ s32 cellSailPlayerOpenStream(CellSailPlayerHandle handle, const char* path)
     if (_sp < 0)
         return (s32)CELL_SAIL_ERROR_INVALID_ARGUMENT;
     /* Stub: don't actually open anything */
+    sail_notify(_sp, SAIL_EV_CALL_COMPLETED, SAIL_CALL_OPEN_STREAM, 0);
     return CELL_OK;
 }
 
@@ -140,6 +161,7 @@ s32 cellSailPlayerCloseStream(CellSailPlayerHandle handle)
     const int _sp = sail_player_slot((u32)handle);
     if (_sp < 0)
         return (s32)CELL_SAIL_ERROR_INVALID_ARGUMENT;
+    sail_notify(_sp, SAIL_EV_CALL_COMPLETED, SAIL_CALL_CLOSE_STREAM, 0);
     return CELL_OK;
 }
 
@@ -152,6 +174,7 @@ s32 cellSailPlayerStart(CellSailPlayerHandle handle)
     s_sail_players[_sp].state = CELL_SAIL_PLAYER_STATE_RUNNING;
     /* Immediately signal finished since we don't play anything */
     s_sail_players[_sp].state = CELL_SAIL_PLAYER_STATE_FINISHED;
+    sail_notify(_sp, SAIL_EV_CALL_COMPLETED, SAIL_CALL_START, 0);
     return CELL_OK;
 }
 
@@ -162,6 +185,7 @@ s32 cellSailPlayerStop(CellSailPlayerHandle handle)
     if (_sp < 0)
         return (s32)CELL_SAIL_ERROR_INVALID_ARGUMENT;
     s_sail_players[_sp].state = CELL_SAIL_PLAYER_STATE_FINISHED;
+    sail_notify(_sp, SAIL_EV_CALL_COMPLETED, SAIL_CALL_STOP, 0);
     return CELL_OK;
 }
 


### PR DESCRIPTION
`cellSailPlayerInitialize2` hands us a guest callback. We stored it in `callback_ea` and never called it — before this change the only two references to that field in the whole file were its declaration and that one assignment.

A title that drives SAIL asynchronously waits on that callback and never gets it. Tokyo Jungle's boot thread polls a flag word its own handler would set, every millisecond, for the life of the process — the flags stay `0x00000000` across thousands of polls.

### What the event actually is

`CellSailEvent` is `{be32 major; be32 minor}` packed into one 64-bit register, major in the high half. Async call completion is `major=2` (CALL_COMPLETED) with `minor` = the `CellSailPlayerCall` id that finished.

This wasn't guessed from an enum — it was read off the title's own handler (`func_0018195C`), which dispatches on the high half of r4:

| major | minor | handler does |
|---|---|---|
| 2 | 1 (BOOT) | set bit `0x1` |
| 2 | 2 (OPEN_STREAM) | set bit `0x10` |
| 2 | 10 (START) | clear `0x10000`, set `0x100` |
| 2 | 11 (STOP) | clear `0x100` |

Bit `0x1` is what its boot wait blocks on.

### Change

Adds `sail_notify(slot, major, minor, arg0)` and calls it at the end of `Boot`, `OpenStream`, `CloseStream`, `Start` and `Stop`. Every player call here runs synchronously, so the notify goes right after the work.

### Verified

Tokyo Jungle, before: main thread polls forever, flags never leave 0.
After: the poll loop exits, the title proceeds through its boot sequence and reaches `cellSaveDataAutoLoad2`.

Stacked on #130 (`fix/cellsail-player-handle`) since it touches the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g73rkhLETZBjZ7rG8Sw2h