### PR TITLE
release: build Linux bundles, and make a dry run work from any branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,12 @@ jobs:
             runs-on: windows-latest
           - platform: mac-arm64
             runs-on: macos-14
+          # Linux ships as the toolkit and the runtime library, not a game
+          # runner: it has no renderer (the null backend's headless software path
+          # is a CI check, not a graphics backend) and the PPU boot scaffold does
+          # not yet load a title on POSIX. VERSION.txt says so in the bundle.
+          - platform: linux-x64
+            runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -49,6 +55,12 @@ jobs:
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         run: brew install ninja sdl2
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends ninja-build libsdl2-dev
 
       # clang-cl on Windows: the loader uses __builtin_bswap* and weak symbols
       # that plain MSVC does not provide (docs/BUILDING.md).
@@ -102,10 +114,22 @@ jobs:
           cp README.md LICENSE CONTRIBUTORS.md "${STAGE}/"
           mkdir -p "${STAGE}/docs" && cp docs/*.md "${STAGE}/docs/"
 
+          # What this bundle can actually do, per platform. Someone who
+          # downloads the Linux zip expecting to run a game should find that out
+          # here rather than after building one.
+          case "${{ matrix.platform }}" in
+            win-x64)    CAN="renders and runs recompiled titles (D3D12)" ;;
+            mac-arm64)  CAN="renders through Metal; cannot yet load a title -- the PPU boot scaffold does not run on POSIX" ;;
+            linux-x64)  CAN="toolkit and runtime library only -- no renderer (Vulkan is unwritten), and the PPU boot scaffold does not run on POSIX" ;;
+            *)          CAN="unknown" ;;
+          esac
+
           { echo "ps3recomp ${VER}"
             echo "platform: ${{ matrix.platform }}"
             echo "commit:   ${GITHUB_SHA}"
-            echo "run:      ${{ github.run_id }}"; } > "${STAGE}/VERSION.txt"
+            echo "run:      ${{ github.run_id }}"
+            echo
+            echo "status:   ${CAN}"; } > "${STAGE}/VERSION.txt"
 
           # cmake -E tar rather than zip/Compress-Archive: CMake is already a
           # hard requirement on both runners, so this is one code path instead of

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,13 @@ jobs:
         shell: bash
         run: |
           set -e
-          VER="${GITHUB_REF_NAME}"
+          # On a tag this is "v0.12.0". On a workflow_dispatch dry run it is the
+          # BRANCH name, which may contain a slash -- "release/v0.12.0" made
+          # dist/${NAME} a nested directory, so the zip landed in dist/release/
+          # and the dist/*.zip upload glob found nothing. Every platform built and
+          # tested fine and the run still failed, which is the least useful way
+          # for a dry run to fail.
+          VER="${GITHUB_REF_NAME//\//-}"
           NAME="ps3recomp-${VER}-${{ matrix.platform }}"
           STAGE="dist/${NAME}"
 


### PR DESCRIPTION
Two fixes to the release workflow, both found by actually running it.

**Linux joins the matrix.** The build and staging steps were already platform-agnostic, so it is a matrix entry plus an apt-get. It ships as the toolkit and runtime library, not a game runner, and `VERSION.txt` now says so per platform:

| platform | status line in the bundle |
|---|---|
| win-x64 | renders and runs recompiled titles (D3D12) |
| mac-arm64 | renders through Metal; cannot yet load a title — the PPU boot scaffold does not run on POSIX |
| linux-x64 | toolkit and runtime library only — no renderer (Vulkan is unwritten), and the PPU boot scaffold does not run on POSIX |

Someone downloading the Linux zip expecting to run a game should find that out from the file, not after building one.

**A dry run from a branch with a slash produced no artefact.** `VER=${GITHUB_REF_NAME}` is the tag on a tag push and the *branch* on a `workflow_dispatch`; `release/v0.12.0` made `dist/${NAME}` nested, so the zip landed in `dist/release/` and the `dist/*.zip` glob found nothing. All three platforms built, tested and staged, and the run failed at upload anyway.

Verified by dry run: win-x64, mac-arm64 and linux-x64 all **success**, attach-to-release correctly skipped.

Worth knowing: **v0.10.0 and v0.11.0 were tagged but never published** — both release runs failed on macOS with an undeclared `RtlCaptureStackBackTrace`. That is since fixed by `runtime/platform/win32_backtrace.h`, so v0.12.0 would be the first published release since v0.9.1 in August.