### PR TITLE
cellGame: the content root strips /dev_hdd0, because ppu_fs does

### DIFF
--- a/libs/system/cellGame.c
+++ b/libs/system/cellGame.c
@@ -60,8 +60,9 @@ static char s_app_ver[16]   = "01.00";
 static char s_content_path[CELL_GAME_PATH_MAX] = "./gamedata/dev_hdd0/game";
 static int  s_content_path_resolved = 0;
 
-/* Resolved the same way ppu_fs.cpp resolves /dev_hdd0: $PS3_HDD0_ROOT if set,
- * else <ppu_vfs_root>/dev_hdd0. */
+/* Resolved the same way ppu_fs.cpp resolves the /dev_hdd0 mount: $PS3_HDD0_ROOT
+ * if set, else the VFS root -- in both cases with the "/dev_hdd0/" prefix
+ * stripped, which is what ppu_fs does to the guest path. */
 extern const char* ppu_vfs_root;
 
 static const char* content_root(void)
@@ -72,8 +73,11 @@ static const char* content_root(void)
         if (hdd0 && *hdd0)
             snprintf(s_content_path, sizeof s_content_path, "%s/game", hdd0);
         else if (ppu_vfs_root && *ppu_vfs_root && strcmp(ppu_vfs_root, ".") != 0)
-            snprintf(s_content_path, sizeof s_content_path,
-                     "%s/dev_hdd0/game", ppu_vfs_root);
+            /* NB: <root>/game, not <root>/dev_hdd0/game. ppu_fs STRIPS the mount
+             * prefix -- guest /dev_hdd0/game/<id> resolves to <root>/game/<id>.
+             * Spelling the device out here just recreates the same split one
+             * directory over, with each side quietly making its own tree. */
+            snprintf(s_content_path, sizeof s_content_path, "%s/game", ppu_vfs_root);
         for (char* q = s_content_path; *q; q++) if (*q == 0x5C) *q = 0x2F;
         printf("[cellGame] content root (host /dev_hdd0/game): %s\n", s_content_path);
     }


### PR DESCRIPTION
[@sagemono](https://github.com/sagemono)'s follow-up on #163, applied by hand rather than merged.

His revised branch corrects what landed in #171: the resolved root was `<vfs>/dev_hdd0/game`, but `ppu_fs` **strips** the mount prefix, so guest `/dev_hdd0/game/<id>` resolves to `<root>/game/<id>`. Spelling the device out here recreated the very split #163 set out to close, one directory over, with each side quietly making its own tree.

**Why by hand and not a merge:** `pr/163` predates canersaka's #157 and does not carry `content_free_kb`, so a clean merge of it would have *deleted* the content-volume-space query. That is the silent-capability-loss pattern this integration has been guarding against, and a rebased follow-up is an easier place to walk into it than a first merge.

Credit is sagemono's; the hand-application only exists to keep both changes. #163 can be closed once this lands — its fix is here.

Regression gate 5/5: vf5, simpsons, twistedmetal, tokyojungle, youdontknowjack.