### PR TITLE
sysPrxForUser: implement sys_ppu_thread_once

### DIFF
--- a/libs/system/sysPrxForUser.c
+++ b/libs/system/sysPrxForUser.c
@@ -7,6 +7,7 @@
  */
 
 #include "sysPrxForUser.h"
+#include <ps3emu/guest_call.h>
 #include "../../runtime/ppu/ppu_memory.h"   /* vm_base, vm_write32: translate + byte-swap */
 #include <stdio.h>
 #include <stdarg.h>
@@ -422,6 +423,46 @@ s32 sys_lwmutex_create(sys_lwmutex_t_hle* lwmutex, const sys_lwmutex_attribute_t
     }
     slot_unlock();
     return CELL_EAGAIN;
+}
+
+/* sys_ppu_thread_once(once_ctrl, init)
+ *
+ * Runs `init` exactly once, the pthread_once of the lv2 user library. It was
+ * not implemented at all, so it fell through to the unresolved-NID handler,
+ * which returns CELL_OK -- success, without ever running the initialiser. Every
+ * subsystem that brings itself up this way was therefore left uninitialised
+ * while its caller was told the init had happened, and the failure only shows
+ * up later as a state error from the first call that needs it.
+ *
+ * Tokyo Jungle reaches its SPURS bring-up through one of these; with the
+ * initialiser skipped, the very next check returns CELL_ESTAT and the whole
+ * bring-up -- including the allocation of the buffer its loader reads into --
+ * is abandoned.
+ *
+ * `once_ctrl` is a guest word, zero before the first call (SYS_PPU_THREAD_ONCE_
+ * INIT). `init` is a function DESCRIPTOR, so it goes through the guest caller.
+ * ponytail: reuses the slot lock rather than a per-control one -- the call is
+ * rare and only ever contended at start-up. */
+
+s32 sys_ppu_thread_once(u32 once_ctrl_ea, u32 init_opd)
+{
+    if (!once_ctrl_ea)
+        return (s32)CELL_EINVAL;
+
+    slot_lock();
+    const int first = (vm_read32(once_ctrl_ea) == 0);
+    if (first)
+        vm_write32(once_ctrl_ea, 1);
+    slot_unlock();
+
+    if (first && init_opd && g_ps3_guest_caller) {
+        static int n = 0;
+        if (n++ < 8)
+            printf("[sysPrxForUser] sys_ppu_thread_once: running init 0x%08X"
+                   " (ctrl 0x%08X)\n", init_opd, once_ctrl_ea);
+        g_ps3_guest_caller(init_opd, 0, 0, 0, 0, 0, 0, 0, 0);
+    }
+    return CELL_OK;
 }
 
 s32 sys_lwmutex_lock(sys_lwmutex_t_hle* lwmutex, u64 timeout)


### PR DESCRIPTION
`sys_ppu_thread_once` had no implementation, so it fell through to the unresolved-NID handler — which returns `CELL_OK`.

That is the worst possible answer for this primitive: **the caller is told its one-time initialiser ran when it never did.** Every subsystem that brings itself up through the lv2 user library's `pthread_once` was left uninitialised while its caller believed otherwise, and the damage only surfaces later, as a state error from the first call that needs the initialised state.

### How it showed up

Tokyo Jungle reaches its SPURS bring-up through one of these. With the initialiser skipped, the next check returned `CELL_ESTAT` (0x8001000F) and the entire bring-up was abandoned — including the `memalign` that fills a global buffer pointer its loader later reads a file into, so that read went to NULL and walked over the title's own OPD table and TOC.

With this in place the title's audio actually comes up. Before: two files opened for the whole run. After:

```
tj_bus.sgd, 17_tj_menu1.sgd, 19_tj_menu3.sgd,
39_tj_ranking.sgd, 20_tj_result.sgd, 05_tj_stage02.sgd
```

### Notes

- `once_ctrl` is a guest word, zero before the first call (`SYS_PPU_THREAD_ONCE_INIT`).
- `init` is a function **descriptor**, so it is invoked through `g_ps3_guest_caller` rather than called directly.
- The NID (`0xA3E3BE68`) was already in `tools/nid_database.py` — it simply had no implementation to bind to, so `gen_hle_nids` never emitted a handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g73rkhLETZBjZ7rG8Sw2h