### PR TITLE
lift_jobmods: seed the entries the modules reach only through data

### DIFF
--- a/tools/lift_jobmods.py
+++ b/tools/lift_jobmods.py
@@ -54,6 +54,71 @@ EXTRA_FUNCS = [a.strip() for a in
                os.environ.get("LBP_JOBMOD_EXTRA_FUNCS", "").split(",") if a.strip()]
 
 
+def manual_link_targets(raw, base=BASE):
+    """Return targets built into the link register by hand:
+        ila  $r0, off
+        a    $r0, $r0, $r126        (r126 = module load base, from the entry's
+        br   fn                      ila/brsl/sf base probe)
+    Every job module's entry does this once (`ila $r0, entry+0xAC ... br body`):
+    the body returns with `bi $r0` to base+off, an address no branch names, so
+    the lift has no entry there. Without it the return unwinds to the manager's
+    drain (drain-mismatch return_pc=0x3258 pc=0x4AEC), the restart re-enters the
+    entry function from its start, the prologue runs twice and the job leaves
+    on a garbage r0 (`exit: synthesised stop at LS 0xE81C`). Seeding base+off
+    is exact: the offset is an immediate."""
+    out = []
+    for off in range(0x30, len(raw) - 20, 4):
+        w = struct.unpack_from(">I", raw, off)[0]
+        if (w >> 25) & 0x7F != 0x21 or (w & 0x7F) != 0:          # ila $r0, i18
+            continue
+        imm = (w >> 7) & 0x3FFFF
+        for k in range(1, 5):
+            w2 = struct.unpack_from(">I", raw, off + 4 * k)[0]
+            if (w2 >> 21) & 0x7FF == 0x0C0 and (w2 & 0x7F) == 0 and ((w2 >> 7) & 0x7F) == 0:
+                if imm % 4 == 0 and 0x30 <= imm < len(raw):        # a $r0, $r0, $rX
+                    out.append(base + imm)
+                break
+    return sorted(set(out))
+
+
+
+def switch_table_targets(raw, base=BASE):
+    """Return the targets of position-independent switch tables.  The
+    compiler emits, for `switch`:
+        ila  $rT, tbl_off ; a $rT, $rT, $r126      ($rT = LS address of table)
+        ... lqx/rotqby entry ... a $r2, $entry, $rT ; bi $r2
+        tbl: .word target0 - tbl, target1 - tbl, ...  (right after the bi)
+    Entries are relative to the table itself and the table follows the `bi`,
+    so no absolute address of any case ever appears in the code: the lift
+    only ever reached the cases by luck (`bi $r2` computed at run time,
+    BRANCH-TO-0 unresolved pc=0x7A08 in jobmod ef33c6c99dc7). A table is
+    accepted only when some `ila` in the module names its offset."""
+    ilas = set()
+    for off in range(0x30, len(raw) - 4, 4):
+        w = struct.unpack_from(">I", raw, off)[0]
+        if (w >> 25) & 0x7F == 0x21:                          # ila $rX, i18
+            ilas.add((w >> 7) & 0x3FFFF)
+    out = []
+    for off in range(0x30, len(raw) - 16, 4):
+        w = struct.unpack_from(">I", raw, off)[0]
+        if (w >> 21) & 0x7FF != 0x1A8 or (w & 0x7F) != 0:     # bi $rA (rt field 0)
+            continue
+        tbl = off + 4
+        if tbl not in ilas:
+            continue
+        targets = []
+        while tbl + 4 * len(targets) + 4 <= len(raw):
+            e = struct.unpack_from(">I", raw, tbl + 4 * len(targets))[0]
+            t = (tbl + e) & 0xFFFFFFFF
+            if t % 4 or not (0x30 <= t < len(raw)):
+                break
+            targets.append(base + t)
+        if len(targets) >= 2:
+            out += targets
+    return sorted(set(out))
+
+
+
 def main():
     if EXTRA_FUNCS:
         print(f"  extra function entries: {', '.join(EXTRA_FUNCS)}")
@@ -83,6 +148,19 @@ def main():
             cmd += ["--code-end", hex(CODE_END[name])]
         # Only offer addresses that fall inside THIS module's image.
         inside = [a for a in EXTRA_FUNCS if BASE <= int(a, 0) < BASE + len(raw)]
+        # The module's first function starts right after the 0x30-byte header
+        # (`4 ila | entry | size | 0 | 0 | C0DEC0DE | 0 | 0 | n`). Usually it is
+        # reached by a branch and found anyway, but in two modules it is a bare
+        # `bi $r0` stub reached only through a function pointer the job builds at
+        # run time (base + 0x30, relocated via the entry's ila/brsl base probe), so
+        # nothing in the code references it and the lift had no entry there: the
+        # job's indirect call fell off the lifted set and came back with a
+        # corrupted stack (drain-mismatch return_pc=0x50C8 pc=0xA800, jobmod
+        # ef33c6c99dc7). Seeding it is exact, not a heuristic: every module's
+        # first instruction is at +0x30.
+        inside.append(hex(BASE + 0x30))
+        inside += [hex(a) for a in manual_link_targets(raw)]
+        inside += [hex(a) for a in switch_table_targets(raw)]
         if inside:
             cmd += ["--extra-funcs", ",".join(inside)]
         r = subprocess.run(cmd, capture_output=True, text=True)

--- a/tools/spu_lifter.py
+++ b/tools/spu_lifter.py
@@ -1156,7 +1156,13 @@ def main() -> None:
                 else:
                     newb.append((s, e))
             if not split and not any(s == a for s, _ in bset):
-                newb.append((a, base + len(data)))
+                # A seed in a gap between bounds (or past the last one) runs to
+                # the next function start, not the image end: otherwise a
+                # 2-instruction stub swallows every function after it and any
+                # rodata tail (hundreds of `.word` unsupported).
+                nxt = min([s for s, _ in bset if s > a] + [base + len(data)])
+                newb.append((a, nxt))
+
             bset = sorted(set(newb))
         # Dedup by start: if an extra addr lands inside two overlapping auto-
         # detected bounds, splitting both yields two bounds with the same start


### PR DESCRIPTION
lift_jobmods: seed the entries the modules reach only through data

Three kinds of function entry in the WWS job modules are never named by a
branch, so the lift had no function there and the job fell off the lifted
set at run time:

- the module's first function, right after the 0x30-byte header. In two
  modules it is a bare `bi $r0` stub reached through a pointer the job
  builds from its load base; calling it corrupted the stack
  (drain-mismatch return_pc=0x50C8 pc=0xA800).
- the return address every module builds by hand at its entry
  (`ila $r0, off; a $r0, $r0, $r126; br body`), 46 of 47 modules.
- position-independent switch tables: the table follows the `bi $r2` and
  its entries are relative to the table's own address, so no case address
  appears anywhere (BRANCH-TO-0 unresolved pc=0x7A08). Every hand seed the
  previous LBP_JOBMOD_EXTRA_FUNCS list carried was one of these cases.

spu_lifter: a seed that falls in a gap between bounds now runs to the next
function start instead of the image end; the 2-instruction stub above had
swallowed every function after it plus the rodata tail (232 `.word`s).
