### PR TITLE
sceNpTrophy: initialize first-use slots and deliver registration completion

### DIFF
--- a/libs/network/sceNpTrophy.c
+++ b/libs/network/sceNpTrophy.c
@@ -9,6 +9,8 @@
  */
 
 #include "sceNpTrophy.h"
+#include "../system/cellSysutil.h"
+#include "ps3emu/guest_call.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -53,8 +55,9 @@ typedef struct {
     int in_use;
 } TrophyHandle;
 
-static TrophyContext s_contexts[SCE_NP_TROPHY_MAX_CONTEXTS];
-static TrophyHandle  s_handles[SCE_NP_TROPHY_MAX_HANDLES];
+/* ID zero is the firmware invalid sentinel; retain all four usable slots. */
+static TrophyContext s_contexts[SCE_NP_TROPHY_MAX_CONTEXTS + 1];
+static TrophyHandle  s_handles[SCE_NP_TROPHY_MAX_HANDLES + 1];
 
 /* ---------------------------------------------------------------------------
  * Persistent storage helpers
@@ -197,7 +200,7 @@ s32 sceNpTrophyTerm(void)
         return SCE_NP_TROPHY_ERROR_NOT_INITIALIZED;
 
     /* Save all registered contexts */
-    for (int i = 0; i < SCE_NP_TROPHY_MAX_CONTEXTS; i++) {
+    for (int i = 1; i <= SCE_NP_TROPHY_MAX_CONTEXTS; i++) {
         if (s_contexts[i].in_use && s_contexts[i].registered)
             trophy_save(&s_contexts[i]);
     }
@@ -220,16 +223,15 @@ s32 sceNpTrophyCreateContext(SceNpTrophyContext* context,
 
     if (!context || !commId)
         return SCE_NP_TROPHY_ERROR_INVALID_ARGUMENT;
-    SceNpTrophyContext* context_h = GUEST_PTR(context, SceNpTrophyContext*);
     const SceNpCommunicationId* commId_h = GUEST_PTR(commId, const SceNpCommunicationId*);
 
-    for (s32 i = 0; i < SCE_NP_TROPHY_MAX_CONTEXTS; i++) {
+    for (s32 i = 1; i <= SCE_NP_TROPHY_MAX_CONTEXTS; i++) {
         if (!s_contexts[i].in_use) {
             memset(&s_contexts[i], 0, sizeof(TrophyContext));
             s_contexts[i].in_use = 1;
             s_contexts[i].commId = *commId_h;
             s_contexts[i].total_trophies = SCE_NP_TROPHY_MAX_NUM_TROPHIES;
-            *context_h = i;
+            vm_write32(GUEST_EA(context), (u32)i);
             printf("[sceNpTrophy] CreateContext(commId=\"%s\") -> ctx=%d\n",
                    commId_h->data, i);
             return CELL_OK;
@@ -244,7 +246,7 @@ s32 sceNpTrophyDestroyContext(SceNpTrophyContext context)
     if (!s_trophy_initialized)
         return SCE_NP_TROPHY_ERROR_NOT_INITIALIZED;
 
-    if (context < 0 || context >= SCE_NP_TROPHY_MAX_CONTEXTS ||
+    if (context <= 0 || context > SCE_NP_TROPHY_MAX_CONTEXTS ||
         !s_contexts[context].in_use)
         return SCE_NP_TROPHY_ERROR_INVALID_CONTEXT;
 
@@ -263,12 +265,11 @@ s32 sceNpTrophyCreateHandle(SceNpTrophyHandle* handle)
 
     if (!handle)
         return SCE_NP_TROPHY_ERROR_INVALID_ARGUMENT;
-    handle = GUEST_PTR(handle, SceNpTrophyHandle*);
 
-    for (s32 i = 0; i < SCE_NP_TROPHY_MAX_HANDLES; i++) {
+    for (s32 i = 1; i <= SCE_NP_TROPHY_MAX_HANDLES; i++) {
         if (!s_handles[i].in_use) {
             s_handles[i].in_use = 1;
-            *handle = i;
+            vm_write32(GUEST_EA(handle), (u32)i);
             printf("[sceNpTrophy] CreateHandle() -> handle=%d\n", i);
             return CELL_OK;
         }
@@ -282,37 +283,13 @@ s32 sceNpTrophyDestroyHandle(SceNpTrophyHandle handle)
     if (!s_trophy_initialized)
         return SCE_NP_TROPHY_ERROR_NOT_INITIALIZED;
 
-    if (handle < 0 || handle >= SCE_NP_TROPHY_MAX_HANDLES ||
+    if (handle <= 0 || handle > SCE_NP_TROPHY_MAX_HANDLES ||
         !s_handles[handle].in_use)
         return SCE_NP_TROPHY_ERROR_INVALID_HANDLE;
 
     s_handles[handle].in_use = 0;
     printf("[sceNpTrophy] DestroyHandle(handle=%d)\n", handle);
     return CELL_OK;
-}
-
-/* Fire a guest SceNpTrophyStatusCallback via the OPD in `statusCb`.
- * Callback ABI: int cb(context, status, completed, total, arg). */
-extern unsigned long long ppu_guest_call_ct(u32 code, u32 toc,
-                                            u64 a0, u64 a1, u64 a2, u64 a3,
-                                            u64 a4, u64 a5, u64 a6, u64 a7);
-
-static void trophy_fire_status_cb(u32 statusCb, u32 arg,
-                                  SceNpTrophyContext context,
-                                  u32 status, u32 completed, u32 total)
-{
-    if (!statusCb) return;
-    /* Resolve the guest OPD (big-endian: [code][toc]). */
-    const u8* opd = (const u8*)(vm_base + statusCb);
-    u32 code = ((u32)opd[0] << 24) | ((u32)opd[1] << 16) |
-               ((u32)opd[2] <<  8) |  (u32)opd[3];
-    u32 toc  = ((u32)opd[4] << 24) | ((u32)opd[5] << 16) |
-               ((u32)opd[6] <<  8) |  (u32)opd[7];
-    printf("[sceNpTrophy] firing status cb: opd=0x%08X code=0x%08X toc=0x%08X "
-           "status=%u (%u/%u)\n", statusCb, code, toc, status, completed, total);
-    ppu_guest_call_ct(code, toc,
-                      (u64)(u32)context, (u64)status, (u64)completed, (u64)total,
-                      (u64)arg, 0, 0, 0);
 }
 
 s32 sceNpTrophyRegisterContext(SceNpTrophyContext context,
@@ -326,16 +303,19 @@ s32 sceNpTrophyRegisterContext(SceNpTrophyContext context,
     if (!s_trophy_initialized)
         return SCE_NP_TROPHY_ERROR_NOT_INITIALIZED;
 
-    if (context < 0 || context >= SCE_NP_TROPHY_MAX_CONTEXTS ||
+    if (context <= 0 || context > SCE_NP_TROPHY_MAX_CONTEXTS ||
         !s_contexts[context].in_use)
         return SCE_NP_TROPHY_ERROR_INVALID_CONTEXT;
 
-    if (handle < 0 || handle >= SCE_NP_TROPHY_MAX_HANDLES ||
+    if (handle <= 0 || handle > SCE_NP_TROPHY_MAX_HANDLES ||
         !s_handles[handle].in_use)
         return SCE_NP_TROPHY_ERROR_INVALID_HANDLE;
 
     if (s_contexts[context].registered)
         return SCE_NP_TROPHY_ERROR_CONTEXT_ALREADY_REG;
+
+    if (!statusCb) return SCE_NP_TROPHY_ERROR_INVALID_ARGUMENT;
+    if (!g_ps3_guest_caller) return SCE_NP_TROPHY_ERROR_UNKNOWN;
 
     /* Load any previously saved trophy data */
     trophy_load(&s_contexts[context]);
@@ -344,14 +324,20 @@ s32 sceNpTrophyRegisterContext(SceNpTrophyContext context,
     printf("[sceNpTrophy] RegisterContext(ctx=%d, handle=%d, statusCb=0x%08X, "
            "arg=0x%08X) -> loaded saved data\n", context, handle, statusCb, arg);
 
-    /* The game blocks (TrophyThread poll on 0x543580) until registration
-     * completes.  Real fw drives that completion by invoking the guest status
-     * callback synchronously on this thread.  Matching the RPCS3 oracle, we
-     * fire it once with INSTALLED (trp_status=3). */
-    {
-        u32 total = s_contexts[context].total_trophies;
-        trophy_fire_status_cb(statusCb, arg, context,
-                              SCE_NP_TROPHY_STATUS_INSTALLED, total, total);
+    /* Use the runner's OPD bridge, not the optional code/TOC scaffold entry
+     * point. Registration status is synchronous; its terminal notification is
+     * delivered through sysutil polling, after the HLE storage load completes.
+     * Intermediate firmware installation progress is not simulated here. */
+    g_ps3_guest_caller(statusCb, (u32)context, SCE_NP_TROPHY_STATUS_INSTALLED,
+                       0, 0, arg, 0, 0, 0);
+    if (!s_trophy_initialized) return SCE_NP_TROPHY_ERROR_NOT_INITIALIZED;
+    if (!s_contexts[context].in_use) return SCE_NP_TROPHY_ERROR_INVALID_CONTEXT;
+    if (!s_handles[handle].in_use) return SCE_NP_TROPHY_ERROR_INVALID_HANDLE;
+    const u64 completion[8] = {(u32)context, SCE_NP_TROPHY_STATUS_PROCESSING_COMPLETE,
+                               0, 0, arg, 0, 0, 0};
+    if (cellSysutilQueueGuestCallbackArgs(statusCb, completion) != CELL_OK) {
+        s_contexts[context].registered = 0;
+        return SCE_NP_TROPHY_ERROR_OUT_OF_MEMORY;
     }
 
     return CELL_OK;
@@ -366,7 +352,7 @@ s32 sceNpTrophyGetRequiredDiskSpace(SceNpTrophyContext context,
     if (!s_trophy_initialized)
         return SCE_NP_TROPHY_ERROR_NOT_INITIALIZED;
 
-    if (context < 0 || context >= SCE_NP_TROPHY_MAX_CONTEXTS ||
+    if (context <= 0 || context > SCE_NP_TROPHY_MAX_CONTEXTS ||
         !s_contexts[context].in_use)
         return SCE_NP_TROPHY_ERROR_INVALID_CONTEXT;
 
@@ -396,7 +382,7 @@ s32 sceNpTrophyGetGameInfo(SceNpTrophyContext context,
     if (!s_trophy_initialized)
         return SCE_NP_TROPHY_ERROR_NOT_INITIALIZED;
 
-    if (context < 0 || context >= SCE_NP_TROPHY_MAX_CONTEXTS ||
+    if (context <= 0 || context > SCE_NP_TROPHY_MAX_CONTEXTS ||
         !s_contexts[context].in_use)
         return SCE_NP_TROPHY_ERROR_INVALID_CONTEXT;
 
@@ -444,7 +430,7 @@ s32 sceNpTrophyGetTrophyInfo(SceNpTrophyContext context,
     if (!s_trophy_initialized)
         return SCE_NP_TROPHY_ERROR_NOT_INITIALIZED;
 
-    if (context < 0 || context >= SCE_NP_TROPHY_MAX_CONTEXTS ||
+    if (context <= 0 || context > SCE_NP_TROPHY_MAX_CONTEXTS ||
         !s_contexts[context].in_use)
         return SCE_NP_TROPHY_ERROR_INVALID_CONTEXT;
 
@@ -487,7 +473,7 @@ s32 sceNpTrophyUnlockTrophy(SceNpTrophyContext context,
     if (!s_trophy_initialized)
         return SCE_NP_TROPHY_ERROR_NOT_INITIALIZED;
 
-    if (context < 0 || context >= SCE_NP_TROPHY_MAX_CONTEXTS ||
+    if (context <= 0 || context > SCE_NP_TROPHY_MAX_CONTEXTS ||
         !s_contexts[context].in_use)
         return SCE_NP_TROPHY_ERROR_INVALID_CONTEXT;
 
@@ -533,7 +519,7 @@ s32 sceNpTrophyGetTrophyUnlockState(SceNpTrophyContext context,
     if (!s_trophy_initialized)
         return SCE_NP_TROPHY_ERROR_NOT_INITIALIZED;
 
-    if (context < 0 || context >= SCE_NP_TROPHY_MAX_CONTEXTS ||
+    if (context <= 0 || context > SCE_NP_TROPHY_MAX_CONTEXTS ||
         !s_contexts[context].in_use)
         return SCE_NP_TROPHY_ERROR_INVALID_CONTEXT;
 
@@ -568,7 +554,7 @@ s32 sceNpTrophyGetGameProgress(SceNpTrophyContext context,
     if (!s_trophy_initialized)
         return SCE_NP_TROPHY_ERROR_NOT_INITIALIZED;
 
-    if (context < 0 || context >= SCE_NP_TROPHY_MAX_CONTEXTS ||
+    if (context <= 0 || context > SCE_NP_TROPHY_MAX_CONTEXTS ||
         !s_contexts[context].in_use)
         return SCE_NP_TROPHY_ERROR_INVALID_CONTEXT;
 

--- a/libs/network/sceNpTrophy.h
+++ b/libs/network/sceNpTrophy.h
@@ -38,8 +38,8 @@ extern "C" {
 /* ---------------------------------------------------------------------------
  * Constants
  * -----------------------------------------------------------------------*/
-#define SCE_NP_TROPHY_INVALID_CONTEXT       ((SceNpTrophyContext)-1)
-#define SCE_NP_TROPHY_INVALID_HANDLE        ((SceNpTrophyHandle)-1)
+#define SCE_NP_TROPHY_INVALID_CONTEXT       ((SceNpTrophyContext)0)
+#define SCE_NP_TROPHY_INVALID_HANDLE        ((SceNpTrophyHandle)0)
 #define SCE_NP_TROPHY_INVALID_TROPHY_ID     ((SceNpTrophyId)-1)
 
 #define SCE_NP_TROPHY_MAX_NUM_TROPHIES      128
@@ -135,6 +135,7 @@ s32 sceNpTrophyRegisterContext(SceNpTrophyContext context,
 #define SCE_NP_TROPHY_STATUS_DATA_CORRUPT       2
 #define SCE_NP_TROPHY_STATUS_INSTALLED          3
 #define SCE_NP_TROPHY_STATUS_REQUIRES_UPDATE    4
+#define SCE_NP_TROPHY_STATUS_PROCESSING_COMPLETE 8
 
 s32 sceNpTrophyGetRequiredDiskSpace(SceNpTrophyContext context,
                                     SceNpTrophyHandle handle,

--- a/libs/network/tests/test_trophy_registration.c
+++ b/libs/network/tests/test_trophy_registration.c
@@ -1,0 +1,46 @@
+/* clang -std=gnu17 -I include libs/network/tests/test_trophy_registration.c
+ * libs/system/cellSysutil.c -Wl,-dead_strip -pthread -o /tmp/test_trophy_registration
+ */
+#include "../sceNpTrophy.c"
+#include <assert.h>
+uint8_t* vm_base;
+uint32_t ppu_vm_size;
+int g_resv_store_active;
+uint32_t g_ww_lo, g_ww_hi;
+void ppu_resv_break_store(uint64_t ea) { (void)ea; }
+void ps3_ww_report_inline(uint32_t a, uint64_t v, int w) { (void)a; (void)v; (void)w; }
+int spu_coh_is_reserved(uint32_t a) { (void)a; return 0; }
+void spu_coh_notify_write(uint32_t a) { (void)a; }
+void spu_lockline_lock(void) {}
+void spu_lockline_unlock(void) {}
+ps3_guest_caller_fn g_ps3_guest_caller;
+static unsigned calls;
+static void callback(u32 opd, u64 context, u64 status, u64 completed, u64 total,
+                     u64 arg, u64 a, u64 b, u64 c)
+{
+    assert(opd == 0x300 && context == 1 && arg == 0xCAFE);
+    assert(!completed && !total && !a && !b && !c);
+    assert(status == (calls ? 8 : 3)); calls++;
+}
+int main(void)
+{
+    char root[] = "/tmp/ps3recomp-trophy-XXXXXX";
+    assert(mkdtemp(root));
+    vm_base = calloc(1, 65536); assert(vm_base);
+    strcpy((char*)vm_base + 0x400, root);
+    sceNpTrophySetStoragePath((void*)0x400);
+    memcpy(vm_base + 0x100, "NPWR00000", 10);
+    assert(sceNpTrophyInit(NULL, 0, 0, 0) == CELL_OK);
+    assert(sceNpTrophyCreateContext((void*)0x200, (void*)0x100, NULL, 0) == CELL_OK);
+    assert(sceNpTrophyCreateHandle((void*)0x204) == CELL_OK);
+    assert(sceNpTrophyRegisterContext(1, 1, 0x300, 0xCAFE, 0) == SCE_NP_TROPHY_ERROR_UNKNOWN);
+    g_ps3_guest_caller = callback;
+    assert(sceNpTrophyRegisterContext(1, 1, 0x300, 0xCAFE, 0) == CELL_OK);
+    assert(calls == 1 && s_contexts[1].registered);
+    cellSysutilCheckCallback(); assert(calls == 2);
+    cellSysutilCheckCallback(); assert(calls == 2);
+    assert(sceNpTrophyTerm() == CELL_OK);
+    char file[256]; snprintf(file, sizeof(file), "%s/NPWR00000.json", root);
+    assert(unlink(file) == 0); assert(rmdir(root) == 0); free(vm_base);
+    puts("Trophy registration delivers installed and deferred completion statuses");
+}

--- a/libs/network/tests/test_trophy_start.c
+++ b/libs/network/tests/test_trophy_start.c
@@ -1,0 +1,45 @@
+/* clang -std=gnu17 -I include libs/network/tests/test_trophy_start.c
+ *   -Wl,-dead_strip -o /tmp/test_trophy_start && /tmp/test_trophy_start
+ */
+#include "../sceNpTrophy.c"
+#include <assert.h>
+uint8_t* vm_base;
+uint32_t ppu_vm_size;
+int g_resv_store_active;
+uint32_t g_ww_lo, g_ww_hi;
+void ppu_resv_break_store(uint64_t ea) { (void)ea; }
+void ps3_ww_report_inline(uint32_t a, uint64_t v, int w) { (void)a; (void)v; (void)w; }
+int spu_coh_is_reserved(uint32_t a) { (void)a; return 0; }
+void spu_coh_notify_write(uint32_t a) { (void)a; }
+void spu_lockline_lock(void) {}
+void spu_lockline_unlock(void) {}
+int main(void)
+{
+    vm_base = calloc(1, 65536);
+    assert(vm_base);
+    memcpy(vm_base + 0x100, "NPWR00000", 9);
+    assert(sceNpTrophyCreateContext((void*)0x200, (void*)0x100, NULL, 0) ==
+           SCE_NP_TROPHY_ERROR_NOT_INITIALIZED);
+    assert(sceNpTrophyInit(NULL, 0, 0, 0) == CELL_OK);
+    assert(sceNpTrophyCreateContext(NULL, (void*)0x100, NULL, 0) ==
+           SCE_NP_TROPHY_ERROR_INVALID_ARGUMENT);
+    for (int i = 0; i < SCE_NP_TROPHY_MAX_CONTEXTS; i++) {
+        assert(sceNpTrophyCreateContext((void*)0x200, (void*)0x100, NULL, 0) == CELL_OK);
+        assert(vm_read32(0x200) == (u32)(i + 1));
+        assert(sceNpTrophyCreateHandle((void*)0x204) == CELL_OK);
+        assert(vm_read32(0x204) == (u32)(i + 1));
+    }
+    assert(sceNpTrophyCreateContext((void*)0x200, (void*)0x100, NULL, 0) == SCE_NP_TROPHY_ERROR_OUT_OF_MEMORY);
+    assert(sceNpTrophyCreateHandle((void*)0x204) == SCE_NP_TROPHY_ERROR_OUT_OF_MEMORY);
+    assert(sceNpTrophyDestroyContext(0) == SCE_NP_TROPHY_ERROR_INVALID_CONTEXT);
+    assert(sceNpTrophyDestroyHandle(0) == SCE_NP_TROPHY_ERROR_INVALID_HANDLE);
+    assert(sceNpTrophyInit(NULL, 0, 0, 0) == SCE_NP_TROPHY_ERROR_ALREADY_INITIALIZED);
+    assert(sceNpTrophyGetRequiredDiskSpace(1, 1, (void*)0x208, 0) == CELL_OK);
+    assert(vm_read64(0x208) == 1024 * 1024);
+    assert(sceNpTrophyDestroyContext(SCE_NP_TROPHY_MAX_CONTEXTS) == CELL_OK);
+    assert(sceNpTrophyDestroyHandle(SCE_NP_TROPHY_MAX_HANDLES) == CELL_OK);
+    assert(s_contexts[1].in_use && s_handles[1].in_use);
+    assert(sceNpTrophyTerm() == CELL_OK);
+    free(vm_base);
+    puts("Trophy initialization and guest-endian checks passed");
+}


### PR DESCRIPTION
Closed after renaming the source branch.
