### PR TITLE
SPU: return through a non-r0 link register publishes that register

### DIFF
--- a/runtime/spu/spu_context.h
+++ b/runtime/spu/spu_context.h
@@ -751,6 +751,14 @@ static inline void spu_pchist_tick(const spu_context* ctx)
         return;                                                \
     } while (0)
 
+/* Host return through a NON-r0 link register. Sony's SPU compiler links
+ * leaf/helper calls through r4/r5/r6/r8/r78 (`brsl $r4, helper` ...
+ * `bi $r4`); SPU_RET would publish r0 as the return PC, which is not where
+ * the guest is going, and spu_drain_call's return-address check can then
+ * never match -- it restarts dispatch from r0's stale value instead. Same
+ * host-frame return as SPU_RET, publishing the register actually branched. */
+#define SPU_RET_REG(ctx, n) do {                                       (ctx)->pc = (ctx)->gpr[n]._u32[0];                             if ((ctx)->host_depth == 0)                                        g_spu_trampoline_fn = spu_indirect_branch;                 return;                                                    } while (0)
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/runtime/spu/tests/test_spu_lifted_start.c
+++ b/runtime/spu/tests/test_spu_lifted_start.c
@@ -716,6 +716,45 @@ static void test_short_dma_lists(void)
           "short GET list leaves quadword padding untouched");
 }
 
+/* A lifted return through a NON-r0 link register. Sony's SPU compiler links
+ * leaf/helper calls through r4/r5/r6/r8/r78 and returns with `bi $rN`; the
+ * lifter lowers that to SPU_RET_REG(ctx, N). SPU_RET publishes r0 instead,
+ * which is not where the guest is going, and spu_drain_call -- which stops a
+ * translated call at its explicit return PC -- then sees pc != return_pc and
+ * restarts dispatch from r0's stale value. Observed on LittleBigPlanet's
+ * wwsjob policy module: every `brsl $r4, helper` ... `bi $r4` tore the
+ * module out of its host frames two DMAs into its first run. */
+static void callee_returns_via_r7(spu_context* ctx) { SPU_RET_REG(ctx, 7); }
+static void callee_returns_via_r0(spu_context* ctx) { SPU_RET(ctx); }
+static void test_nonzero_link_return(void)
+{
+    spu_context* ctx = (spu_context*)calloc(1, sizeof *ctx);
+    if (!ctx) { check(0, "allocate non-r0 return context"); return; }
+    spu_begin_image(90); spu_begin_image(0);
+    ctx->image_id = 90; ctx->host_depth = 1;
+    ctx->gpr[7]._u32[0] = 0x900;  /* the link the caller planted with brsl $r7 */
+    ctx->gpr[0]._u32[0] = 0x888;  /* r0 holds an unrelated nested-call link */
+    ctx->pc = 0x400;
+    g_spu_trampoline_fn = 0;
+    callee_returns_via_r7(ctx);
+    spu_drain_call(ctx, 0x900);
+    check(ctx->pc == 0x900, "SPU_RET_REG publishes the link register it returns through");
+    check(!g_spu_trampoline_fn, "non-r0 link return leaves no pending continuation");
+    check(ctx->status != SPU_STATUS_STOPPED_BY_HALT,
+          "spu_drain_call accepts the non-r0 return at its return address");
+
+    /* Negative control: the old lowering. r0 is not the return register, so
+     * the drain's return-address check cannot match and it restarts dispatch. */
+    ctx->host_depth = 1; ctx->status = 0; ctx->pc = 0x400;
+    g_spu_trampoline_fn = 0;
+    callee_returns_via_r0(ctx);
+    spu_drain_call(ctx, 0x900);
+    check(ctx->pc == 0x888, "SPU_RET publishes r0 (the defect the macro fixes)");
+    check(ctx->status == SPU_STATUS_STOPPED_BY_HALT,
+          "spu_drain_call restarts dispatch when a return publishes the wrong register");
+    free(ctx);
+}
+
 int main(void)
 {
     printf("SPU lifted thread-group start\n");
@@ -730,6 +769,7 @@ int main(void)
     test_guest_stack_reset();
     test_taskset_resume_stack();
     test_alternate_link_return();
+    test_nonzero_link_return();
 
     signal(SIGSEGV, guard_fault);
     signal(SIGBUS,  guard_fault);

--- a/tools/spu_lifter.py
+++ b/tools/spu_lifter.py
@@ -900,6 +900,11 @@ class SPULifter:
                     or addr in self.link_return:
                 # SPU_RET: host return while a matched brsl frame is live
                 # (host_depth>0); at 0 the frame was destroyed -> dispatch to r0.
+                # A return through a NON-r0 link (compute_link_returns) must
+                # publish THAT register as the return PC: SPU_RET publishes r0,
+                # and spu_drain_call restarts dispatch when pc != return_pc.
+                if tgt_reg != "0":
+                    return f"{_ied}SPU_RET_REG(ctx, {tgt_reg});"
                 return f"{_ied}SPU_RET(ctx);"
             # Computed indirect tail: set pc + trampoline to the dispatcher, unwind.
             return (f"{_ied}ctx->pc = {g(tgt_reg)}._u32[0]; "
@@ -944,6 +949,8 @@ class SPULifter:
             # land on an unregistered mid-function PC.
             if (tgt_reg == "0" and addr not in self.bi_r0_jump) \
                     or addr in self.link_return:
+                if tgt_reg != "0":
+                    return f"if ({cond}) {{ {_ied}SPU_RET_REG(ctx, {tgt_reg}); }}"
                 return f"if ({cond}) {{ {_ied}SPU_RET(ctx); }}"
             return (f"if ({cond}) {{ {_ied}ctx->pc = {g(tgt_reg)}._u32[0]; "
                     f"g_spu_trampoline_fn = spu_indirect_branch; return; }}")


### PR DESCRIPTION
SPU: return through a non-r0 link register publishes that register

`bi $rN` where rN carries the link (Sony's compiler links through r4/r5/r6/
r8/r78 as well as r0) lowered to SPU_RET, which sets pc from r0. The caller's
drain then compared pc with its return address and never matched, so every
such return unwound the host stack: the WWS job manager restarted on every
job and its DMA count stayed at 2 per run.

SPU_RET_REG(ctx, n) sets pc from gpr[n] and the lifter emits it at both
link-return sites when the link register is not r0. The lifted-start test
gets a case that returns through r7 and checks the pc, the trampoline state
and the status, with the r0 form as the negative control.
