### PR TITLE
sceNp: initialize the local score service while offline

### DIFF
--- a/libs/network/sceNp.c
+++ b/libs/network/sceNp.c
@@ -17,6 +17,7 @@
  * -----------------------------------------------------------------------*/
 
 static int  s_np_initialized = 0;
+static int  s_score_initialized = 0;
 static char s_fake_username[SCE_NP_ONLINEID_MAX_LENGTH + 1] = "PS3Player";
 
 /* ---------------------------------------------------------------------------
@@ -246,3 +247,25 @@ s32 sceNpManagerGetNpId(SceNpId* npId)               { return sceNpGetNpId(0, np
 s32 sceNpManagerGetOnlineId(SceNpOnlineId* onlineId) { return sceNpGetOnlineId(0, onlineId); }
 s32 sceNpManagerGetOnlineName(SceNpOnlineName* name) { return sceNpGetOnlineName(0, name); }
 s32 sceNpManagerGetAccountAge(s32* age)              { return sceNpGetAccountAge(0, age); }
+
+/* Score setup is local even while the NP manager is offline. Games may
+ * initialize it before starting the worker that decides whether to use PSN. */
+s32 sceNpScoreInit(void)
+{
+    if (s_score_initialized)
+        return SCE_NP_COMMUNITY_ERROR_ALREADY_INITIALIZED;
+    if (!s_np_initialized)
+        return SCE_NP_ERROR_NOT_INITIALIZED;
+    s_score_initialized = 1;
+    return CELL_OK;
+}
+
+s32 sceNpScoreTerm(void)
+{
+    if (!s_score_initialized)
+        return SCE_NP_COMMUNITY_ERROR_NOT_INITIALIZED;
+    if (!s_np_initialized)
+        return SCE_NP_ERROR_NOT_INITIALIZED;
+    s_score_initialized = 0;
+    return CELL_OK;
+}

--- a/libs/network/sceNp.h
+++ b/libs/network/sceNp.h
@@ -102,6 +102,11 @@ typedef struct SceNpMyLanguages {
 s32 sceNpInit(u32 poolSize, void* poolPtr);
 s32 sceNpTerm(void);
 
+#define SCE_NP_COMMUNITY_ERROR_ALREADY_INITIALIZED 0x8002a101
+#define SCE_NP_COMMUNITY_ERROR_NOT_INITIALIZED     0x8002a102
+s32 sceNpScoreInit(void);
+s32 sceNpScoreTerm(void);
+
 s32 sceNpGetNpId(s32 userId, SceNpId* npId);
 s32 sceNpGetOnlineId(s32 userId, SceNpOnlineId* onlineId);
 s32 sceNpGetOnlineName(s32 userId, SceNpOnlineName* onlineName);

--- a/libs/network/tests/test_score_init.c
+++ b/libs/network/tests/test_score_init.c
@@ -1,0 +1,37 @@
+/* clang -std=gnu17 -I include libs/network/tests/test_score_init.c
+ *   -Wl,-dead_strip -o /tmp/test_score_init && /tmp/test_score_init
+ */
+#include "../sceNp.c"
+#include <assert.h>
+#include <stdlib.h>
+uint8_t* vm_base;
+uint32_t ppu_vm_size;
+int g_resv_store_active;
+uint32_t g_ww_lo, g_ww_hi;
+void ppu_resv_break_store(uint64_t ea) { (void)ea; }
+void ps3_ww_report_inline(uint32_t a, uint64_t v, int w) { (void)a; (void)v; (void)w; }
+int spu_coh_is_reserved(uint32_t a) { (void)a; return 0; }
+void spu_coh_notify_write(uint32_t a) { (void)a; }
+void spu_lockline_lock(void) {}
+void spu_lockline_unlock(void) {}
+int main(void)
+{
+    vm_base = calloc(1, 65536);
+    assert(vm_base);
+    assert((u32)sceNpScoreInit() == SCE_NP_ERROR_NOT_INITIALIZED);
+    assert((u32)sceNpScoreTerm() == SCE_NP_COMMUNITY_ERROR_NOT_INITIALIZED);
+    assert(sceNpInit(131072, (void*)0x1000) == CELL_OK);
+    assert(sceNpScoreInit() == CELL_OK);
+    assert((u32)sceNpScoreInit() == SCE_NP_COMMUNITY_ERROR_ALREADY_INITIALIZED);
+    /* Local score setup must not claim a PSN connection or change its status. */
+    assert(sceNpManagerGetStatus((void*)0x100) == CELL_OK);
+    assert((s32)vm_read32(0x100) == SCE_NP_MANAGER_STATUS_OFFLINE);
+    assert(sceNpScoreTerm() == CELL_OK);
+    assert((u32)sceNpScoreTerm() == SCE_NP_COMMUNITY_ERROR_NOT_INITIALIZED);
+    assert(sceNpScoreInit() == CELL_OK);
+    assert(sceNpScoreTerm() == CELL_OK);
+    assert(sceNpTerm() == CELL_OK);
+    assert((u32)sceNpScoreInit() == SCE_NP_ERROR_NOT_INITIALIZED);
+    free(vm_base);
+    puts("Score lifecycle and offline status checks passed");
+}

--- a/tools/nid_database.py
+++ b/tools/nid_database.py
@@ -450,6 +450,8 @@ _BUILTIN_FUNCTIONS: list[tuple[str, str]] = [
     ("sysPrxForUser", "_sys_heap_memalign"),                 # 0x44265c08 x2
     ("sysPrxForUser", "sys_spu_image_close"),                # 0xe0da8efd x2
     ("sysPrxForUser", "sys_mmapper_allocate_memory"),        # 0xb257540b x1
+    ("sceNp", "sceNpScoreInit"),
+    ("sceNp", "sceNpScoreTerm"),
     ("sceNp", "sceNpManagerGetStatus"),                      # 0xa7bff757 x5
     ("sceNp", "sceNpManagerGetNpId"),                        # 0xfe37a7f4 x5
     ("sceNp", "sceNpManagerRegisterCallback"),               # 0xe7dcd3b4 x5


### PR DESCRIPTION
The legacy Yakuza runner stopped during network setup because the local score-service lifecycle calls were missing. Initializing the score service should not require a live PSN connection or report that the user is online.

This adds ScoreInit and ScoreTerm with initialization-state checks, registers their NIDs, and keeps the manager status offline. The legacy runner's import routing is handled in the macOS PR; these service calls are shared behavior.

Verified: the standalone lifecycle test passes initialization ordering, duplicate initialization, termination and offline manager status on this branch. The combined macOS build gets past the earlier network setup failure. Windows gameplay has not been rerun.
