### PR TITLE
Make three first-port failures explain themselves

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,23 @@ if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
         -fno-strict-aliasing
     )
 elseif(MSVC)
+    # Real cl.exe -- clang-cl reports its id as Clang and is handled above.
+    #
+    # This does not currently build. The runtime and the lifted output use GCC/
+    # Clang builtins that cl has no equivalent for, and the failure lands as a
+    # wall of errors in whichever file the build happens to reach first rather
+    # than as anything that names the cause. Say it here instead.
+    message(WARNING
+        "Building with cl.exe (MSVC). This is not currently supported.\n"
+        "  The runtime uses __atomic_* builtins, __int128 and __builtin_bswap*, "
+        "and the lifted output uses __int128 for the PPC 64x64 multiplies. "
+        "cl has none of them.\n"
+        "  Use clang-cl instead -- it consumes the MSVC headers and libraries, "
+        "so nothing else about a Visual Studio build changes:\n"
+        "    cmake -S . -B build -G Ninja "
+        "-DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl\n"
+        "  See docs/BUILDING.md. Porting the intrinsics to cl is a welcome "
+        "contribution; nothing else stands in the way.")
     target_compile_options(ps3recomp_runtime PRIVATE
         /W3 /wd4100 /wd4244 /wd4267 /wd4996
         /Zc:__cplusplus

--- a/docs/GAME_PORTING_GUIDE.md
+++ b/docs/GAME_PORTING_GUIDE.md
@@ -227,6 +227,34 @@ python tools/spu_disasm.py spu_programs/spu_0.elf > spu_disasm/spu_0.txt
 # SPU lifter generates similar C output for each SPU program
 ```
 
+### HLE handler table
+
+Lifting produces the game's code. It does **not** produce the bridge from the
+game's firmware imports to this runtime's HLE implementations, and that is a
+separate generated file:
+
+```bash
+python tools/gen_hle_nids.py --all --out src/gen/ppu_hle_nids.cpp
+```
+
+Compile it into the port. It defines `ppu_hle_register_all()`, which
+`ppu_hle_init()` calls at startup. `runtime/ppu/ppu_hle.cpp` carries a **weak**
+do-nothing version, so leaving this out is not a link error — the port builds,
+starts, and then behaves as though every firmware import returned 0. The usual
+first symptom is an indirect call to something that is not an address:
+
+```
+[ppu] unresolved indirect call -> 0x39800000
+```
+
+`0x39800000` is the PowerPC instruction `li r12,0`, the first word of an import
+stub. The runtime prints a warning at startup when it finds no handlers
+registered, which names this directly.
+
+Regenerate it whenever you update ps3recomp: the table is generated from the
+toolkit's registered modules, so one built against a different revision can
+reference handlers this one does not have.
+
 ---
 
 ## Phase 6: Project Setup

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -120,16 +120,51 @@ python tools/post_lift.py --recomp-dir src/recomp/
 ```
 This renames `.c` → `.cpp`, patches the header, and applies the split-function fallthrough fix.
 
-### Step 6: Build the Recompiled Game
+### Step 6: Generate the HLE handler table
+
+Lifting produces the game's own code. It does **not** produce the bridge from
+the game's firmware imports to this runtime's HLE implementations — that is a
+separate generated file, and a port without it builds and starts and then fails
+in a way that does not name the cause:
+
+```
+[ppu] unresolved indirect call -> 0x39800000 (tid=1 lr=0x000103C0)
+```
+
+`0x39800000` is not an address, it is the PowerPC instruction `li r12,0` — the
+first word of an import stub. With no handlers registered, every firmware import
+falls through and the first call through one lands there.
+
+```bash
+python ../tools/gen_hle_nids.py --all --out src/gen/ppu_hle_nids.cpp
+```
+
+Compile the result into the port along with the lifted sources. It defines
+`ppu_hle_register_all()`, which `ppu_hle_init()` calls at startup;
+`runtime/ppu/ppu_hle.cpp` carries a weak do-nothing version so that a build
+without it still links, which is why the omission is not a build error.
+
+The runtime says so at startup if it ends up with no handlers, so if you see
+that warning this is the step you are missing.
+
+### Step 7: Build the Recompiled Game
 
 ```bash
 cmake -B build -G Ninja -DPS3RECOMP_DIR=/path/to/ps3recomp
 cmake --build build
 ```
 
-Lifted output produces very large translation units. On MSVC (and `clang-cl`)
-add `/bigobj` to the target that compiles them, or the object files overflow
-their section limit:
+Use **clang-cl** on Windows, not `cl`. The runtime uses `__atomic_*` builtins,
+`__int128` and `__builtin_bswap*`, and the lifted output uses `__int128` for the
+PPC 64x64 multiplies; `cl` has none of them. clang-cl consumes the same MSVC
+headers and libraries, so nothing else about the build changes:
+
+```bash
+cmake -B build -G Ninja -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+```
+
+Lifted output also produces very large translation units, so add `/bigobj` to the
+target that compiles them or the object files overflow their section limit:
 
 ```cmake
 if(MSVC)
@@ -140,7 +175,7 @@ endif()
 `lbp/CMakeLists.txt` in this repository does exactly that and is the working
 reference; the starter template does not set it for you.
 
-### Step 7: Run
+### Step 8: Run
 
 The game executable takes the path to the decrypted ELF as its first argument
 -- it is loaded into the guest address space at startup, not baked into the

--- a/runtime/ppu/ppu_hle.cpp
+++ b/runtime/ppu/ppu_hle.cpp
@@ -753,4 +753,24 @@ extern "C" void ps3_hle_call(uint32_t nid, ppu_context* ctx)
 extern "C" void ppu_hle_register_all(void) __attribute__((weak));
 extern "C" void ppu_hle_register_all(void) {}
 
-extern "C" void ppu_hle_init(void) { ppu_hle_register_all(); }
+extern "C" void ppu_hle_init(void)
+{
+    ppu_hle_register_all();
+
+    /* The generated registration unit is per-game and easy to leave out: the
+     * weak stub above means a build without it links and starts, then fails
+     * later and somewhere else. Say so here, once, at the point where it is
+     * still obvious what to do about it. */
+    if (ps3_hle_count() == 0) {
+        fprintf(stderr,
+            "\n[ps3] WARNING: no HLE handlers are registered.\n"
+            "  ppu_hle_register_all() is the weak do-nothing stub, so every firmware\n"
+            "  import will return 0 and the first indirect call through one lands on\n"
+            "  the import stub's own instruction word (a bare address like 0x39800000\n"
+            "  is `li r12,0`, not a function).\n"
+            "  Generate the table and add it to the build:\n"
+            "      python tools/gen_hle_nids.py --all --out src/gen/ppu_hle_nids.cpp\n"
+            "  See docs/GETTING_STARTED.md.\n\n");
+        fflush(stderr);
+    }
+}

--- a/runtime/ppu/ppu_loader.cpp
+++ b/runtime/ppu/ppu_loader.cpp
@@ -2142,6 +2142,17 @@ extern "C" void ps3_indirect_call(ppu_context* ctx)
     last = cur; streak = 0;
     fprintf(stderr, "[ppu] unresolved indirect call -> 0x%08X (tid=%llu lr=0x%08X)\n",
             (uint32_t)ctx->ctr, (unsigned long long)ctx->thread_id, (uint32_t)ctx->lr);
+    /* With no NID table the very first one of these is the expected outcome
+     * rather than a mystery, so name the cause instead of the symptom. */
+    { extern uint32_t ps3_hle_count(void);
+      static int said = 0;
+      if (!said && ps3_hle_count() == 0) {
+          said = 1;
+          fprintf(stderr,
+              "       ^ no HLE handlers are registered, so this is almost certainly\n"
+              "         a firmware import rather than guest code. Run\n"
+              "         tools/gen_hle_nids.py and build its output into the port.\n");
+      } }
     static int dumped = 0;
     if (dumped < 3) {
         dumped++;


### PR DESCRIPTION
From feedback bringing up a first port on a fresh checkout. Three separate
failures, none of which said what was actually wrong.

## The step that was not documented

Lifting produces the game's code. It does **not** produce the bridge from the
game's firmware imports to our HLE implementations — that is `gen_hle_nids.py`,
and it appeared **zero times** in `GETTING_STARTED.md` and
`GAME_PORTING_GUIDE.md`, the two documents someone follows to do exactly this.

Both now cover it, between lifting and building.

## Why leaving it out is silent

`ppu_hle_register_all()` has a **weak** do-nothing definition so a build without
the generated unit still links. That is deliberate and worth keeping — but it
means the omission is not a build error. The port compiles, starts, and behaves
as though every firmware import returned 0. What you actually see is:

```
[ppu] unresolved indirect call -> 0x39800000 (tid=1 lr=0x000103C0)
```

`0x39800000` **is not an address.** It is the PowerPC instruction `li r12,0` —
the first word of an import stub. Unless you already know that, the message
points nowhere.

Now:

```
[ps3] WARNING: no HLE handlers are registered.
  ppu_hle_register_all() is the weak do-nothing stub, so every firmware
  import will return 0 and the first indirect call through one lands on
  the import stub's own instruction word (a bare address like 0x39800000
  is `li r12,0`, not a function).
  Generate the table and add it to the build:
      python tools/gen_hle_nids.py --all --out src/gen/ppu_hle_nids.cpp
```

Printed at startup by `ppu_hle_init()`, and repeated once on the
unresolved-call path if the count is still zero — because that is where the
symptom actually shows up.

## cl.exe configured happily and then failed

The runtime uses `__atomic_*` builtins, `__int128` and `__builtin_bswap*`, and
the lifted output uses `__int128` for the PPC 64×64 multiplies. `cl` has none of
them, so the build dies in whichever file it reaches first.

CMake had an `elseif(MSVC)` branch that let this happen. Worth noting *why* it
was reachable at all: clang-cl reports its compiler id as `Clang` and is caught
by the branch above, so `elseif(MSVC)` only ever catches real `cl`. It now warns
with the specific constructs and the exact configure line.

Deliberately a warning, not a hard error — porting those intrinsics is a welcome
contribution and a `FATAL_ERROR` would stand in its way.

`GETTING_STARTED.md` also said *"on MSVC (and `clang-cl`) add `/bigobj`"*, which
reads as though `cl` were supported with one caveat. It now says which compiler
to use and why.

## Verified

The startup warning was **compiled and run** against the weak stub, not just
eyeballed — it prints. Builds clean on windows-clang-cl, linux-gcc and
linux-clang; PPU scaffold ratchet still 0 on all three.