### PR TITLE
spu_lifter: scan the basic block, not the function, when classifying bi $rN

### DIFF
--- a/tools/spu_lifter.py
+++ b/tools/spu_lifter.py
@@ -402,12 +402,25 @@ def compute_link_returns(insns, bounds) -> set:
             # move), the target was computed here -> a real indirect branch, not
             # a return. Scan stops at unconditional flow breaks (block boundary
             # -- see the twin guard in compute_bi_r0_jumps).
+            # Scan the real BASIC BLOCK, not the enclosing lifted function.
+            # The two are not the same: the lifter splits long straight-line
+            # runs into several functions that chain by fallthrough, and a scan
+            # bounded by `fn` stops at a split that is not a control-flow edge
+            # at all. pm_wwsjob's command-dispatch prologue is exactly that --
+            # one 0x7C-byte block cut into five functions (0x2DF8, 0x2E18,
+            # 0x2E38, 0x2E60, 0x2E78) -- so the `bi $r6` at 0x2E74 was examined
+            # against the four instructions of 0x2E60..0x2E78 alone. Its
+            # predecessor, the `br 0x2DF8` that loads r6 from the LS 0x15B0
+            # handler table, enters the block far above that window and was
+            # invisible, so the guard below could not fire and every job
+            # command handler was skipped -- the very case its comment cites.
             written = False
             block_start = s
-            for j in range(idx - 1, -1, -1):
-                w = fn[j]
+            gi = idx_of_all[insn.addr]
+            for j in range(gi - 1, -1, -1):
+                w = ordered[j]
                 if w.mnemonic in ("bi", "br", "bra", "iret", "stop", "stopd"):
-                    block_start = fn[j + 1].addr if j + 1 <= idx else s
+                    block_start = ordered[j + 1].addr
                     break
                 if (w.mnemonic not in _NO_RT_WRITE and _dest_reg(w) == rn
                         and not _is_identity_move(w)):


### PR DESCRIPTION
compute_link_returns decides whether `bi $rN` (N != 0) is a link-register return or a computed dispatch. Both of its backward scans were bounded by the enclosing entry in `bounds` !!the lifted FUNCTION!!  rather than by the basic block.

Those are not the same thing. The lifter splits long straight-line runs into several functions that chain by fallthrough, and a split is not a control-flow edge; a scan that stops at one stops in the middle of a block, having seen only part of it.

That is enough to defeat the predecessor refinement this function already carries, in exactly the case its own comment cites. pm_wwsjob's command interpreter loads a handler address into r6 from the LS 0x15B0 table, branches into a shared decode block, and dispatches with `bi $r6` at LS 0x2E74. That block is one 0x7C-byte straight-line run, but it is cut into five functions (0x2DF8, 0x2E18, 0x2E38, 0x2E60, 0x2E78), so the branch was judged against the four instructions of 0x2E60..0x2E78 alone. The predecessor that computes r6 enters the block at 0x2DF8, far outside that window, so `computed_in` could never be set -- and r6, never written in the visible fragment, looked exactly like a caller's link register.

The result is silent and total: every job command handler was emitted as `SPU_RET(ctx)`. The interpreter read its command stream, returned instead of dispatching, and no handler ever ran, so the "declare buffer set" command never populated bufferSetArray at LS 0xDF0, and LittleBigPlanet's job manager sat forever on a table of zeros (measured: 1 write of zeros against 670,435 reads, with the PPU loader threads spinning on job completions that could not arrive).

Walking the real block instead: bufferSetArray is written 9 times with live entries, and the reads drop from 670,435 to 30.

The `written` scan gets the same treatment for the same reason, a register written earlier in the block but in a previous function fragment was invisible to it too.